### PR TITLE
Fix Android reader launch, APK signing, and PDF assets

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -181,7 +181,7 @@ jobs:
             fs.writeFileSync(p, s.replace(/(defaultConfig\s*\{\n)/, "$1        missingDimensionStrategy(\"store\", \"foss\")\n"));
           '
 
-      - name: Configure Android signing
+      - name: Prepare Android signing key
         if: matrix.platform == 'android'
         env:
           ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
@@ -199,17 +199,52 @@ jobs:
           fi
 
           base64 -d <<< "$KEYSTORE_BASE64" > "$RUNNER_TEMP/android-release.jks"
-          pushd src-tauri/gen/android
-          echo "keyAlias=$ANDROID_KEY_ALIAS" > keystore.properties
-          echo "password=$KEYSTORE_PASSWORD" >> keystore.properties
-          echo "storeFile=$RUNNER_TEMP/android-release.jks" >> keystore.properties
-          popd
 
       - name: Build Android APK
         if: matrix.platform == 'android'
         run: pnpm tauri android build
         env:
           NODE_OPTIONS: --max-old-space-size=4096
+
+      # Tauri's Android build produces an unsigned universal APK.  Signing it is
+      # deliberately a separate, explicit release step so the file uploaded below
+      # cannot be mistaken for a release-ready APK.
+      - name: Align, sign, and verify Android release APK
+        if: matrix.platform == 'android'
+        env:
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          KEYSTORE_PASSWORD="${ANDROID_KEYSTORE_PASSWORD:-$ANDROID_KEY_PASSWORD}"
+          KEY_PASSWORD="${ANDROID_KEY_PASSWORD:-$KEYSTORE_PASSWORD}"
+          export KEYSTORE_PASSWORD
+          export ANDROID_SIGNING_KEY_PASSWORD="$KEY_PASSWORD"
+          BUILD_TOOLS="$ANDROID_HOME/build-tools/35.0.0"
+          UNSIGNED_APK="src-tauri/gen/android/app/build/outputs/apk/universal/release/app-universal-release-unsigned.apk"
+          ALIGNED_APK="$RUNNER_TEMP/moke-release-aligned.apk"
+          RELEASE_APK="src-tauri/gen/android/app/build/outputs/apk/universal/release/moke-android-release.apk"
+
+          [ -f "$UNSIGNED_APK" ] || { echo "Expected unsigned APK not found: $UNSIGNED_APK" >&2; exit 1; }
+          [ -x "$BUILD_TOOLS/zipalign" ] || { echo "zipalign not found in $BUILD_TOOLS" >&2; exit 1; }
+          [ -x "$BUILD_TOOLS/apksigner" ] || { echo "apksigner not found in $BUILD_TOOLS" >&2; exit 1; }
+
+          # Android requires 16 KiB alignment before APK Signature Scheme signing.
+          "$BUILD_TOOLS/zipalign" -P 16 -f -v 4 "$UNSIGNED_APK" "$ALIGNED_APK"
+          "$BUILD_TOOLS/apksigner" sign \
+            --ks "$RUNNER_TEMP/android-release.jks" \
+            --ks-key-alias "$ANDROID_KEY_ALIAS" \
+            --ks-pass env:KEYSTORE_PASSWORD \
+            --key-pass env:ANDROID_SIGNING_KEY_PASSWORD \
+            --out "$RELEASE_APK" \
+            "$ALIGNED_APK"
+
+          "$BUILD_TOOLS/apksigner" verify --verbose --print-certs "$RELEASE_APK"
+          "$BUILD_TOOLS/zipalign" -c -P 16 -v 4 "$RELEASE_APK"
+          echo "ANDROID_RELEASE_APK=$RELEASE_APK" >> "$GITHUB_ENV"
 
       # ============ iOS 构建 ============
       - name: Override iOS bundle identifier
@@ -306,8 +341,7 @@ jobs:
         if: ${{ matrix.platform == 'android' && startsWith(github.ref, 'refs/tags/') }}
         uses: softprops/action-gh-release@v2
         with:
-          files: |
-            src-tauri/gen/android/app/build/outputs/apk/**/*.apk
+          files: ${{ env.ANDROID_RELEASE_APK }}
 
       - name: Create Release
         if: ${{ matrix.platform != 'android' && startsWith(github.ref, 'refs/tags/') }}
@@ -326,8 +360,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.platform }}-artifact
-          path: |
-            src-tauri/gen/android/app/build/outputs/apk/**/*.apk
+          path: ${{ env.ANDROID_RELEASE_APK }}
           if-no-files-found: error
 
       - name: Upload Tauri artifact (Push / PR)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moke",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@9.15.9",

--- a/src/app/detail/page.tsx
+++ b/src/app/detail/page.tsx
@@ -9,6 +9,7 @@ import { deleteOfflineBook, getOfflineBook, saveOfflineBook } from '@/lib/offlin
 import { useServerStore } from '@/lib/store/server';
 import { useSettingsStore } from '@/lib/store/settings';
 import { fetchReadingProgress } from '@/lib/reading-progress';
+import { buildEmbeddedReaderUrl } from '@/lib/moke-reader';
 import { resolveServerAssetUrl } from '@/lib/utils';
 import { AuthImage } from '@/components/ui/AuthImage';
 
@@ -240,6 +241,21 @@ function DetailContent() {
         // 只需替换打包资源，无需改动这里的调用方式。
         const { invoke } = await import('@tauri-apps/api/core');
         const restoreProgress = await fetchReadingProgress(book.id);
+        const { platform } = await import('@tauri-apps/plugin-os');
+        const currentPlatform = await platform();
+
+        // Mobile Tauri has one WebView, so desktop's reader-window command is
+        // unavailable. Navigate that WebView to the bundled reader instead.
+        if (currentPlatform === 'android' || currentPlatform === 'ios') {
+          router.push(buildEmbeddedReaderUrl({
+            filePath: record.filePath,
+            eink: useSettingsStore.getState().eink,
+            mokeBookId: String(book.id),
+            restoreProgress,
+          }));
+          return;
+        }
+
         await invoke('open_reader', {
           filePath: record.filePath,
           eink: useSettingsStore.getState().eink,

--- a/src/app/user/page.tsx
+++ b/src/app/user/page.tsx
@@ -2,8 +2,7 @@
 
 import Link from 'next/link';
 import { useEffect, useMemo, useState } from 'react';
-import { useRouter } from 'next/navigation';
-import { ArrowRight, BookOpen, Download, Mail, Send, Settings, Shield, Upload, User } from 'lucide-react';
+import { ArrowRight, BookOpen, Download, LogIn, Mail, Send, Settings, Shield, Upload, User } from 'lucide-react';
 import { DesktopLayout } from '@/components/layout/DesktopLayout';
 import { request } from '@/lib/api';
 import { useServerStore } from '@/lib/store/server';
@@ -29,6 +28,7 @@ interface UserDetailResponse {
     permission?: string;
     is_admin?: boolean;
     admin?: boolean;
+    is_login?: boolean;
     extra?: Partial<Record<HistoryType, HistoryItem[]>>;
   };
 }
@@ -41,7 +41,6 @@ const historyCards: Array<{ key: HistoryType; label: string; icon: typeof BookOp
 ];
 
 export default function UserPage() {
-  const router = useRouter();
   const { user, serverUrl } = useServerStore();
   const [loading, setLoading] = useState(true);
   const [message, setMessage] = useState('');
@@ -63,8 +62,14 @@ export default function UserPage() {
         });
         const data: UserDetailResponse = await res.json();
 
-        if (data.err === 'user.need_login') {
-          router.push('/login');
+        if (data.err === 'user.need_login' || !data.user?.is_login) {
+          setProfile(null);
+          setHistoryMap({
+            read_history: [],
+            download_history: [],
+            push_history: [],
+            upload_history: [],
+          });
           return;
         }
 
@@ -91,8 +96,9 @@ export default function UserPage() {
     if (serverUrl) {
       loadProfile();
     }
-  }, [router, serverUrl]);
+  }, [serverUrl]);
 
+  const isLoggedIn = Boolean(profile?.is_login ?? user);
   const displayName = profile?.nickname || profile?.name || user?.name || '未命名用户';
   const username = profile?.username || user?.username || '-';
   const email = profile?.email || user?.email || '未绑定邮箱';
@@ -129,6 +135,21 @@ export default function UserPage() {
         ) : message ? (
           <div className="rounded-2xl border border-destructive/30 bg-destructive/10 px-5 py-4 text-sm text-destructive">
             {message}
+          </div>
+        ) : !isLoggedIn ? (
+          <div className="rounded-[32px] app-glass px-6 py-12 text-center sm:px-10">
+            <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-2xl bg-primary/10 text-primary">
+              <User className="h-8 w-8" />
+            </div>
+            <h2 className="mt-5 text-xl font-semibold text-foreground">登录以查看个人面板</h2>
+            <p className="mt-2 text-sm text-muted-foreground">登录后可查看账户信息、阅读历史和个人使用数据。</p>
+            <Link
+              href="/login"
+              className="mt-6 inline-flex h-11 items-center justify-center gap-2 rounded-2xl bg-primary px-6 text-base font-semibold text-primary-foreground shadow-lg shadow-primary/15 transition hover:opacity-90 active:opacity-80"
+            >
+              <LogIn className="h-4 w-4" />
+              登录
+            </Link>
           </div>
         ) : (
           <div className="space-y-6">

--- a/src/lib/moke-reader.ts
+++ b/src/lib/moke-reader.ts
@@ -1,0 +1,26 @@
+import type { ReadingProgressPayload } from './reading-progress';
+
+export function buildEmbeddedReaderUrl({
+  filePath,
+  eink,
+  mokeBookId,
+  restoreProgress,
+}: {
+  filePath: string;
+  eink: boolean;
+  mokeBookId: string;
+  restoreProgress: ReadingProgressPayload | null;
+}): string {
+  const params = new URLSearchParams({
+    file: filePath,
+    moke: '1',
+    mokeEink: eink ? '1' : '0',
+    mokeBookId,
+  });
+
+  if (restoreProgress) {
+    params.set('mokeRestoreProgress', JSON.stringify(restoreProgress));
+  }
+
+  return `/readest/reader?${params.toString()}`;
+}

--- a/tests/moke-reader.test.mjs
+++ b/tests/moke-reader.test.mjs
@@ -1,0 +1,35 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { buildEmbeddedReaderUrl } from '../src/lib/moke-reader.ts';
+
+test('buildEmbeddedReaderUrl preserves the mobile reader launch context', () => {
+  const url = new URL(
+    buildEmbeddedReaderUrl({
+      filePath: 'C:\\Users\\reader\\我的书.pdf',
+      eink: true,
+      mokeBookId: '14',
+      restoreProgress: {
+        schema: 'moke.readest.progress.v1',
+        reader: 'readest',
+        moke_book_id: '14',
+        location: 'page=142',
+        updated_at: '2026-07-24T00:00:00.000Z',
+      },
+    }),
+    'https://moke.invalid',
+  );
+
+  assert.equal(url.pathname, '/readest/reader');
+  assert.equal(url.searchParams.get('file'), 'C:\\Users\\reader\\我的书.pdf');
+  assert.equal(url.searchParams.get('moke'), '1');
+  assert.equal(url.searchParams.get('mokeEink'), '1');
+  assert.equal(url.searchParams.get('mokeBookId'), '14');
+  assert.deepEqual(JSON.parse(url.searchParams.get('mokeRestoreProgress')), {
+    schema: 'moke.readest.progress.v1',
+    reader: 'readest',
+    moke_book_id: '14',
+    location: 'page=142',
+    updated_at: '2026-07-24T00:00:00.000Z',
+  });
+});


### PR DESCRIPTION
## Summary

- Open the embedded Readest reader in the Android/iOS WebView instead of invoking the desktop-only reader command.
- Align APKs for 16 KiB pages, sign them explicitly, verify both signature and alignment, and publish only the signed APK.
- Load embedded PDF.js assets from Readest's own `/readest/vendor/pdfjs` directory.

## Root causes

- The release workflow uploaded Tauri's `*-unsigned.apk` output after writing a keystore file that the build did not consume.
- Mobile Tauri does not support the desktop reader-window command.
- The embedded reader requested PDF worker/WASM assets from the root vendor path, which lacks the reader-owned PDF WASM files.

## Validation

- `pnpm test`
- `pnpm typecheck`
- `pnpm lint` (0 errors; existing warnings only)
- Readest PDF asset test
- Root and Readest builds completed
- Checked emitted Readest PDF worker/WASM assets
