### PR TITLE
Fix Readest development proxy

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -21,6 +21,12 @@ const nextConfig = {
   async rewrites() {
     if (isDev) {
       return [
+        // The packaged frontend uses `reader.html`; Next's dev server exposes
+        // the equivalent App Router page as `/reader`.
+        {
+          source: '/readest/reader.html',
+          destination: 'http://localhost:3001/readest/reader',
+        },
         {
           source: '/readest/:path*',
           destination: 'http://localhost:3001/readest/:path*',

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -5,7 +5,10 @@ import path from 'node:path';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const root = path.resolve(__dirname, '..');
 
-const reader = spawn('pnpm', ['--filter', '@readest/readest-app', 'dev'], {
+// Keep Moke on Tauri's configured dev URL (3000). Without an explicit port,
+// Readest starts first on 3000 and forces Moke onto 3001, reversing the
+// embedded-reader proxy topology.
+const reader = spawn('pnpm', ['--filter', '@readest/readest-app', 'dev', '--port', '3001'], {
   cwd: path.join(root, 'readest'),
   shell: true,
   stdio: 'inherit',


### PR DESCRIPTION
## What changed

- Start the embedded Readest development server explicitly on port 3001.
- Route the packaged `reader.html` entry to the Next.js development route.

## Why

Readest previously occupied port 3000 before Moke started, forcing Moke onto 3001 while Tauri still opened port 3000. This reversed the intended proxy topology and caused Readest requests to fail.

## Validation

- Verified the development rewrite configuration resolves `/readest/reader.html` to the reader route.
- Verified the branch was pushed to origin.