### PR TITLE
fix: align Cargo.lock with [patch.crates-io] for turso_ext and tauri-plugin-deep-link

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -7135,8 +7135,6 @@ dependencies = [
 [[package]]
 name = "tauri-plugin-deep-link"
 version = "2.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ee75bc5627f77bfdf40c913255ebc258117b10ebe2b2239a1a1cf40b0b58aa"
 dependencies = [
  "dunce",
  "plist",
@@ -8245,8 +8243,6 @@ dependencies = [
 [[package]]
 name = "turso_ext"
 version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a47927d766b9ae7e3adf092d5e150dce80533615edc502641797878f190080"
 dependencies = [
  "chrono",
  "getrandom 0.4.3",


### PR DESCRIPTION
Fix src-tauri/Cargo.lock so the [patch.crates-io] redirects for turso_ext and tauri-plugin-deep-link apply, which makes `cargo test --lib --locked` pass in CI.

Both crates are patched to vendored path dependencies (readest/patches/...), but the lock still listed them as registry sources. Removed the stale `source`/`checksum` fields so they match the other path-patched tauri crates.

Fixes #11

Generated with [Claude Code](https://claude.ai/code)