### PR TITLE
fix: HOU-9 网络书保存与轮询健壮性（M1/L1/L2/L4）

### DIFF
--- a/src/app/library/page.tsx
+++ b/src/app/library/page.tsx
@@ -99,6 +99,15 @@ export default function LibraryPage() {
   const [networkContextMenu, setNetworkContextMenu] = useState<{ x: number; y: number; book: NetworkBook } | null>(null);
   const lastSelectedIdRef = useRef<string | null>(null);
 
+  const networkSaveAbortRef = useRef<AbortController | null>(null);
+  const [networkSavingKeys, setNetworkSavingKeys] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    return () => {
+      networkSaveAbortRef.current?.abort();
+    };
+  }, []);
+
   // Clear selection when tab switches or server changes
   useEffect(() => {
     setSelectedIds(new Set());
@@ -439,22 +448,33 @@ export default function LibraryPage() {
       toast('缺少书源信息，无法保存。');
       return;
     }
+    const key = `${sourceId}:${book.book_url}`;
+    if (networkSavingKeys.has(key)) return;
+    setNetworkSavingKeys((prev) => new Set(prev).add(key));
+    const controller = new AbortController();
+    networkSaveAbortRef.current = controller;
     const title = book.title || book.name || '该书';
     try {
       await saveNetworkBook(serverUrl, sourceId, book.book_url);
+      if (controller.signal.aborted) return;
       toast(`已开始保存《${title}》到本地书库`);
       const result = await pollNetworkSaveForBook(serverUrl, sourceId, book.book_url, {
         intervalMs: 1500,
         maxMisses: 3,
+        signal: controller.signal,
       });
+      if (controller.signal.aborted) return;
       if (result.status === 'completed') {
         toast(`《${title}》已保存到书库`);
       } else if (result.status === 'failed') {
         toast(`《${title}》保存失败：${result.error || '未知错误'}`);
-      } else {
+      } else if (result.status === 'timeout') {
+        toast(`《${title}》保存超时，请稍后到书库查看或重试。`);
+      } else if (result.status === 'lost') {
         toast('保存进度丢失，可能服务器已重启，请稍后重试。');
       }
     } catch (error) {
+      if (controller.signal.aborted) return;
       if (error instanceof MokeApiError && error.code === 'permission.not_permit') {
         toast('当前账号没有保存网络书的权限，请联系管理员在后台开启「保存」权限。');
         return;
@@ -465,6 +485,12 @@ export default function LibraryPage() {
         return;
       }
       toast(getErrorMessage(error, '保存失败，请检查网络或登录状态。'));
+    } finally {
+      setNetworkSavingKeys((prev) => {
+        const next = new Set(prev);
+        next.delete(key);
+        return next;
+      });
     }
   };
 
@@ -488,10 +514,10 @@ export default function LibraryPage() {
         key: 'save',
         label: '保存到本地书库',
         icon: <Download className="w-3.5 h-3.5" />,
-        disabled: sourceId == null || !book.book_url,
+        disabled:
+          sourceId == null || !book.book_url || networkSavingKeys.has(`${sourceId}:${book.book_url}`),
         onClick: () => void saveNetworkBookWithFeedback(book),
-      },
-    ];
+      },    ];
   };
 
   // Empty selection while in batch mode → leave batch mode.
@@ -973,13 +999,16 @@ export default function LibraryPage() {
           />
         );
       })()}
-      {networkContextMenu && (
-        <BookContextMenu
-          position={{ x: networkContextMenu.x, y: networkContextMenu.y }}
-          items={buildNetworkMenuItems(networkContextMenu.book)}
-          onClose={() => setNetworkContextMenu(null)}
-        />
-      )}
+      {networkContextMenu && (() => {
+        const book = networkContextMenu.book;
+        return (
+          <BookContextMenu
+            position={{ x: networkContextMenu.x, y: networkContextMenu.y }}
+            items={buildNetworkMenuItems(book)}
+            onClose={() => setNetworkContextMenu(null)}
+          />
+        );
+      })()}
     </DesktopLayout>
   );
 }

--- a/src/app/library/page.tsx
+++ b/src/app/library/page.tsx
@@ -99,12 +99,14 @@ export default function LibraryPage() {
   const [networkContextMenu, setNetworkContextMenu] = useState<{ x: number; y: number; book: NetworkBook } | null>(null);
   const lastSelectedIdRef = useRef<string | null>(null);
 
-  const networkSaveAbortRef = useRef<AbortController | null>(null);
+  const networkSaveAbortRef = useRef<Set<AbortController>>(new Set());
   const [networkSavingKeys, setNetworkSavingKeys] = useState<Set<string>>(new Set());
 
   useEffect(() => {
+    const abortControllers = networkSaveAbortRef.current;
     return () => {
-      networkSaveAbortRef.current?.abort();
+      for (const controller of abortControllers) controller.abort();
+      abortControllers.clear();
     };
   }, []);
 
@@ -452,7 +454,7 @@ export default function LibraryPage() {
     if (networkSavingKeys.has(key)) return;
     setNetworkSavingKeys((prev) => new Set(prev).add(key));
     const controller = new AbortController();
-    networkSaveAbortRef.current = controller;
+    networkSaveAbortRef.current.add(controller);
     const title = book.title || book.name || '该书';
     try {
       await saveNetworkBook(serverUrl, sourceId, book.book_url);
@@ -486,6 +488,7 @@ export default function LibraryPage() {
       }
       toast(getErrorMessage(error, '保存失败，请检查网络或登录状态。'));
     } finally {
+      networkSaveAbortRef.current.delete(controller);
       setNetworkSavingKeys((prev) => {
         const next = new Set(prev);
         next.delete(key);
@@ -517,7 +520,8 @@ export default function LibraryPage() {
         disabled:
           sourceId == null || !book.book_url || networkSavingKeys.has(`${sourceId}:${book.book_url}`),
         onClick: () => void saveNetworkBookWithFeedback(book),
-      },    ];
+      },
+    ];
   };
 
   // Empty selection while in batch mode → leave batch mode.

--- a/src/app/network-book/page.tsx
+++ b/src/app/network-book/page.tsx
@@ -27,13 +27,18 @@ function NetworkBookContent() {
   const [saving, setSaving] = useState(false);
   const [saveProgress, setSaveProgress] = useState<{ percent: number; done: number; total: number } | null>(null);
   const [saveError, setSaveError] = useState('');
+  const [saveDone, setSaveDone] = useState(false);
   const sourceId = sourceIdParam ? Number(sourceIdParam) : null;
   const aliveRef = useRef(true);
+  const saveAbortRef = useRef<AbortController | null>(null);
 
   useEffect(() => {
     aliveRef.current = true;
+    const controller = new AbortController();
+    saveAbortRef.current = controller;
     return () => {
       aliveRef.current = false;
+      controller.abort();
     };
   }, []);
 
@@ -69,12 +74,14 @@ function NetworkBookContent() {
     if (!serverUrl || sourceId == null || !bookUrl || saving) return;
     setSaving(true);
     setSaveError('');
+    setSaveDone(false);
     setSaveProgress(null);
     try {
       await saveNetworkBook(serverUrl, sourceId, bookUrl, fmt);
       const result = await pollNetworkSaveForBook(serverUrl, sourceId, bookUrl, {
         intervalMs: 1500,
         maxMisses: 3,
+        signal: saveAbortRef.current?.signal,
         onUpdate: (state) => {
           if (state.status === 'running' && aliveRef.current) {
             setSaveProgress({ percent: state.progress, done: state.done, total: state.total });
@@ -82,12 +89,21 @@ function NetworkBookContent() {
         },
       });
       if (!aliveRef.current) return;
-      if (result.status === 'completed' && result.bookId) {
+      if (result.status === 'completed') {
         setSaveProgress(null);
-        router.push(`/detail?id=${result.bookId}`);
+        if (result.bookId) {
+          router.push(`/detail?id=${result.bookId}`);
+          return;
+        }
+        setSaveDone(true);
         return;
       }
       setSaveProgress(null);
+      if (result.status === 'timeout') {
+        setSaveError('保存超时，请稍后到书库查看或重试。');
+        return;
+      }
+      if (result.status === 'aborted') return;
       setSaveError(
         result.status === 'failed' && result.error
           ? result.error
@@ -212,6 +228,13 @@ function NetworkBookContent() {
                 <p className="mt-3 flex w-full items-start gap-1.5 px-1 text-xs leading-relaxed text-destructive md:w-[220px]">
                   <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
                   {saveError}
+                </p>
+              )}
+
+              {saveDone && (
+                <p className="mt-3 flex w-full items-start gap-1.5 px-1 text-xs leading-relaxed text-primary md:w-[220px]">
+                  <CheckCircle2 className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                  已保存到书库，请到书库查看。
                 </p>
               )}
             </div>

--- a/src/lib/network-book-core.ts
+++ b/src/lib/network-book-core.ts
@@ -26,39 +26,78 @@ export interface NetworkSaveStatusResponse {
   error?: string;
 }
 
-/** 保存到本地书库的轮询状态：终态为 completed / failed / lost。 */
+/** 保存到本地书库的轮询状态：终态为 completed / failed / lost / timeout / aborted。 */
 export type NetworkSaveState =
   | { status: 'running'; done: number; total: number; progress: number }
-  | { status: 'completed'; bookId: number }
+  | { status: 'completed'; bookId?: number }
   | { status: 'failed'; error: string }
-  | { status: 'lost' };
+  | { status: 'lost' }
+  | { status: 'timeout' }
+  | { status: 'aborted' };
+
+/** 服务器显式终态之外的 status 取值（pending / queued 等）视为未知，按 miss 容忍。 */
+const KNOWN_TERMINAL_OR_RUNNING = ['running', 'completed', 'failed'] as const;
+
+type KnownSaveStatus = (typeof KNOWN_TERMINAL_OR_RUNNING)[number];
+
+function isKnownSaveStatus(
+  status: NetworkSaveStatusResponse | null,
+): status is NetworkSaveStatusResponse & { status: KnownSaveStatus } {
+  return (
+    status != null &&
+    status.found === true &&
+    status.status != null &&
+    (KNOWN_TERMINAL_OR_RUNNING as readonly string[]).includes(status.status)
+  );
+}
+
+/** 轮询总时长上限（默认 10 分钟），超时后返回 `timeout`，避免任务卡死在 running 时无限轮询。 */
+export const DEFAULT_POLL_TIMEOUT_MS = 10 * 60 * 1000;
 
 const defaultSleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
 
 /**
  * 轮询网络书保存任务直到终态。
  *
- * - `!found` 或 `fetchStatus` 抛错计一次 miss，连续 `maxMisses` 次判 `lost`
- *   （容忍瞬时错误 / 任务注册竞态；后台任务可能因服务器重启丢失）。
+ * - `!found`、`fetchStatus` 抛错或 status 为未知取值（pending/queued/字段缺失）各计一次
+ *   miss，连续 `maxMisses` 次判 `lost`（容忍瞬时错误 / 任务注册竞态 / 排队中的任务）。
  * - `running` 时通过 `onUpdate` 回报进度，然后 `sleep` 后继续。
  * - `completed` / `failed` 立即返回。
+ * - 总耗时超过 `timeoutMs` 返回 `timeout`；`signal` 被中止返回 `aborted`（组件卸载时可取消）。
  */
 export async function pollNetworkSave({
   fetchStatus,
   intervalMs = 1500,
   maxMisses = 3,
+  timeoutMs = DEFAULT_POLL_TIMEOUT_MS,
+  signal,
   sleep = defaultSleep,
   onUpdate,
 }: {
   fetchStatus: () => Promise<NetworkSaveStatusResponse | null>;
   intervalMs?: number;
   maxMisses?: number;
+  timeoutMs?: number;
+  signal?: AbortSignal;
   sleep?: (ms: number) => Promise<void>;
   onUpdate?: (state: NetworkSaveState) => void;
 }): Promise<NetworkSaveState> {
+  const startedAt = Date.now();
   let misses = 0;
 
   for (;;) {
+    if (signal?.aborted) {
+      const aborted: NetworkSaveState = { status: 'aborted' };
+      onUpdate?.(aborted);
+      return aborted;
+    }
+
+    if (Date.now() - startedAt >= timeoutMs) {
+      const timeout: NetworkSaveState = { status: 'timeout' };
+      onUpdate?.(timeout);
+      return timeout;
+    }
+
     let status: NetworkSaveStatusResponse | null;
     try {
       status = await fetchStatus();
@@ -66,7 +105,7 @@ export async function pollNetworkSave({
       status = null;
     }
 
-    if (!status || !status.found) {
+    if (!isKnownSaveStatus(status)) {
       misses += 1;
       if (misses >= maxMisses) {
         const lost: NetworkSaveState = { status: 'lost' };
@@ -94,7 +133,7 @@ export async function pollNetworkSave({
     if (status.status === 'completed') {
       const completed: NetworkSaveState = {
         status: 'completed',
-        bookId: status.book_id ?? 0,
+        bookId: status.book_id ?? undefined,
       };
       onUpdate?.(completed);
       return completed;

--- a/src/lib/network-book-core.ts
+++ b/src/lib/network-book-core.ts
@@ -74,7 +74,7 @@ export async function pollNetworkSave({
   sleep = defaultSleep,
   onUpdate,
 }: {
-  fetchStatus: () => Promise<NetworkSaveStatusResponse | null>;
+  fetchStatus: (signal?: AbortSignal) => Promise<NetworkSaveStatusResponse | null>;
   intervalMs?: number;
   maxMisses?: number;
   timeoutMs?: number;
@@ -100,7 +100,7 @@ export async function pollNetworkSave({
 
     let status: NetworkSaveStatusResponse | null;
     try {
-      status = await fetchStatus();
+      status = await fetchStatus(signal);
     } catch {
       status = null;
     }

--- a/src/lib/network-books.ts
+++ b/src/lib/network-books.ts
@@ -84,6 +84,8 @@ export async function fetchNetworkSaveStatus(
 export type PollNetworkSaveOptions = {
   intervalMs?: number;
   maxMisses?: number;
+  timeoutMs?: number;
+  signal?: AbortSignal;
   sleep?: (ms: number) => Promise<void>;
   onUpdate?: (state: NetworkSaveState) => void;
 };

--- a/src/lib/network-books.ts
+++ b/src/lib/network-books.ts
@@ -72,10 +72,12 @@ export async function fetchNetworkSaveStatus(
   serverUrl: string,
   sourceId: number,
   bookUrl: string,
+  signal?: AbortSignal,
 ): Promise<NetworkSaveStatusResponse> {
   const params = new URLSearchParams({ source_id: String(sourceId), book_url: bookUrl });
   const response = await request(`${serverUrl}/api/network/save/status?${params.toString()}`, {
     credentials: 'include',
+    signal,
   });
   const data = await readApiJson<NetworkSaveStatusResponse>(response, '查询保存进度失败。');
   return data;
@@ -99,6 +101,6 @@ export function pollNetworkSaveForBook(
 ): Promise<NetworkSaveState> {
   return pollNetworkSave({
     ...options,
-    fetchStatus: () => fetchNetworkSaveStatus(serverUrl, sourceId, bookUrl),
+    fetchStatus: (signal) => fetchNetworkSaveStatus(serverUrl, sourceId, bookUrl, signal),
   });
 }

--- a/tests/network-book-core.test.mjs
+++ b/tests/network-book-core.test.mjs
@@ -119,3 +119,83 @@ test('pollNetworkSave 异常后恢复：先抛错再完成，不误判 lost', as
   });
   assert.deepEqual(state, { status: 'completed', bookId: 9 });
 });
+
+test('pollNetworkSave completed 但缺 book_id 时仍返回 completed（不误判丢失）', async () => {
+  const state = await pollNetworkSave({
+    fetchStatus: async () => ({ found: true, status: 'completed' }),
+    sleep: noopSleep,
+  });
+  assert.deepEqual(state, { status: 'completed', bookId: undefined });
+});
+
+test('pollNetworkSave 未知 status（pending/queued）按 miss 计数，不直接判 failed', async () => {
+  const { calls, sleep } = makeFakeSleep();
+  const state = await pollNetworkSave({
+    fetchStatus: async () => ({ found: true, status: 'pending' }),
+    intervalMs: 100,
+    maxMisses: 3,
+    sleep,
+  });
+  assert.equal(calls(), 2); // pending#1 与 pending#2 后各等待一次，pending#3 直接判 lost
+  assert.deepEqual(state, { status: 'lost' });
+});
+
+test('pollNetworkSave 未知 status 后恢复 running/completed 不误判', async () => {
+  const responses = [
+    { found: true, status: 'pending' },
+    { found: true, status: 'running', progress: 20, done: 1, total: 5 },
+    { found: true, status: 'completed', book_id: 11 },
+  ];
+  const state = await pollNetworkSave({
+    fetchStatus: async () => responses.shift() ?? { found: false },
+    sleep: noopSleep,
+    maxMisses: 3,
+  });
+  assert.deepEqual(state, { status: 'completed', bookId: 11 });
+});
+
+test('pollNetworkSave 超过总时长上限返回 timeout', async () => {
+  const state = await pollNetworkSave({
+    fetchStatus: async () => ({ found: true, status: 'running', progress: 10, done: 1, total: 10 }),
+    sleep: noopSleep,
+    timeoutMs: 0, // 立即超时
+  });
+  assert.deepEqual(state, { status: 'timeout' });
+});
+
+test('pollNetworkSave 收到 AbortSignal 后返回 aborted', async () => {
+  const controller = new AbortController();
+  controller.abort();
+  const state = await pollNetworkSave({
+    fetchStatus: async () => ({ found: true, status: 'running', progress: 10, done: 1, total: 10 }),
+    sleep: noopSleep,
+    signal: controller.signal,
+  });
+  assert.deepEqual(state, { status: 'aborted' });
+});
+
+test('pollNetworkSave 轮询途中取消返回 aborted，不再继续请求', async () => {
+  const controller = new AbortController();
+  let requests = 0;
+  const state = await pollNetworkSave({
+    fetchStatus: async () => {
+      requests += 1;
+      if (requests >= 2) controller.abort();
+      return { found: true, status: 'running', progress: 10, done: 1, total: 10 };
+    },
+    sleep: noopSleep,
+    signal: controller.signal,
+  });
+  assert.equal(requests, 2);
+  assert.deepEqual(state, { status: 'aborted' });
+});
+
+test('pollNetworkSave 超时上限后未知状态也返回 timeout（防无限轮询）', async () => {
+  const state = await pollNetworkSave({
+    fetchStatus: async () => ({ found: true, status: 'pending' }),
+    sleep: noopSleep,
+    timeoutMs: 0,
+    maxMisses: 100,
+  });
+  assert.deepEqual(state, { status: 'timeout' });
+});


### PR DESCRIPTION
修复 HOU-9（M1/L1/L2/L4）：网络书保存轮询加超时/取消、未知状态与缺 book_id 不再误报、保存去重。详见 issue HOU-9。验证：pnpm test 通过、lint 0 error、typecheck 通过。