### PR TITLE
fix: HOU-10 网络书搜索结果与 source_id 参数（M2/L3）

### DIFF
--- a/src/app/network-book/page.tsx
+++ b/src/app/network-book/page.tsx
@@ -20,8 +20,9 @@ function NetworkBookContent() {
   const { serverUrl } = useServerStore();
   const sourceIdParam = searchParams.get('source_id');
   const bookUrl = searchParams.get('book_url');
-  // 用 Number.isFinite 校验：`Number('abc')` 得 NaN，`NaN == null` 为 false，
-  // 会让守卫放行并向服务器发出 `source_id=NaN` 请求；非法值归一为 null 走守卫。
+  // 用 Number.isInteger 校验：`Number('abc')` 得 NaN、`Number('12.5')` 得小数，
+  // 都不是合法的书源 id；`NaN == null` 为 false，会让守卫放行并向服务器发出
+  // `source_id=NaN` 请求；非法值归一为 null 走守卫。
   const sourceId = parseNetworkSourceId(sourceIdParam);
 
   const [book, setBook] = useState<NetworkBookDetail | null>(null);

--- a/src/app/network-book/page.tsx
+++ b/src/app/network-book/page.tsx
@@ -12,6 +12,7 @@ import {
   saveNetworkBook,
   type NetworkBookDetail,
 } from '@/lib/network-books';
+import { parseNetworkSourceId } from '@/lib/network-book-core';
 
 function NetworkBookContent() {
   const searchParams = useSearchParams();
@@ -19,6 +20,9 @@ function NetworkBookContent() {
   const { serverUrl } = useServerStore();
   const sourceIdParam = searchParams.get('source_id');
   const bookUrl = searchParams.get('book_url');
+  // 用 Number.isFinite 校验：`Number('abc')` 得 NaN，`NaN == null` 为 false，
+  // 会让守卫放行并向服务器发出 `source_id=NaN` 请求；非法值归一为 null 走守卫。
+  const sourceId = parseNetworkSourceId(sourceIdParam);
 
   const [book, setBook] = useState<NetworkBookDetail | null>(null);
   const [loading, setLoading] = useState(true);
@@ -28,7 +32,6 @@ function NetworkBookContent() {
   const [saveProgress, setSaveProgress] = useState<{ percent: number; done: number; total: number } | null>(null);
   const [saveError, setSaveError] = useState('');
   const [saveDone, setSaveDone] = useState(false);
-  const sourceId = sourceIdParam ? Number(sourceIdParam) : null;
   const aliveRef = useRef(true);
   const saveAbortRef = useRef<AbortController | null>(null);
 

--- a/src/lib/network-book-core.ts
+++ b/src/lib/network-book-core.ts
@@ -2,8 +2,32 @@
  * 网络书（在线书库）相关的纯逻辑，与 DOM / `@/` 别名无关，便于 Node 单测。
  *
  * 上层 `network-books.ts`（client 侧）负责调用服务器 API 并把 `fetchStatus`
- * 绑定到 `pollNetworkSave`；本文件只做 URL 构造和状态轮询。
+ * 绑定到 `pollNetworkSave`；本文件只做 URL 构造、状态轮询和搜索结果归一化。
  */
+
+export interface NetworkSearchBook {
+  title?: string;
+  name?: string;
+  author?: string;
+  authors?: string | Array<{ name: string }>;
+  book_url: string;
+  cover_url?: string;
+  img?: string;
+  thumb?: string;
+  source_id?: number;
+  source_name?: string;
+}
+
+/** 按源分组的搜索结果条目（`{ source_id, source_name, books/items }`）。 */
+export interface NetworkSearchGroupResult {
+  source_id?: number;
+  source_name?: string;
+  books?: NetworkSearchBook[];
+  items?: NetworkSearchBook[];
+}
+
+/** 搜索结果数组中的单个条目：分组对象、裸书对象，或裸数组。 */
+export type NetworkSearchResultEntry = NetworkSearchGroupResult | NetworkSearchBook | NetworkSearchBook[];
 
 export function buildNetworkBookHref(sourceId: number, bookUrl: string): string {
   const params = new URLSearchParams({
@@ -40,27 +64,59 @@ export interface NetworkSearchStatusResponse {
 }
 
 /**
- * 把按来源分组（或散装）的搜索结果扁平化为单本书列表，并在扁平化时保留
- * 每本书所属的书源 id/名称（后续进入网络书详情需要 `source_id` + `book_url`）。
+ * 把搜索结果扁平化为带 `source_id` / `source_name` 的书籍列表。
+ *
+ * 条目有三种形态，统一处理：
+ * - 分组对象 `{ source_id, source_name, books/items }`：展开其书籍，缺省时补
+ *   分组携带的源信息；
+ * - 裸书对象（无 `books`/`items` 分组）：不再静默丢弃，保留书籍自身的源信息；
+ * - 裸数组：逐项补齐源信息，避免透传后书籍无法打开详情 / 保存。
+ *
+ * `fallback` 为本搜索整体归属的源（按源搜索时传入），仅作最后兜底。
  */
 export function flattenNetworkSearchResults(
-  results?: NetworkSearchStatusResponse['results'],
-): NetworkBook[] {
-  return (results || []).flatMap((r: { source_id?: number; source_name?: string; books?: NetworkBook[]; items?: NetworkBook[] } | NetworkBook) => {
-    if (Array.isArray(r)) return r;
-    if (typeof r === 'object' && r !== null) {
-      const asResult = r as { source_id?: number; source_name?: string; books?: NetworkBook[]; items?: NetworkBook[] };
-      const items = asResult.books || asResult.items || [];
-      return items.map((b) => ({
+  results: NetworkSearchResultEntry[] | undefined,
+  fallback?: { source_id?: number; source_name?: string },
+): NetworkSearchBook[] {
+  return (results || []).flatMap((r) => {
+    if (Array.isArray(r)) {
+      return r.map((b) => ({
         ...b,
-        source_id: b.source_id ?? asResult.source_id,
-        source_name: b.source_name ?? asResult.source_name,
+        source_id: b.source_id ?? fallback?.source_id,
+        source_name: b.source_name ?? fallback?.source_name,
       }));
+    }
+    if (typeof r === 'object' && r !== null) {
+      const group = r as NetworkSearchGroupResult;
+      const items = group.books || group.items;
+      if (Array.isArray(items)) {
+        return items.map((b) => ({
+          ...b,
+          source_id: b.source_id ?? group.source_id ?? fallback?.source_id,
+          source_name: b.source_name ?? group.source_name ?? fallback?.source_name,
+        }));
+      }
+      return [
+        {
+          ...(r as NetworkSearchBook),
+          source_id: (r as NetworkSearchBook).source_id ?? fallback?.source_id,
+          source_name: (r as NetworkSearchBook).source_name ?? fallback?.source_name,
+        },
+      ];
     }
     return [];
   });
 }
 
+/**
+ * 解析 URL 参数中的 `source_id`。空串 / 缺失 / 非数字都返回 `null`，
+ * 避免把 `Number('abc')` 的 `NaN` 透传给服务器。
+ */
+export function parseNetworkSourceId(raw: string | null): number | null {
+  if (raw == null || raw.trim() === '') return null;
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : null;
+}
 /** `/api/network/save/status` 的归一化响应（`readApiJson` 返回的原始字段）。 */
 export interface NetworkSaveStatusResponse {
   err?: string;

--- a/src/lib/network-book-core.ts
+++ b/src/lib/network-book-core.ts
@@ -66,25 +66,27 @@ export interface NetworkSearchStatusResponse {
 /**
  * 把搜索结果扁平化为带 `source_id` / `source_name` 的书籍列表。
  *
+ * 服务器实际只返回分组形态（talebook `SearchTaskService.get_status` 仅汇总
+ * `state == "done"` 且 `books` 非空的源）；裸书 / 裸数组分支仅为归一化入口的防御，
+ * 服务器不提供整体源信息，无源可补，保持原样透传。
+ *
  * 条目有三种形态，统一处理：
  * - 分组对象 `{ source_id, source_name, books/items }`：展开其书籍，缺省时补
  *   分组携带的源信息；
- * - 裸书对象（无 `books`/`items` 分组）：不再静默丢弃，保留书籍自身的源信息；
- * - 裸数组：逐项补齐源信息，避免透传后书籍无法打开详情 / 保存。
+ * - 裸数组：逐项透传；
+ * - 裸书对象：须带书字段（`book_url` / `title` / `name`）才算书，保留书籍自身
+ *   的源信息；否则视为占位对象（如仅有 `source_id`/`source_name` 的空分组）丢弃，
+ *   避免渲染成点不开的幽灵卡片。
  *
- * `fallback` 为本搜索整体归属的源（按源搜索时传入），仅作最后兜底。
+ * 运行时 `results` 来自未校验的 JSON，非数组时安全返回空数组。
  */
 export function flattenNetworkSearchResults(
   results: NetworkSearchResultEntry[] | undefined,
-  fallback?: { source_id?: number; source_name?: string },
 ): NetworkSearchBook[] {
-  return (results || []).flatMap((r) => {
+  if (!Array.isArray(results)) return [];
+  return results.flatMap((r) => {
     if (Array.isArray(r)) {
-      return r.map((b) => ({
-        ...b,
-        source_id: b.source_id ?? fallback?.source_id,
-        source_name: b.source_name ?? fallback?.source_name,
-      }));
+      return r;
     }
     if (typeof r === 'object' && r !== null) {
       const group = r as NetworkSearchGroupResult;
@@ -92,30 +94,27 @@ export function flattenNetworkSearchResults(
       if (Array.isArray(items)) {
         return items.map((b) => ({
           ...b,
-          source_id: b.source_id ?? group.source_id ?? fallback?.source_id,
-          source_name: b.source_name ?? group.source_name ?? fallback?.source_name,
+          source_id: b.source_id ?? group.source_id,
+          source_name: b.source_name ?? group.source_name,
         }));
       }
-      return [
-        {
-          ...(r as NetworkSearchBook),
-          source_id: (r as NetworkSearchBook).source_id ?? fallback?.source_id,
-          source_name: (r as NetworkSearchBook).source_name ?? fallback?.source_name,
-        },
-      ];
+      const book = r as NetworkSearchBook;
+      if (!book.book_url && !book.title && !book.name) return [];
+      return [book];
     }
     return [];
   });
 }
 
 /**
- * 解析 URL 参数中的 `source_id`。空串 / 缺失 / 非数字都返回 `null`，
- * 避免把 `Number('abc')` 的 `NaN` 透传给服务器。
+ * 解析 URL 参数中的 `source_id`。空串 / 缺失 / 非数字 / 非整数都返回 `null`，
+ * 避免把 `Number('abc')` 的 `NaN` 或 `Number('12.5')` 的小数透传给服务器
+ * （书源 id 是数据库整数）。
  */
 export function parseNetworkSourceId(raw: string | null): number | null {
   if (raw == null || raw.trim() === '') return null;
   const n = Number(raw);
-  return Number.isFinite(n) ? n : null;
+  return Number.isInteger(n) ? n : null;
 }
 /** `/api/network/save/status` 的归一化响应（`readApiJson` 返回的原始字段）。 */
 export interface NetworkSaveStatusResponse {

--- a/tests/network-book-core.test.mjs
+++ b/tests/network-book-core.test.mjs
@@ -4,6 +4,7 @@ import assert from 'node:assert/strict';
 import {
   buildNetworkBookHref,
   flattenNetworkSearchResults,
+  parseNetworkSourceId,
   pollNetworkSave,
   pollNetworkSearch,
 } from '../src/lib/network-book-core.ts';
@@ -23,6 +24,89 @@ function makeFakeSleep() {
     },
   };
 }
+
+test('flattenNetworkSearchResults 展开分组结果并补齐 source_id/source_name', () => {
+  const flat = flattenNetworkSearchResults([
+    {
+      source_id: 1,
+      source_name: '源A',
+      books: [{ name: '书1', book_url: '/a1' }, { name: '书2', book_url: '/a2' }],
+    },
+    {
+      source_id: 2,
+      source_name: '源B',
+      items: [{ name: '书3', book_url: '/b1' }],
+    },
+  ]);
+  assert.deepEqual(flat, [
+    { name: '书1', book_url: '/a1', source_id: 1, source_name: '源A' },
+    { name: '书2', book_url: '/a2', source_id: 1, source_name: '源A' },
+    { name: '书3', book_url: '/b1', source_id: 2, source_name: '源B' },
+  ]);
+});
+
+test('flattenNetworkSearchResults 分组书籍自带 source 时以书籍自身为准', () => {
+  const flat = flattenNetworkSearchResults([
+    {
+      source_id: 1,
+      source_name: '源A',
+      books: [{ name: '书1', book_url: '/a1', source_id: 9, source_name: '覆盖源' }],
+    },
+  ]);
+  assert.deepEqual(flat, [{ name: '书1', book_url: '/a1', source_id: 9, source_name: '覆盖源' }]);
+});
+
+test('flattenNetworkSearchResults 裸书对象不再被静默丢弃', () => {
+  const flat = flattenNetworkSearchResults([
+    { name: '裸书1', book_url: '/n1', source_id: 3, source_name: '裸源' },
+  ]);
+  assert.deepEqual(flat, [{ name: '裸书1', book_url: '/n1', source_id: 3, source_name: '裸源' }]);
+});
+
+test('flattenNetworkSearchResults 裸书对象缺 source 时使用 fallback 源', () => {
+  const flat = flattenNetworkSearchResults(
+    [{ name: '裸书2', book_url: '/n2' }],
+    { source_id: 7, source_name: '搜索源' },
+  );
+  assert.deepEqual(flat, [{ name: '裸书2', book_url: '/n2', source_id: 7, source_name: '搜索源' }]);
+});
+
+test('flattenNetworkSearchResults 裸数组逐项补齐 source_id/source_name', () => {
+  const flat = flattenNetworkSearchResults([
+    [{ name: '裸组1', book_url: '/g1' }, { name: '裸组2', book_url: '/g2' }],
+  ], { source_id: 5, source_name: '搜索源' });
+  assert.deepEqual(flat, [
+    { name: '裸组1', book_url: '/g1', source_id: 5, source_name: '搜索源' },
+    { name: '裸组2', book_url: '/g2', source_id: 5, source_name: '搜索源' },
+  ]);
+});
+
+test('flattenNetworkSearchResults 裸数组条目自带 source 时保留条目自身', () => {
+  const flat = flattenNetworkSearchResults([
+    [{ name: '裸组1', book_url: '/g1', source_id: 11, source_name: '自带源' }],
+  ], { source_id: 5, source_name: '搜索源' });
+  assert.deepEqual(flat, [{ name: '裸组1', book_url: '/g1', source_id: 11, source_name: '自带源' }]);
+});
+
+test('flattenNetworkSearchResults 空/非法条目安全返回空数组', () => {
+  assert.deepEqual(flattenNetworkSearchResults(undefined), []);
+  assert.deepEqual(flattenNetworkSearchResults([]), []);
+  assert.deepEqual(flattenNetworkSearchResults([null, 42, 'x']), []);
+});
+
+test('parseNetworkSourceId 合法数字字符串返回数字', () => {
+  assert.equal(parseNetworkSourceId('12'), 12);
+  assert.equal(parseNetworkSourceId('0'), 0);
+  assert.equal(parseNetworkSourceId(' 7 '), 7);
+});
+
+test('parseNetworkSourceId 非数字/空串/缺失返回 null', () => {
+  assert.equal(parseNetworkSourceId('abc'), null);
+  assert.equal(parseNetworkSourceId(''), null);
+  assert.equal(parseNetworkSourceId('   '), null);
+  assert.equal(parseNetworkSourceId(null), null);
+  assert.equal(parseNetworkSourceId('12.5x'), null);
+});
 
 test('buildNetworkBookHref 携带 source_id 并编码 book_url', () => {
   const href = buildNetworkBookHref(12, 'https://example.com/book?a=1&b=中文');
@@ -200,42 +284,6 @@ test('pollNetworkSave 超时上限后未知状态也返回 timeout（防无限�
     maxMisses: 100,
   });
   assert.deepEqual(state, { status: 'timeout' });
-});
-
-test('flattenNetworkSearchResults 保留分组的 source_id/source_name', () => {
-  const books = flattenNetworkSearchResults([
-    {
-      source_id: 1,
-      source_name: '源A',
-      books: [{ title: '书A', book_url: 'u1' }],
-    },
-    {
-      source_id: 2,
-      source_name: '源B',
-      items: [{ title: '书B', book_url: 'u2' }],
-    },
-  ]);
-  assert.deepEqual(books, [
-    { title: '书A', book_url: 'u1', source_id: 1, source_name: '源A' },
-    { title: '书B', book_url: 'u2', source_id: 2, source_name: '源B' },
-  ]);
-});
-
-test('flattenNetworkSearchResults 单本自带的 source_id 优先于分组', () => {
-  const books = flattenNetworkSearchResults([
-    {
-      source_id: 1,
-      source_name: '源A',
-      books: [{ title: '书A', book_url: 'u1', source_id: 9, source_name: '源X' }],
-    },
-  ]);
-  assert.deepEqual(books, [{ title: '书A', book_url: 'u1', source_id: 9, source_name: '源X' }]);
-});
-
-test('flattenNetworkSearchResults 空/散装条目安全返回空数组', () => {
-  assert.deepEqual(flattenNetworkSearchResults(undefined), []);
-  assert.deepEqual(flattenNetworkSearchResults([]), []);
-  assert.deepEqual(flattenNetworkSearchResults([{}, null, 'x']), []);
 });
 
 test('pollNetworkSearch 直到 finished 才返回，中间结果通过 onPartial 上报', async () => {

--- a/tests/network-book-core.test.mjs
+++ b/tests/network-book-core.test.mjs
@@ -63,28 +63,29 @@ test('flattenNetworkSearchResults 裸书对象不再被静默丢弃', () => {
   assert.deepEqual(flat, [{ name: '裸书1', book_url: '/n1', source_id: 3, source_name: '裸源' }]);
 });
 
-test('flattenNetworkSearchResults 裸书对象缺 source 时使用 fallback 源', () => {
-  const flat = flattenNetworkSearchResults(
-    [{ name: '裸书2', book_url: '/n2' }],
-    { source_id: 7, source_name: '搜索源' },
-  );
-  assert.deepEqual(flat, [{ name: '裸书2', book_url: '/n2', source_id: 7, source_name: '搜索源' }]);
+test('flattenNetworkSearchResults 裸书对象缺 source 时原样保留', () => {
+  const flat = flattenNetworkSearchResults([{ name: '裸书2', book_url: '/n2' }]);
+  assert.deepEqual(flat, [{ name: '裸书2', book_url: '/n2' }]);
 });
 
-test('flattenNetworkSearchResults 裸数组逐项补齐 source_id/source_name', () => {
+test('flattenNetworkSearchResults 无书字段的占位对象被丢弃', () => {
+  assert.deepEqual(flattenNetworkSearchResults([{ source_id: 3, source_name: '源C' }]), []);
+});
+
+test('flattenNetworkSearchResults 裸数组逐项透传（服务器不提供整体源信息）', () => {
   const flat = flattenNetworkSearchResults([
     [{ name: '裸组1', book_url: '/g1' }, { name: '裸组2', book_url: '/g2' }],
-  ], { source_id: 5, source_name: '搜索源' });
+  ]);
   assert.deepEqual(flat, [
-    { name: '裸组1', book_url: '/g1', source_id: 5, source_name: '搜索源' },
-    { name: '裸组2', book_url: '/g2', source_id: 5, source_name: '搜索源' },
+    { name: '裸组1', book_url: '/g1' },
+    { name: '裸组2', book_url: '/g2' },
   ]);
 });
 
 test('flattenNetworkSearchResults 裸数组条目自带 source 时保留条目自身', () => {
   const flat = flattenNetworkSearchResults([
     [{ name: '裸组1', book_url: '/g1', source_id: 11, source_name: '自带源' }],
-  ], { source_id: 5, source_name: '搜索源' });
+  ]);
   assert.deepEqual(flat, [{ name: '裸组1', book_url: '/g1', source_id: 11, source_name: '自带源' }]);
 });
 
@@ -94,18 +95,25 @@ test('flattenNetworkSearchResults 空/非法条目安全返回空数组', () => 
   assert.deepEqual(flattenNetworkSearchResults([null, 42, 'x']), []);
 });
 
+test('flattenNetworkSearchResults results 非数组时安全返回空数组', () => {
+  assert.deepEqual(flattenNetworkSearchResults({ books: [{ name: '书1', book_url: '/a1' }] }), []);
+  assert.deepEqual(flattenNetworkSearchResults('not-an-array'), []);
+  assert.deepEqual(flattenNetworkSearchResults(null), []);
+});
+
 test('parseNetworkSourceId 合法数字字符串返回数字', () => {
   assert.equal(parseNetworkSourceId('12'), 12);
   assert.equal(parseNetworkSourceId('0'), 0);
   assert.equal(parseNetworkSourceId(' 7 '), 7);
 });
 
-test('parseNetworkSourceId 非数字/空串/缺失返回 null', () => {
+test('parseNetworkSourceId 非数字/非整数/空串/缺失返回 null', () => {
   assert.equal(parseNetworkSourceId('abc'), null);
   assert.equal(parseNetworkSourceId(''), null);
   assert.equal(parseNetworkSourceId('   '), null);
   assert.equal(parseNetworkSourceId(null), null);
   assert.equal(parseNetworkSourceId('12.5x'), null);
+  assert.equal(parseNetworkSourceId('12.5'), null);
 });
 
 test('buildNetworkBookHref 携带 source_id 并编码 book_url', () => {


### PR DESCRIPTION
修复 HOU-10（M2/L3）：保留裸书搜索结果并补 source_id，拒绝 NaN source_id 请求。详见 issue HOU-10。验证：pnpm test（含新增 10 用例）通过、lint 0 error、typecheck 通过。