### PR TITLE
fix: HOU-11 桌面端进度重复保存（M3）

### DIFF
--- a/src/app/detail/page.tsx
+++ b/src/app/detail/page.tsx
@@ -303,7 +303,7 @@ function DetailContent() {
             eink: useSettingsStore.getState().eink,
             mokeBookId: String(book.id),
             restoreProgress,
-            serverUrl: useServerStore.getState().serverUrl || '',
+            serverUrl: useServerStore.getState().serverUrl,
           });
           await openEmbeddedReaderBook(href, router.push);
           return;

--- a/src/app/detail/page.tsx
+++ b/src/app/detail/page.tsx
@@ -305,7 +305,7 @@ function DetailContent() {
             restoreProgress,
             serverUrl: useServerStore.getState().serverUrl,
           });
-          await openEmbeddedReaderBook(href, router.push);
+          await openEmbeddedReaderBook(href, router.push, currentPlatform);
           return;
         }
 

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -81,7 +81,7 @@ export default function SettingsPage() {
     try {
       await openEmbeddedReaderHome({
         eink: useSettingsStore.getState().eink,
-        serverUrl: serverUrl || '',
+        serverUrl,
         navigate: (href) => router.push(href),
       });
     } catch (error) {

--- a/src/app/welcome/page.tsx
+++ b/src/app/welcome/page.tsx
@@ -107,7 +107,7 @@ export default function WelcomePage() {
     try {
       await openEmbeddedReaderHome({
         eink: useSettingsStore.getState().eink,
-        serverUrl: useServerStore.getState().serverUrl || '',
+        serverUrl: useServerStore.getState().serverUrl,
         navigate: (href) => router.push(href),
       });
     } catch (e) {

--- a/src/lib/moke-reader.ts
+++ b/src/lib/moke-reader.ts
@@ -3,6 +3,18 @@ import type { ReadingProgressPayload } from './reading-progress';
 export const isSingleWebviewRuntime = (platform: string): boolean =>
   platform === 'ohos' || platform === 'android' || platform === 'ios';
 
+/**
+ * Whether the reader itself must save progress to the server (and therefore the
+ * embedded reader URL should carry `mokeServerUrl`).
+ *
+ * Single-WebView runtimes (OHOS/Android/iOS) and the web build replace the host
+ * app, so there is no main-window ReaderProgressProvider to save for them.
+ * Desktop keeps the old behavior — the reader-home window gets no serverUrl and
+ * the main window's ReaderProgressProvider is the single saver.
+ */
+export const shouldIncludeServerUrl = (isTauri: boolean, platform: string): boolean =>
+  !isTauri || isSingleWebviewRuntime(platform);
+
 export async function getMokeRuntimePlatform(): Promise<string> {
   if (process.env.NEXT_PUBLIC_APP_PLATFORM !== 'tauri') return 'web';
 
@@ -100,21 +112,19 @@ export function buildReaderHomeWindowLabel(timestamp: number = Date.now()): stri
 export function buildEmbeddedReaderHomeUrl({
   eink,
   serverUrl,
-  includeServerUrl,
 }: {
   eink: boolean;
-  serverUrl: string;
-  includeServerUrl: boolean;
+  serverUrl?: string;
 }): string {
   const params = new URLSearchParams({
     moke: '1',
     mokeEink: eink ? '1' : '0',
   });
 
-  // Guard against the callers' `serverUrl || ''` convention: an empty string
-  // must not produce a bare `mokeServerUrl=` param that readest would treat as
-  // "server configured" when it only checks for the param's presence.
-  if (includeServerUrl && serverUrl) {
+  // Only carry mokeServerUrl when non-empty: a bare `mokeServerUrl=` param would
+  // be treated by readest as "server configured" when it only checks for the
+  // param's presence. Omit the param on desktop (callers simply don't pass it).
+  if (serverUrl) {
     params.set('mokeServerUrl', serverUrl);
   }
 
@@ -127,28 +137,38 @@ export async function openEmbeddedReaderHome({
   navigate,
 }: {
   eink: boolean;
-  serverUrl: string;
+  serverUrl?: string;
   navigate: (href: string) => void;
 }): Promise<void> {
   const isTauri = process.env.NEXT_PUBLIC_APP_PLATFORM === 'tauri';
 
   let currentPlatform = 'web';
   if (isTauri) {
-    currentPlatform = await getMokeRuntimePlatform();
+    try {
+      currentPlatform = await getMokeRuntimePlatform();
+    } catch (error) {
+      // A failed probe must not block opening the reader — the desktop path
+      // never uses the probe result. Treat as desktop (non single-WebView).
+      console.warn('Unable to detect runtime platform, assuming desktop reader window flow:', error);
+      currentPlatform = 'desktop';
+    }
   }
 
   const singleWebview = isSingleWebviewRuntime(currentPlatform);
 
-  // Only pass mokeServerUrl where the reader must save progress itself: single-
-  // WebView runtimes (OHOS/Android/iOS) and the web build replace the host app,
-  // so there is no main-window ReaderProgressProvider to save for them. Desktop
-  // keeps the old behavior — the reader-home window gets no serverUrl and the
-  // main window's ReaderProgressProvider is the single saver (mokeBridge would
-  // otherwise POST a second, duplicate write on every page:changed).
+  // Only pass mokeServerUrl where the reader must save progress itself:
+  // single-WebView runtimes (OHOS/Android/iOS) and the web build replace the
+  // host app, so there is no main-window ReaderProgressProvider to save for
+  // them (mokeBridge would otherwise POST a second, duplicate write on every
+  // page:changed). Desktop keeps the old behavior — the reader-home window gets
+  // no serverUrl and the main window's ReaderProgressProvider is the single
+  // saver. That is safe for the desktop built-in library: it does not read
+  // mokeServerUrl at all — server browsing (shelf/library/search/detail) is
+  // served by the main window, and the reader-home window is only a reading
+  // container.
   const href = buildEmbeddedReaderHomeUrl({
     eink,
-    serverUrl,
-    includeServerUrl: !isTauri || singleWebview,
+    serverUrl: shouldIncludeServerUrl(isTauri, currentPlatform) ? serverUrl : undefined,
   });
 
   if (!isTauri) {
@@ -201,15 +221,20 @@ export function buildEmbeddedReaderUrl({
   eink: boolean;
   mokeBookId: string;
   restoreProgress: ReadingProgressPayload | null;
-  serverUrl: string;
+  serverUrl?: string;
 }): string {
   const params = new URLSearchParams({
     file: filePath,
     moke: '1',
     mokeEink: eink ? '1' : '0',
     mokeBookId,
-    mokeServerUrl: serverUrl,
   });
+
+  // Same empty-value guard as buildEmbeddedReaderHomeUrl: callers may pass ''
+  // and a bare `mokeServerUrl=` would be treated as "server configured".
+  if (serverUrl) {
+    params.set('mokeServerUrl', serverUrl);
+  }
 
   if (restoreProgress) {
     params.set('mokeRestoreProgress', JSON.stringify(restoreProgress));

--- a/src/lib/moke-reader.ts
+++ b/src/lib/moke-reader.ts
@@ -92,6 +92,27 @@ export function buildReaderHomeWindowLabel(timestamp: number = Date.now()): stri
   return `moke-home-${timestamp}`;
 }
 
+export function buildEmbeddedReaderHomeUrl({
+  eink,
+  serverUrl,
+  includeServerUrl,
+}: {
+  eink: boolean;
+  serverUrl: string;
+  includeServerUrl: boolean;
+}): string {
+  const params = new URLSearchParams({
+    moke: '1',
+    mokeEink: eink ? '1' : '0',
+  });
+
+  if (includeServerUrl) {
+    params.set('mokeServerUrl', serverUrl);
+  }
+
+  return `/readest/?${params.toString()}`;
+}
+
 export async function openEmbeddedReaderHome({
   eink,
   serverUrl,
@@ -101,21 +122,33 @@ export async function openEmbeddedReaderHome({
   serverUrl: string;
   navigate: (href: string) => void;
 }): Promise<void> {
-  const params = new URLSearchParams({
-    moke: '1',
-    mokeEink: eink ? '1' : '0',
-    mokeServerUrl: serverUrl,
-  });
-  const href = `/readest/?${params.toString()}`;
+  const isTauri = process.env.NEXT_PUBLIC_APP_PLATFORM === 'tauri';
 
-  if (process.env.NEXT_PUBLIC_APP_PLATFORM !== 'tauri') {
+  let currentPlatform = 'web';
+  if (isTauri) {
+    currentPlatform = await getMokeRuntimePlatform();
+  }
+
+  const singleWebview = isSingleWebviewRuntime(currentPlatform);
+
+  // Only pass mokeServerUrl where the reader must save progress itself: single-
+  // WebView runtimes (OHOS/Android/iOS) and the web build replace the host app,
+  // so there is no main-window ReaderProgressProvider to save for them. Desktop
+  // keeps the old behavior — the reader-home window gets no serverUrl and the
+  // main window's ReaderProgressProvider is the single saver (mokeBridge would
+  // otherwise POST a second, duplicate write on every page:changed).
+  const href = buildEmbeddedReaderHomeUrl({
+    eink,
+    serverUrl,
+    includeServerUrl: !isTauri || singleWebview,
+  });
+
+  if (!isTauri) {
     navigate(href);
     return;
   }
 
-  const currentPlatform = await getMokeRuntimePlatform();
-
-  if (isSingleWebviewRuntime(currentPlatform)) {
+  if (singleWebview) {
     await navigateFullDocument(href, navigate);
     return;
   }

--- a/src/lib/moke-reader.ts
+++ b/src/lib/moke-reader.ts
@@ -109,6 +109,17 @@ export function buildReaderHomeWindowLabel(timestamp: number = Date.now()): stri
   return `moke-home-${timestamp}`;
 }
 
+/**
+ * Only carry mokeServerUrl when non-empty: a bare `mokeServerUrl=` param would
+ * be treated by readest as "server configured" when it only checks for the
+ * param's presence. Shared by both embedded-reader URL builders.
+ */
+function setServerUrlParam(params: URLSearchParams, serverUrl?: string): void {
+  if (serverUrl) {
+    params.set('mokeServerUrl', serverUrl);
+  }
+}
+
 export function buildEmbeddedReaderHomeUrl({
   eink,
   serverUrl,
@@ -121,12 +132,7 @@ export function buildEmbeddedReaderHomeUrl({
     mokeEink: eink ? '1' : '0',
   });
 
-  // Only carry mokeServerUrl when non-empty: a bare `mokeServerUrl=` param would
-  // be treated by readest as "server configured" when it only checks for the
-  // param's presence. Omit the param on desktop (callers simply don't pass it).
-  if (serverUrl) {
-    params.set('mokeServerUrl', serverUrl);
-  }
+  setServerUrlParam(params, serverUrl);
 
   return `/readest/?${params.toString()}`;
 }
@@ -143,14 +149,17 @@ export async function openEmbeddedReaderHome({
   const isTauri = process.env.NEXT_PUBLIC_APP_PLATFORM === 'tauri';
 
   let currentPlatform = 'web';
+  let probeFailed = false;
   if (isTauri) {
     try {
       currentPlatform = await getMokeRuntimePlatform();
     } catch (error) {
-      // A failed probe must not block opening the reader — the desktop path
-      // never uses the probe result. Treat as desktop (non single-WebView).
+      // A failed probe must not block opening the reader. Fall back to the
+      // desktop window flow (on single-WebView runtimes window creation fails
+      // and we degrade to in-place navigation, which is the right flow there).
       console.warn('Unable to detect runtime platform, assuming desktop reader window flow:', error);
       currentPlatform = 'desktop';
+      probeFailed = true;
     }
   }
 
@@ -166,9 +175,17 @@ export async function openEmbeddedReaderHome({
   // mokeServerUrl at all — server browsing (shelf/library/search/detail) is
   // served by the main window, and the reader-home window is only a reading
   // container.
+  //
+  // Trade-off on probe failure: keep mokeServerUrl. A single-WebView runtime
+  // that fails the probe (its main-window ReaderProgressProvider is already
+  // unloaded) would otherwise silently lose progress saving — worse than an
+  // occasional duplicate save on desktop.
+  const includeServerUrl =
+    (isTauri && probeFailed) || shouldIncludeServerUrl(isTauri, currentPlatform);
+
   const href = buildEmbeddedReaderHomeUrl({
     eink,
-    serverUrl: shouldIncludeServerUrl(isTauri, currentPlatform) ? serverUrl : undefined,
+    serverUrl: includeServerUrl ? serverUrl : undefined,
   });
 
   if (!isTauri) {
@@ -230,11 +247,7 @@ export function buildEmbeddedReaderUrl({
     mokeBookId,
   });
 
-  // Same empty-value guard as buildEmbeddedReaderHomeUrl: callers may pass ''
-  // and a bare `mokeServerUrl=` would be treated as "server configured".
-  if (serverUrl) {
-    params.set('mokeServerUrl', serverUrl);
-  }
+  setServerUrlParam(params, serverUrl);
 
   if (restoreProgress) {
     params.set('mokeRestoreProgress', JSON.stringify(restoreProgress));
@@ -246,6 +259,7 @@ export function buildEmbeddedReaderUrl({
 export async function openEmbeddedReaderBook(
   href: string,
   navigate: (href: string) => void,
+  platformOverride?: string,
 ): Promise<void> {
-  await navigateFullDocument(href, navigate);
+  await navigateFullDocument(href, navigate, platformOverride);
 }

--- a/src/lib/moke-reader.ts
+++ b/src/lib/moke-reader.ts
@@ -55,20 +55,25 @@ export function runtimeCategoryFromPlatform(platform: string): RuntimeCategory {
 export async function navigateFullDocument(
   href: string,
   fallback: (href: string) => void,
+  platformOverride?: string,
 ): Promise<void> {
   if (process.env.NEXT_PUBLIC_APP_PLATFORM !== 'tauri') {
     fallback(href);
     return;
   }
   let currentPlatform: string;
-  try {
-    currentPlatform = await getMokeRuntimePlatform();
-  } catch (error) {
-    // If the runtime probe fails (e.g. IPC unavailable in dev mode), never
-    // block navigation — fall through to the client router.
-    console.warn('Unable to detect runtime platform, using router navigation:', error);
-    fallback(href);
-    return;
+  if (platformOverride) {
+    currentPlatform = platformOverride;
+  } else {
+    try {
+      currentPlatform = await getMokeRuntimePlatform();
+    } catch (error) {
+      // If the runtime probe fails (e.g. IPC unavailable in dev mode), never
+      // block navigation — fall through to the client router.
+      console.warn('Unable to detect runtime platform, using router navigation:', error);
+      fallback(href);
+      return;
+    }
   }
   if (!isSingleWebviewRuntime(currentPlatform)) {
     fallback(href);
@@ -106,7 +111,10 @@ export function buildEmbeddedReaderHomeUrl({
     mokeEink: eink ? '1' : '0',
   });
 
-  if (includeServerUrl) {
+  // Guard against the callers' `serverUrl || ''` convention: an empty string
+  // must not produce a bare `mokeServerUrl=` param that readest would treat as
+  // "server configured" when it only checks for the param's presence.
+  if (includeServerUrl && serverUrl) {
     params.set('mokeServerUrl', serverUrl);
   }
 
@@ -149,7 +157,9 @@ export async function openEmbeddedReaderHome({
   }
 
   if (singleWebview) {
-    await navigateFullDocument(href, navigate);
+    // Reuse the platform already probed above instead of probing again inside
+    // navigateFullDocument (each probe is a Rust IPC call).
+    await navigateFullDocument(href, navigate, currentPlatform);
     return;
   }
 

--- a/tests/moke-reader.test.mjs
+++ b/tests/moke-reader.test.mjs
@@ -2,14 +2,13 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 
 import {
-import {
   buildEmbeddedReaderHomeUrl,
   buildEmbeddedReaderUrl,
   buildReaderHomeWindowLabel,
   isSingleWebviewRuntime,
   resolveRuntimeCategory,
   runtimeCategoryFromPlatform,
-} from '../src/lib/moke-reader.ts';
+  shouldIncludeServerUrl,
 } from '../src/lib/moke-reader.ts';
 
 test('OHOS uses the single-WebView reader flow', () => {
@@ -65,6 +64,22 @@ test('reader-home window label never matches the extension reader-* enumeration'
   assert.ok(label.startsWith('moke-home-'));
 });
 
+test('shouldIncludeServerUrl maps runtime → serverUrl inclusion decision', () => {
+  // Web build: reader replaces the host app, must save progress itself.
+  assert.equal(shouldIncludeServerUrl(false, 'web'), true);
+  assert.equal(shouldIncludeServerUrl(false, 'desktop'), true);
+
+  // Single-WebView runtimes: reader replaces the host app, must save itself.
+  assert.equal(shouldIncludeServerUrl(true, 'ohos'), true);
+  assert.equal(shouldIncludeServerUrl(true, 'android'), true);
+  assert.equal(shouldIncludeServerUrl(true, 'ios'), true);
+
+  // Desktop: main-window ReaderProgressProvider is the single saver.
+  assert.equal(shouldIncludeServerUrl(true, 'windows'), false);
+  assert.equal(shouldIncludeServerUrl(true, 'linux'), false);
+  assert.equal(shouldIncludeServerUrl(true, 'macos'), false);
+});
+
 test('buildEmbeddedReaderUrl preserves the mobile reader launch context', () => {
   const url = new URL(
     buildEmbeddedReaderUrl({
@@ -96,15 +111,28 @@ test('buildEmbeddedReaderUrl preserves the mobile reader launch context', () => 
     location: 'page=142',
     updated_at: '2026-07-24T00:00:00.000Z',
   });
+
+  // Empty serverUrl must not produce a bare `mokeServerUrl=` param.
+  const empty = new URL(
+    buildEmbeddedReaderUrl({
+      filePath: 'C:\\book.pdf',
+      eink: false,
+      mokeBookId: '15',
+      restoreProgress: null,
+      serverUrl: '',
+    }),
+    'https://moke.invalid',
+  );
+  assert.equal(empty.searchParams.get('moke'), '1');
+  assert.equal(empty.searchParams.get('mokeServerUrl'), null);
 });
 
-test('buildEmbeddedReaderHomeUrl passes mokeServerUrl only when the reader must save progress itself', () => {
-  // Single-WebView runtimes: reader-home window must direct-save progress.
+test('buildEmbeddedReaderHomeUrl carries mokeServerUrl only when non-empty', () => {
+  // Reader must save progress itself: a serverUrl is carried verbatim.
   const mobile = new URL(
     buildEmbeddedReaderHomeUrl({
       eink: true,
       serverUrl: 'http://192.168.1.5:8080',
-      includeServerUrl: true,
     }),
     'https://moke.invalid',
   );
@@ -113,13 +141,12 @@ test('buildEmbeddedReaderHomeUrl passes mokeServerUrl only when the reader must 
   assert.equal(mobile.searchParams.get('mokeEink'), '1');
   assert.equal(mobile.searchParams.get('mokeServerUrl'), 'http://192.168.1.5:8080');
 
-  // Desktop: no mokeServerUrl so the main window's ReaderProgressProvider is the
-  // single saver (no duplicate write via mokeBridge's direct POST).
+  // Desktop: callers omit serverUrl, so no mokeServerUrl is emitted and the
+  // main window's ReaderProgressProvider is the single saver (no duplicate
+  // write via mokeBridge's direct POST).
   const desktop = new URL(
     buildEmbeddedReaderHomeUrl({
       eink: false,
-      serverUrl: 'http://192.168.1.5:8080',
-      includeServerUrl: false,
     }),
     'https://moke.invalid',
   );
@@ -128,13 +155,11 @@ test('buildEmbeddedReaderHomeUrl passes mokeServerUrl only when the reader must 
   assert.equal(desktop.searchParams.get('mokeEink'), '0');
   assert.equal(desktop.searchParams.get('mokeServerUrl'), null);
 
-  // Empty serverUrl must not produce a bare `mokeServerUrl=` param even when
-  // includeServerUrl is true (callers pass `serverUrl || ''`).
+  // Empty serverUrl must not produce a bare `mokeServerUrl=` param either.
   const empty = new URL(
     buildEmbeddedReaderHomeUrl({
       eink: false,
       serverUrl: '',
-      includeServerUrl: true,
     }),
     'https://moke.invalid',
   );

--- a/tests/moke-reader.test.mjs
+++ b/tests/moke-reader.test.mjs
@@ -127,4 +127,19 @@ test('buildEmbeddedReaderHomeUrl passes mokeServerUrl only when the reader must 
   assert.equal(desktop.searchParams.get('moke'), '1');
   assert.equal(desktop.searchParams.get('mokeEink'), '0');
   assert.equal(desktop.searchParams.get('mokeServerUrl'), null);
+
+  // Empty serverUrl must not produce a bare `mokeServerUrl=` param even when
+  // includeServerUrl is true (callers pass `serverUrl || ''`).
+  const empty = new URL(
+    buildEmbeddedReaderHomeUrl({
+      eink: false,
+      serverUrl: '',
+      includeServerUrl: true,
+    }),
+    'https://moke.invalid',
+  );
+  assert.equal(empty.pathname, '/readest/');
+  assert.equal(empty.searchParams.get('moke'), '1');
+  assert.equal(empty.searchParams.get('mokeEink'), '0');
+  assert.equal(empty.searchParams.get('mokeServerUrl'), null);
 });

--- a/tests/moke-reader.test.mjs
+++ b/tests/moke-reader.test.mjs
@@ -2,11 +2,14 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 
 import {
+import {
+  buildEmbeddedReaderHomeUrl,
   buildEmbeddedReaderUrl,
   buildReaderHomeWindowLabel,
   isSingleWebviewRuntime,
   resolveRuntimeCategory,
   runtimeCategoryFromPlatform,
+} from '../src/lib/moke-reader.ts';
 } from '../src/lib/moke-reader.ts';
 
 test('OHOS uses the single-WebView reader flow', () => {
@@ -93,4 +96,35 @@ test('buildEmbeddedReaderUrl preserves the mobile reader launch context', () => 
     location: 'page=142',
     updated_at: '2026-07-24T00:00:00.000Z',
   });
+});
+
+test('buildEmbeddedReaderHomeUrl passes mokeServerUrl only when the reader must save progress itself', () => {
+  // Single-WebView runtimes: reader-home window must direct-save progress.
+  const mobile = new URL(
+    buildEmbeddedReaderHomeUrl({
+      eink: true,
+      serverUrl: 'http://192.168.1.5:8080',
+      includeServerUrl: true,
+    }),
+    'https://moke.invalid',
+  );
+  assert.equal(mobile.pathname, '/readest/');
+  assert.equal(mobile.searchParams.get('moke'), '1');
+  assert.equal(mobile.searchParams.get('mokeEink'), '1');
+  assert.equal(mobile.searchParams.get('mokeServerUrl'), 'http://192.168.1.5:8080');
+
+  // Desktop: no mokeServerUrl so the main window's ReaderProgressProvider is the
+  // single saver (no duplicate write via mokeBridge's direct POST).
+  const desktop = new URL(
+    buildEmbeddedReaderHomeUrl({
+      eink: false,
+      serverUrl: 'http://192.168.1.5:8080',
+      includeServerUrl: false,
+    }),
+    'https://moke.invalid',
+  );
+  assert.equal(desktop.pathname, '/readest/');
+  assert.equal(desktop.searchParams.get('moke'), '1');
+  assert.equal(desktop.searchParams.get('mokeEink'), '0');
+  assert.equal(desktop.searchParams.get('mokeServerUrl'), null);
 });


### PR DESCRIPTION
修复 HOU-11（M3）：桌面 reader-home 窗口不再携带 mokeServerUrl，避免进度重复保存。详见 issue HOU-11。验证：pnpm test 26/26、typecheck、lint 0 error。