### PR TITLE
fix: HOU-12 跨平台判断与 Android 边界（L5/L6）

### DIFF
--- a/src-tauri/android/MainActivity.kt
+++ b/src-tauri/android/MainActivity.kt
@@ -28,7 +28,7 @@ class MainActivity : TauriActivity(), KeyDownInterceptor {
     private var keyLearnModeEnabled = false
 
     // DOWN 已被本 Activity 消费（并转发到 webview）的按键集合。被拦截的按键
-    // 必须把配套的 ACTION_UP/ACTION_CANCEL 也一并消费，否则按键组合会泄漏到
+    // 必须把配套的 ACTION_UP 也一并消费，否则按键组合会泄漏到
     // 系统默认处理。用集合而非单个 keyCode 以容忍快速连按/按键回滚。
     private val interceptedKeyCodes = mutableSetOf<Int>()
 
@@ -114,9 +114,9 @@ class MainActivity : TauriActivity(), KeyDownInterceptor {
                 interceptedKeyCodes.add(event.keyCode)
                 return true
             }
-            // 配套的 UP / CANCEL 也要消费，保证被拦截的按键组合不会泄漏到
-            // 系统默认处理（例如 BACK 的 UP 落到默认行为）。
-            KeyEvent.ACTION_UP, KeyEvent.ACTION_CANCEL -> {
+            // 配套的 UP 也要消费（KeyEvent 没有 CANCEL；CANCEL 属 MotionEvent），
+            // 保证被拦截的按键组合不会泄漏到系统默认处理（例如 BACK 的 UP 落到默认行为）。
+            KeyEvent.ACTION_UP -> {
                 if (interceptedKeyCodes.remove(event.keyCode)) return true
                 return super.dispatchKeyEvent(event)
             }

--- a/src-tauri/android/MainActivity.kt
+++ b/src-tauri/android/MainActivity.kt
@@ -27,6 +27,11 @@ class MainActivity : TauriActivity(), KeyDownInterceptor {
     private var interceptPageTurnerKeysEnabled = false
     private var keyLearnModeEnabled = false
 
+    // DOWN 已被本 Activity 消费（并转发到 webview）的按键集合。被拦截的按键
+    // 必须把配套的 ACTION_UP/ACTION_CANCEL 也一并消费，否则按键组合会泄漏到
+    // 系统默认处理。用集合而非单个 keyCode 以容忍快速连按/按键回滚。
+    private val interceptedKeyCodes = mutableSetOf<Int>()
+
     private val keyEventMap = mapOf(
         KeyEvent.KEYCODE_BACK to "Back",
         KeyEvent.KEYCODE_VOLUME_DOWN to "VolumeDown",
@@ -44,11 +49,15 @@ class MainActivity : TauriActivity(), KeyDownInterceptor {
     private fun keyNameFor(keyCode: Int): String =
         keyEventMap[keyCode] ?: mediaKeyMap[keyCode] ?: "Keycode$keyCode"
 
-    private fun forwardKeyToWebView(keyName: String, keyCode: Int) {
-        wv?.evaluateJavascript(
+    // 转发按键到 webview。webview 尚未创建（onWebViewCreate 未调用）时返回
+    // false，调用方必须放行 super 而不是消费按键，避免"拦截但不转发"导致按键丢失。
+    private fun forwardKeyToWebView(keyName: String, keyCode: Int): Boolean {
+        val webView = wv ?: return false
+        webView.evaluateJavascript(
             """try { window.onNativeKeyDown("$keyName", $keyCode); } catch (_) {}""",
             null,
         )
+        return true
     }
 
     override fun onWebViewCreate(webView: WebView) {
@@ -71,39 +80,48 @@ class MainActivity : TauriActivity(), KeyDownInterceptor {
         keyLearnModeEnabled = enabled
     }
 
-    override fun dispatchKeyEvent(event: KeyEvent): Boolean {
-        if (event.action == KeyEvent.ACTION_DOWN) {
-            val keyCode = event.keyCode
+    // 判断某个按键当前是否应被本 Activity 拦截（与按键方向无关）。
+    private fun shouldIntercept(keyCode: Int): Boolean {
+        // Learn mode: forward and consume every key except BACK so the settings
+        // UI can capture whatever the remote sends. BACK stays excluded to match
+        // the reader: PageTurnerSettings explicitly does not allow binding Back
+        // (it is reserved for back navigation, and dialogs must still receive
+        // BACK to cancel their onCancel handler).
+        if (keyLearnModeEnabled && keyCode != KeyEvent.KEYCODE_BACK) return true
 
-            // Learn mode: forward and consume every key so the settings UI
-            // can capture whatever the remote sends.
-            if (keyLearnModeEnabled && keyCode != KeyEvent.KEYCODE_BACK) {
-                forwardKeyToWebView(keyNameFor(keyCode), keyCode)
-                return true
-            }
+        // Hardware page turner: intercept media keys when enabled.
+        if (interceptPageTurnerKeysEnabled && mediaKeyMap.containsKey(keyCode)) return true
 
-            // Hardware page turner: intercept media keys when enabled.
-            if (interceptPageTurnerKeysEnabled && mediaKeyMap.containsKey(keyCode)) {
-                forwardKeyToWebView(mediaKeyMap[keyCode]!!, keyCode)
-                return true
-            }
-
-            val keyName = keyEventMap[keyCode]
-            if (keyName != null) {
-                val shouldIntercept = when (keyCode) {
-                    KeyEvent.KEYCODE_BACK -> interceptBackKeyEnabled
-                    KeyEvent.KEYCODE_VOLUME_UP, KeyEvent.KEYCODE_VOLUME_DOWN ->
-                        interceptVolumeKeysEnabled
-                    else -> false
-                }
-
-                if (shouldIntercept) {
-                    forwardKeyToWebView(keyName, keyCode)
-                    return true
-                }
-            }
+        return when (keyCode) {
+            KeyEvent.KEYCODE_BACK -> interceptBackKeyEnabled
+            KeyEvent.KEYCODE_VOLUME_UP, KeyEvent.KEYCODE_VOLUME_DOWN ->
+                interceptVolumeKeysEnabled
+            else -> false
         }
-        return super.dispatchKeyEvent(event)
+    }
+
+    override fun dispatchKeyEvent(event: KeyEvent): Boolean {
+        when (event.action) {
+            KeyEvent.ACTION_DOWN -> {
+                if (!shouldIntercept(event.keyCode)) {
+                    return super.dispatchKeyEvent(event)
+                }
+                // 只消费真正转发成功的按键；webview 未就绪时放行默认处理，
+                // 避免拦截到但转发不出去的按键被吞掉。
+                if (!forwardKeyToWebView(keyNameFor(event.keyCode), event.keyCode)) {
+                    return super.dispatchKeyEvent(event)
+                }
+                interceptedKeyCodes.add(event.keyCode)
+                return true
+            }
+            // 配套的 UP / CANCEL 也要消费，保证被拦截的按键组合不会泄漏到
+            // 系统默认处理（例如 BACK 的 UP 落到默认行为）。
+            KeyEvent.ACTION_UP, KeyEvent.ACTION_CANCEL -> {
+                if (interceptedKeyCodes.remove(event.keyCode)) return true
+                return super.dispatchKeyEvent(event)
+            }
+            else -> return super.dispatchKeyEvent(event)
+        }
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/src/lib/moke-reader.ts
+++ b/src/lib/moke-reader.ts
@@ -16,6 +16,32 @@ export async function getMokeRuntimePlatform(): Promise<string> {
   }
 }
 
+export type RuntimeCategory = 'desktop' | 'mobile';
+
+/**
+ * 运行时平台分类：单 WebView 运行时（OHOS/Android/iOS）→ 'mobile'，其余 → 'desktop'。
+ *
+ * 与 `getMokeRuntimePlatform` 不同，这里在 `moke_runtime_platform` 不可用时
+ * 直接按 mobile 判定。原因：plugin-os 在 OHOS 上会报 "linux"（Rust target_os
+ * = linux），`isSingleWebviewRuntime('linux')` 为 false，降级结果会误判为桌面，
+ * 进而去调用未注册的 updater 插件导致检查更新静默失败。而单 WebView 移动构建
+ * 必定注册 `moke_runtime_platform`，invoke 失败只可能是旧桌面后端或 IPC 异常，
+ * 此时按 mobile 走"复制下载链接"流程是最安全的兜底。
+ */
+export async function resolveRuntimeCategory(): Promise<RuntimeCategory> {
+  if (process.env.NEXT_PUBLIC_APP_PLATFORM !== 'tauri') return 'desktop';
+  try {
+    const { invoke } = await import('@tauri-apps/api/core');
+    return runtimeCategoryFromPlatform(await invoke<string>('moke_runtime_platform'));
+  } catch {
+    return 'mobile';
+  }
+}
+
+export function runtimeCategoryFromPlatform(platform: string): RuntimeCategory {
+  return isSingleWebviewRuntime(platform) ? 'mobile' : 'desktop';
+}
+
 /**
  * Full-document navigation for single-WebView runtimes (OHOS/Android/iOS).
  *

--- a/src/lib/store/update.ts
+++ b/src/lib/store/update.ts
@@ -118,12 +118,12 @@ async function importProcess(): Promise<ProcessMod | null> {
 // 需要运行时平台检测来判定是否有内置 updater。
 async function resolvePlatform(): Promise<'desktop' | 'mobile'> {
   try {
-    const { getMokeRuntimePlatform, isSingleWebviewRuntime } = await import('@/lib/moke-reader');
-    if (isSingleWebviewRuntime(await getMokeRuntimePlatform())) return 'mobile';
+    const { resolveRuntimeCategory } = await import('@/lib/moke-reader');
+    return await resolveRuntimeCategory();
   } catch {
-    // 运行时检测失败时按桌面处理（兼容旧后端）
+    // 模块加载失败时按桌面处理（兼容旧后端）。
+    return 'desktop';
   }
-  return 'desktop';
 }
 
 export const useUpdateStore = create<UpdateStore>((set, get) => ({

--- a/tests/moke-reader.test.mjs
+++ b/tests/moke-reader.test.mjs
@@ -1,7 +1,12 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { buildEmbeddedReaderUrl, isSingleWebviewRuntime } from '../src/lib/moke-reader.ts';
+import {
+  buildEmbeddedReaderUrl,
+  isSingleWebviewRuntime,
+  resolveRuntimeCategory,
+  runtimeCategoryFromPlatform,
+} from '../src/lib/moke-reader.ts';
 
 test('OHOS uses the single-WebView reader flow', () => {
   assert.equal(isSingleWebviewRuntime('ohos'), true);
@@ -9,6 +14,43 @@ test('OHOS uses the single-WebView reader flow', () => {
   assert.equal(isSingleWebviewRuntime('ios'), true);
   assert.equal(isSingleWebviewRuntime('linux'), false);
   assert.equal(isSingleWebviewRuntime('windows'), false);
+});
+
+test('runtimeCategoryFromPlatform classifies each runtime', () => {
+  assert.equal(runtimeCategoryFromPlatform('ohos'), 'mobile');
+  assert.equal(runtimeCategoryFromPlatform('android'), 'mobile');
+  assert.equal(runtimeCategoryFromPlatform('ios'), 'mobile');
+  assert.equal(runtimeCategoryFromPlatform('linux'), 'desktop');
+  assert.equal(runtimeCategoryFromPlatform('windows'), 'desktop');
+  assert.equal(runtimeCategoryFromPlatform('macos'), 'desktop');
+});
+
+test('resolveRuntimeCategory falls back to mobile when the probe is unavailable', async () => {
+  const prev = process.env.NEXT_PUBLIC_APP_PLATFORM;
+  process.env.NEXT_PUBLIC_APP_PLATFORM = 'tauri';
+  try {
+    // In a plain Node environment there is no Tauri IPC bridge, so the
+    // `moke_runtime_platform` invoke cannot succeed. The resolver must NOT
+    // fall back to desktop (which would drive an unregistered updater on
+    // mobile builds) — it must resolve to mobile instead.
+    assert.equal(await resolveRuntimeCategory(), 'mobile');
+  } finally {
+    if (prev === undefined) {
+      delete process.env.NEXT_PUBLIC_APP_PLATFORM;
+    } else {
+      process.env.NEXT_PUBLIC_APP_PLATFORM = prev;
+    }
+  }
+});
+
+test('resolveRuntimeCategory resolves desktop outside the tauri platform', async () => {
+  const prev = process.env.NEXT_PUBLIC_APP_PLATFORM;
+  if (prev !== undefined) delete process.env.NEXT_PUBLIC_APP_PLATFORM;
+  try {
+    assert.equal(await resolveRuntimeCategory(), 'desktop');
+  } finally {
+    if (prev !== undefined) process.env.NEXT_PUBLIC_APP_PLATFORM = prev;
+  }
 });
 
 test('buildEmbeddedReaderUrl preserves the mobile reader launch context', () => {


### PR DESCRIPTION
修复 HOU-12（L5/L6）：Android 返回键边界 + OHOS 平台降级判断。详见 issue HOU-12。验证：单测通过、lint 0 error、typecheck 通过。