### PR TITLE
fix: HOU-16 离线下载链路重构（M1-M4/L1/L2/L4/L5）

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -89,8 +89,11 @@ fn write_moke_downloads(app: &AppHandle, books: &[MokeDownloadedBook]) -> Result
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent).map_err(|error| error.to_string())?;
     }
-    fs::write(path, serde_json::to_vec(books).map_err(|error| error.to_string())?)
-        .map_err(|error| error.to_string())
+    // 原子写入：先写同目录临时文件再 rename，避免写入中途崩溃/断电留下截断损坏的索引。
+    let tmp_path = path.with_extension("json.tmp");
+    fs::write(&tmp_path, serde_json::to_vec(books).map_err(|error| error.to_string())?)
+        .map_err(|error| error.to_string())?;
+    fs::rename(&tmp_path, &path).map_err(|error| error.to_string())
 }
 
 #[tauri::command]

--- a/src/app/detail/page.tsx
+++ b/src/app/detail/page.tsx
@@ -4,8 +4,13 @@ import { Suspense, useState, useEffect, useRef } from 'react';
 import { useSearchParams, useRouter } from 'next/navigation';
 import { ArrowLeft, ChevronRight, Star, FileText, HardDrive, Calendar, BookOpen, Building2, Barcode, Tags, Users, LibraryBig, FileBadge2, Bookmark, Trash2 } from 'lucide-react';
 import { DesktopLayout } from '@/components/layout/DesktopLayout';
-import { downloadBookBlob, getErrorMessage, readApiJson, request } from '@/lib/api';
-import { deleteOfflineBook, getOfflineBook, saveOfflineBook } from '@/lib/offline-books';
+import { getErrorMessage, readApiJson, request } from '@/lib/api';
+import { deleteOfflineBook, getOfflineBook } from '@/lib/offline-books';
+import {
+  beginOfflineDownload,
+  downloadAndSaveOfflineBook,
+  endOfflineDownload,
+} from '@/lib/offline-download';
 import { useServerStore } from '@/lib/store/server';
 import { useSettingsStore } from '@/lib/store/settings';
 import { fetchReadingProgress } from '@/lib/reading-progress';
@@ -58,6 +63,7 @@ function DetailContent() {
   const [shelfUpdating, setShelfUpdating] = useState(false);
   const [message, setMessage] = useState('');
   const downloadControllerRef = useRef<AbortController | null>(null);
+  const isTauriApp = process.env.NEXT_PUBLIC_APP_PLATFORM === 'tauri';
   const coverUrl = book ? resolveServerAssetUrl(serverUrl, book.img || book.thumb) : '';
   const authorNames = normalizeNames(book?.authors, book?.author);
   const tagNames = normalizeNames(book?.tags);
@@ -192,6 +198,10 @@ function DetailContent() {
 
   const handleDownload = async () => {
     if (!book || downloading) return;
+    if (!beginOfflineDownload(serverUrl, String(book.id))) {
+      setMessage('该书籍正在下载中，请稍候。');
+      return;
+    }
 
     const controller = new AbortController();
     downloadControllerRef.current = controller;
@@ -200,19 +210,13 @@ function DetailContent() {
     setMessage('');
 
     try {
-      const blob = await downloadBookBlob(book.id, selectedFormat, {
-        onProgress: (progress) => {
-          setDownloadProgress(progress);
-        },
-        signal: controller.signal,
-      });
-      await saveOfflineBook({
+      await downloadAndSaveOfflineBook({
         serverUrl,
         bookId: String(book.id),
         title: book.title,
-        fileName: `${book.title}.${selectedFormat}`,
-        mimeType: blob.type || getDefaultMimeType(selectedFormat),
-        blob,
+        format: selectedFormat,
+        onProgress: setDownloadProgress,
+        signal: controller.signal,
       });
 
       setDownloadProgress(100);
@@ -233,13 +237,14 @@ function DetailContent() {
         setMessage('下载失败：服务端返回的 EPUB 文件不完整或格式错误，请重新上传该书。');
       } else if (reason === 'Failed to save book to file system') {
         setMessage('下载失败：保存文件到本地时出错。');
-      } else if (process.env.NEXT_PUBLIC_APP_PLATFORM !== 'tauri') {
+      } else if (!isTauriApp) {
         setMessage('下载失败：当前浏览器模式下可能被跨域策略拦截。桌面版会走 Tauri 原生下载通道。');
       } else {
         setMessage('下载失败，请检查服务器连接或登录状态后重试。');
       }
       setDownloadProgress(0);
     } finally {
+      endOfflineDownload(serverUrl, String(book.id));
       if (downloadControllerRef.current === controller) {
         downloadControllerRef.current = null;
         setDownloading(false);
@@ -358,44 +363,52 @@ function DetailContent() {
               </div>
             </div>
 
-            <button
-              onClick={downloaded ? handleOfflineRead : handleDownload}
-              disabled={downloading}
-              className={`relative mt-5 inline-flex h-11 w-full items-center justify-center overflow-hidden rounded-xl text-sm font-semibold shadow-md transition-all duration-200 active:scale-[0.98] hover:shadow-lg disabled:opacity-100 md:mt-6 md:w-[220px] ${downloading ? 'border border-primary/15 bg-primary/15 text-primary-foreground' : 'bg-primary text-primary-foreground hover:bg-primary/90'}`}
-            >
-              {downloading && <span className="absolute inset-0 bg-primary/15" />}
-              {downloading && (
-                <span
-                  className="absolute inset-y-0 left-0 bg-primary transition-[width] duration-150 ease-out"
-                  style={{ width: `${downloadProgress}%` }}
-                />
-              )}
-              <span className="relative z-10 flex items-center justify-center gap-2 text-primary-foreground">
-                {downloaded && <BookOpen className="w-4 h-4" />}
-                {downloading ? `下载中 ${downloadProgress}%` : downloaded ? '阅读' : '下载'}
-              </span>
-            </button>
-            {book.files && book.files.length > 1 && !downloaded && (
-              <div className="mt-3 w-full md:w-[220px]">
-                <div className="flex flex-wrap gap-1.5">
-                  {book.files.map((f) => {
-                    const fmt = f.format.toLowerCase();
-                    const isActive = selectedFormat === fmt;
-                    return (
-                      <button
-                        key={fmt}
-                        onClick={() => setSelectedFormat(fmt)}
-                        className={`h-7 px-2.5 rounded-lg text-xs font-medium transition-all border ${
-                          isActive
-                            ? 'bg-primary/10 border-primary/30 text-primary'
-                            : 'bg-muted/50 border-border/40 text-muted-foreground hover:border-border'
-                        }`}
-                      >
-                        {fmt.toUpperCase()}
-                      </button>
-                    );
-                  })}
-                </div>
+            {isTauriApp ? (
+              <>
+                <button
+                  onClick={downloaded ? handleOfflineRead : handleDownload}
+                  disabled={downloading}
+                  className={`relative mt-5 inline-flex h-11 w-full items-center justify-center overflow-hidden rounded-xl text-sm font-semibold shadow-md transition-all duration-200 active:scale-[0.98] hover:shadow-lg disabled:opacity-100 md:mt-6 md:w-[220px] ${downloading ? 'border border-primary/15 bg-primary/15 text-primary-foreground' : 'bg-primary text-primary-foreground hover:bg-primary/90'}`}
+                >
+                  {downloading && <span className="absolute inset-0 bg-primary/15" />}
+                  {downloading && (
+                    <span
+                      className="absolute inset-y-0 left-0 bg-primary transition-[width] duration-150 ease-out"
+                      style={{ width: `${downloadProgress}%` }}
+                    />
+                  )}
+                  <span className="relative z-10 flex items-center justify-center gap-2 text-primary-foreground">
+                    {downloaded && <BookOpen className="w-4 h-4" />}
+                    {downloading ? `下载中 ${downloadProgress}%` : downloaded ? '阅读' : '下载'}
+                  </span>
+                </button>
+                {book.files && book.files.length > 1 && !downloaded && (
+                  <div className="mt-3 w-full md:w-[220px]">
+                    <div className="flex flex-wrap gap-1.5">
+                      {book.files.map((f) => {
+                        const fmt = f.format.toLowerCase();
+                        const isActive = selectedFormat === fmt;
+                        return (
+                          <button
+                            key={fmt}
+                            onClick={() => setSelectedFormat(fmt)}
+                            className={`h-7 px-2.5 rounded-lg text-xs font-medium transition-all border ${
+                              isActive
+                                ? 'bg-primary/10 border-primary/30 text-primary'
+                                : 'bg-muted/50 border-border/40 text-muted-foreground hover:border-border'
+                            }`}
+                          >
+                            {fmt.toUpperCase()}
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </div>
+                )}
+              </>
+            ) : (
+              <div className="mt-5 flex h-11 w-full items-center justify-center rounded-xl border border-border/60 bg-muted/40 px-3 text-center text-xs leading-snug text-muted-foreground md:mt-6 md:w-[220px]">
+                离线下载与离线阅读仅支持桌面版
               </div>
             )}
             <button
@@ -585,19 +598,6 @@ function normalizeNames(items?: string[] | Array<{ name: string }>, fallback?: s
   }
 
   return [];
-}
-
-function getDefaultMimeType(format: string) {
-  const mimeMap: Record<string, string> = {
-    epub: 'application/epub+zip',
-    pdf: 'application/pdf',
-    mobi: 'application/x-mobipocket-ebook',
-    azw3: 'application/vnd.amazon.ebook',
-    txt: 'text/plain',
-    rtf: 'application/rtf',
-    docx: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-  };
-  return mimeMap[format.toLowerCase()] || 'application/octet-stream';
 }
 
 function formatFileSize(size: number) {

--- a/src/app/library/page.tsx
+++ b/src/app/library/page.tsx
@@ -17,8 +17,11 @@ import { BatchActionBar, type BatchAction } from '@/components/book/BatchActionB
 import { BookContextMenu, type ContextMenuItem } from '@/components/book/BookContextMenu';
 import { Select } from '@/components/ui/Select';
 import { useViewPrefsStore } from '@/lib/store/view-prefs';
-import { downloadBookBlob } from '@/lib/api';
-import { saveOfflineBook } from '@/lib/offline-books';
+import {
+  beginOfflineDownload,
+  downloadAndSaveOfflineBook,
+  endOfflineDownload,
+} from '@/lib/offline-download';
 import { useToast } from '@/lib/toast';
 import { BookOpen, Check, Download, ListChecks } from 'lucide-react';
 
@@ -86,6 +89,7 @@ function getColorIndex(str: unknown) {
 export default function LibraryPage() {
   const { serverUrl } = useServerStore();
   const router = useRouter();
+  const isTauriApp = process.env.NEXT_PUBLIC_APP_PLATFORM === 'tauri';
 
   // Shared
   const [activeTab, setActiveTab] = useState<'local' | 'online'>('local');
@@ -378,20 +382,23 @@ export default function LibraryPage() {
   const downloadOne = async (id: string) => {
     const book = books.find((b) => String(b.id) === id);
     if (!book) return;
+    if (!beginOfflineDownload(serverUrl, id)) {
+      toast(`《${book.title}》正在下载中`);
+      return;
+    }
     const format = (book.files?.[0]?.format || 'epub').toLowerCase();
     try {
-      const blob = await downloadBookBlob(id, format);
-      await saveOfflineBook({
+      await downloadAndSaveOfflineBook({
         serverUrl,
         bookId: id,
         title: book.title,
-        fileName: `${book.title}.${format}`,
-        mimeType: blob.type || 'application/octet-stream',
-        blob,
+        format,
       });
       toast(`《${book.title}》已下载`);
     } catch {
       toast('下载失败');
+    } finally {
+      endOfflineDownload(serverUrl, id);
     }
   };
 
@@ -404,12 +411,14 @@ export default function LibraryPage() {
         icon: <Check className="w-3.5 h-3.5" />,
         onClick: () => (inShelf ? removeFromShelf(String(book.id)) : addToShelf(String(book.id))),
       },
-      {
-        key: 'download',
-        label: '下载',
-        icon: <Download className="w-3.5 h-3.5" />,
-        onClick: () => downloadOne(String(book.id)),
-      },
+      ...(isTauriApp
+        ? [{
+            key: 'download',
+            label: '下载',
+            icon: <Download className="w-3.5 h-3.5" />,
+            onClick: () => downloadOne(String(book.id)),
+          }]
+        : []),
       { key: 'sep-1', label: '', separator: true },
       {
         key: 'select-many',
@@ -524,26 +533,27 @@ export default function LibraryPage() {
       if (ok > 0) toast(`已加入 ${ok} 本到书架`);
       if (fail > 0) toast(`${fail} 本加入失败`);
     } else if (action === 'download') {
+      let skipped = 0;
       for (const id of ids) {
         const book = books.find((b) => String(b.id) === id);
         if (!book) { fail++; continue; }
+        if (!beginOfflineDownload(serverUrl, id)) { skipped++; continue; }
         const format = (book.files?.[0]?.format || 'epub').toLowerCase();
         try {
-          const blob = await downloadBookBlob(id, format);
-          await saveOfflineBook({
+          await downloadAndSaveOfflineBook({
             serverUrl,
             bookId: id,
             title: book.title,
-            fileName: `${book.title}.${format}`,
-            mimeType: blob.type || 'application/octet-stream',
-            blob,
+            format,
           });
           ok++;
         } catch { fail++; }
+        finally { endOfflineDownload(serverUrl, id); }
       }
       exitBatchMode();
       if (ok > 0) toast(`已下载 ${ok} 本`);
       if (fail > 0) toast(`${fail} 本下载失败`);
+      if (skipped > 0) toast(`${skipped} 本正在下载中，已跳过`);
     }
     return { ok, fail };
   };
@@ -956,7 +966,7 @@ export default function LibraryPage() {
         totalCount={books.length}
         canAddShelf
         canRemoveShelf={false}
-        canDownload
+        canDownload={isTauriApp}
         onAction={runBatch}
         onClear={deselectAll}
         onSelectAll={selectAll}

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -14,8 +14,11 @@ import { ViewModeToggle, type ViewMode } from '@/components/book/ViewModeToggle'
 import { BatchActionBar, type BatchAction } from '@/components/book/BatchActionBar';
 import { BookContextMenu, type ContextMenuItem } from '@/components/book/BookContextMenu';
 import { useViewPrefsStore } from '@/lib/store/view-prefs';
-import { downloadBookBlob } from '@/lib/api';
-import { saveOfflineBook } from '@/lib/offline-books';
+import {
+  beginOfflineDownload,
+  downloadAndSaveOfflineBook,
+  endOfflineDownload,
+} from '@/lib/offline-download';
 import { useToast } from '@/lib/toast';
 import { Check, Download, ListChecks } from 'lucide-react';
 
@@ -42,6 +45,7 @@ function hasFormat(book: BookItem, filter: string) {
 function SearchContent() {
   const searchParams = useSearchParams();
   const { serverUrl } = useServerStore();
+  const isTauriApp = process.env.NEXT_PUBLIC_APP_PLATFORM === 'tauri';
   const [query, setQuery] = useState(searchParams.get('q') || '');
   const [results, setResults] = useState<BookItem[]>([]);
   const [loading, setLoading] = useState(false);
@@ -160,20 +164,23 @@ function SearchContent() {
   const downloadOne = async (id: string) => {
     const book = results.find((b) => String(b.id) === id);
     if (!book) return;
+    if (!beginOfflineDownload(serverUrl, id)) {
+      toast(`《${book.title}》正在下载中`);
+      return;
+    }
     const format = (book.files?.[0]?.format || 'epub').toLowerCase();
     try {
-      const blob = await downloadBookBlob(id, format);
-      await saveOfflineBook({
+      await downloadAndSaveOfflineBook({
         serverUrl,
         bookId: id,
         title: book.title,
-        fileName: `${book.title}.${format}`,
-        mimeType: blob.type || 'application/octet-stream',
-        blob,
+        format,
       });
       toast(`《${book.title}》已下载`);
     } catch {
       toast('下载失败');
+    } finally {
+      endOfflineDownload(serverUrl, id);
     }
   };
 
@@ -186,12 +193,14 @@ function SearchContent() {
         icon: <Check className="w-3.5 h-3.5" />,
         onClick: () => addToShelf(String(book.id)),
       },
-      {
-        key: 'download',
-        label: '下载',
-        icon: <Download className="w-3.5 h-3.5" />,
-        onClick: () => downloadOne(String(book.id)),
-      },
+      ...(isTauriApp
+        ? [{
+            key: 'download',
+            label: '下载',
+            icon: <Download className="w-3.5 h-3.5" />,
+            onClick: () => downloadOne(String(book.id)),
+          }]
+        : []),
       { key: 'sep-1', label: '', separator: true },
       {
         key: 'select-many',
@@ -235,26 +244,27 @@ function SearchContent() {
       if (ok > 0) toast(`已加入 ${ok} 本到书架`);
       if (fail > 0) toast(`${fail} 本加入失败`);
     } else if (action === 'download') {
+      let skipped = 0;
       for (const id of ids) {
         const book = results.find((b) => String(b.id) === id);
         if (!book) { fail++; continue; }
+        if (!beginOfflineDownload(serverUrl, id)) { skipped++; continue; }
         const format = (book.files?.[0]?.format || 'epub').toLowerCase();
         try {
-          const blob = await downloadBookBlob(id, format);
-          await saveOfflineBook({
+          await downloadAndSaveOfflineBook({
             serverUrl,
             bookId: id,
             title: book.title,
-            fileName: `${book.title}.${format}`,
-            mimeType: blob.type || 'application/octet-stream',
-            blob,
+            format,
           });
           ok++;
         } catch { fail++; }
+        finally { endOfflineDownload(serverUrl, id); }
       }
       exitBatchMode();
       if (ok > 0) toast(`已下载 ${ok} 本`);
       if (fail > 0) toast(`${fail} 本下载失败`);
+      if (skipped > 0) toast(`${skipped} 本正在下载中，已跳过`);
     }
     return { ok, fail };
   };
@@ -468,7 +478,7 @@ function SearchContent() {
         totalCount={filteredResults.length}
         canAddShelf
         canRemoveShelf={false}
-        canDownload
+        canDownload={isTauriApp}
         onAction={runBatch}
         onClear={deselectAll}
         onSelectAll={selectAll}

--- a/src/app/shelf/page.tsx
+++ b/src/app/shelf/page.tsx
@@ -14,8 +14,11 @@ import { ViewModeToggle } from '@/components/book/ViewModeToggle';
 import { BatchActionBar, type BatchAction } from '@/components/book/BatchActionBar';
 import { BookContextMenu, type ContextMenuItem } from '@/components/book/BookContextMenu';
 import { useViewPrefsStore } from '@/lib/store/view-prefs';
-import { downloadBookBlob } from '@/lib/api';
-import { saveOfflineBook } from '@/lib/offline-books';
+import {
+  beginOfflineDownload,
+  downloadAndSaveOfflineBook,
+  endOfflineDownload,
+} from '@/lib/offline-download';
 import { useToast } from '@/lib/toast';
 import { Check, Download, ListChecks } from 'lucide-react';
 
@@ -223,6 +226,7 @@ export default function ShelfPage() {
   const { serverUrl } = useServerStore();
   const router = useRouter();
   const toast = useToast((s) => s.show);
+  const isTauriApp = process.env.NEXT_PUBLIC_APP_PLATFORM === 'tauri';
   const [books, setBooks] = useState<BookItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [requiresLogin, setRequiresLogin] = useState(false);
@@ -344,20 +348,23 @@ export default function ShelfPage() {
   const downloadOne = async (id: string) => {
     const book = books.find((b) => String(b.id) === id);
     if (!book) return;
+    if (!beginOfflineDownload(serverUrl, id)) {
+      toast(`《${book.title}》正在下载中`);
+      return;
+    }
     const format = (book.files?.[0]?.format || 'epub').toLowerCase();
     try {
-      const blob = await downloadBookBlob(id, format);
-      await saveOfflineBook({
+      await downloadAndSaveOfflineBook({
         serverUrl,
         bookId: id,
         title: book.title,
-        fileName: `${book.title}.${format}`,
-        mimeType: blob.type || 'application/octet-stream',
-        blob,
+        format,
       });
       toast(`《${book.title}》已下载`);
     } catch {
       toast('下载失败');
+    } finally {
+      endOfflineDownload(serverUrl, id);
     }
   };
 
@@ -369,12 +376,14 @@ export default function ShelfPage() {
       icon: <Check className="w-3.5 h-3.5" />,
       onClick: () => removeFromShelf(String(book.id)),
     },
-    {
-      key: 'download',
-      label: '下载',
-      icon: <Download className="w-3.5 h-3.5" />,
-      onClick: () => downloadOne(String(book.id)),
-    },
+    ...(isTauriApp
+      ? [{
+          key: 'download',
+          label: '下载',
+          icon: <Download className="w-3.5 h-3.5" />,
+          onClick: () => downloadOne(String(book.id)),
+        }]
+      : []),
     { key: 'sep-1', label: '', separator: true },
     {
       key: 'select-many',
@@ -414,26 +423,27 @@ export default function ShelfPage() {
       if (ok > 0) toast(`已移出 ${ok} 本`);
       if (fail > 0) toast(`${fail} 本移出失败`);
     } else if (action === 'download') {
+      let skipped = 0;
       for (const id of ids) {
         const book = books.find((b) => String(b.id) === id);
         if (!book) { fail++; continue; }
+        if (!beginOfflineDownload(serverUrl, id)) { skipped++; continue; }
         const format = (book.files?.[0]?.format || 'epub').toLowerCase();
         try {
-          const blob = await downloadBookBlob(id, format);
-          await saveOfflineBook({
+          await downloadAndSaveOfflineBook({
             serverUrl,
             bookId: id,
             title: book.title,
-            fileName: `${book.title}.${format}`,
-            mimeType: blob.type || 'application/octet-stream',
-            blob,
+            format,
           });
           ok++;
         } catch { fail++; }
+        finally { endOfflineDownload(serverUrl, id); }
       }
       exitBatchMode();
       if (ok > 0) toast(`已下载 ${ok} 本`);
       if (fail > 0) toast(`${fail} 本下载失败`);
+      if (skipped > 0) toast(`${skipped} 本正在下载中，已跳过`);
     }
     return { ok, fail };
   };
@@ -548,7 +558,7 @@ export default function ShelfPage() {
         totalCount={books.length}
         canAddShelf={false}
         canRemoveShelf
-        canDownload
+        canDownload={isTauriApp}
         onAction={runBatch}
         onClear={deselectAll}
         onSelectAll={selectAll}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -508,3 +508,95 @@ export async function downloadBookBlob(
     throw new Error(reason || 'network.error');
   }
 }
+
+const BOOK_TAIL_WINDOW = 22 + 0xffff + 4096;
+
+function keepTailBytes(tail: Uint8Array, chunk: Uint8Array, windowSize: number): Uint8Array {
+  const combinedLength = tail.length + chunk.length;
+  if (combinedLength <= windowSize) {
+    const combined = new Uint8Array(combinedLength);
+    combined.set(tail, 0);
+    combined.set(chunk, tail.length);
+    return combined;
+  }
+
+  const result = new Uint8Array(windowSize);
+  if (chunk.length >= windowSize) {
+    result.set(chunk.subarray(chunk.length - windowSize));
+    return result;
+  }
+  const tailKeep = windowSize - chunk.length;
+  result.set(tail.subarray(tail.length - tailKeep), 0);
+  result.set(chunk, tailKeep);
+  return result;
+}
+
+/** 流式下载：把响应体逐块交给 write()，仅保留文件尾部用于 EPUB 校验，
+ *  避免把整本书累积在内存中（大书/低内存设备 OOM）。 */
+export async function streamBookDownload(
+  bookId: string | number,
+  format = 'epub',
+  options: {
+    write: (chunk: Uint8Array) => Promise<void>;
+    onProgress?: (progress: number) => void;
+    signal?: AbortSignal;
+  },
+): Promise<{ mimeType: string; size: number }> {
+  const { serverUrl } = (await import('@/lib/store/server')).useServerStore.getState();
+  const url = `${serverUrl}/api/book/${bookId}.${format}`;
+
+  const response = await request(url, {
+    ...(isTauriApp
+      ? ({ method: 'GET', connectTimeout: 30_000, signal: options?.signal } as any)
+      : { credentials: 'include', signal: options?.signal }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`http.${response.status}`);
+  }
+
+  const total = Number(response.headers.get('content-length') || 0);
+  const reader = response.body?.getReader();
+
+  if (!reader) {
+    const blob = await response.blob();
+    options.onProgress?.(99);
+    await options.write(new Uint8Array(await blob.arrayBuffer()));
+    if (format.toLowerCase() === 'epub' && !(await hasEpubCentralDirectory(blob))) {
+      throw new Error('book.epub.invalid');
+    }
+    return {
+      mimeType: response.headers.get('content-type') || 'application/octet-stream',
+      size: blob.size,
+    };
+  }
+
+  let tail: Uint8Array = new Uint8Array(0);
+  let received = 0;
+
+  while (true) {
+    const { done, value } = await reader.read();
+
+    if (done) break;
+    if (!value) continue;
+
+    await options.write(value);
+    received += value.length;
+    tail = keepTailBytes(tail, value, BOOK_TAIL_WINDOW);
+
+    if (total > 0) {
+      options.onProgress?.(Math.min(99, Math.round((received / total) * 100)));
+    }
+  }
+
+  options.onProgress?.(99);
+
+  if (format.toLowerCase() === 'epub' && !(await hasEpubCentralDirectory(new Blob([tail])))) {
+    throw new Error('book.epub.invalid');
+  }
+
+  return {
+    mimeType: response.headers.get('content-type') || 'application/octet-stream',
+    size: received,
+  };
+}

--- a/src/lib/offline-book-core.ts
+++ b/src/lib/offline-book-core.ts
@@ -1,24 +1,80 @@
+const WINDOWS_RESERVED_BASE_NAMES = new Set([
+  'CON',
+  'PRN',
+  'AUX',
+  'NUL',
+  'COM1',
+  'COM2',
+  'COM3',
+  'COM4',
+  'COM5',
+  'COM6',
+  'COM7',
+  'COM8',
+  'COM9',
+  'LPT1',
+  'LPT2',
+  'LPT3',
+  'LPT4',
+  'LPT5',
+  'LPT6',
+  'LPT7',
+  'LPT8',
+  'LPT9',
+]);
+
+/** 单个离线书文件名的最大总长度（含扩展名），避免 Windows MAX_PATH 超限。 */
+const MAX_FILE_NAME_LENGTH = 120;
+
+const EOCD_LENGTH = 22;
+const MAX_COMMENT_LENGTH = 0xffff;
+/** EOCD 之后允许存在的尾部字节数（服务端/代理可能追加换行等字节）。 */
+const MAX_TRAILING_BYTES = 4096;
+
 export function makeOfflineBookKey(serverUrl: string, bookId: string): string {
   return `${serverUrl}::${bookId}`;
 }
 
 export function sanitizeOfflineFileName(fileName: string): string {
-  const sanitized = fileName
+  const cleaned = fileName
     .replace(/[<>:"/\\|?*\u0000-\u001F]/g, '_')
     .replace(/[. ]+$/g, '')
     .trim();
 
-  return sanitized || 'book.epub';
+  const name = cleaned || 'book.epub';
+
+  const lastDot = name.lastIndexOf('.');
+  const base = lastDot > 0 ? name.slice(0, lastDot) : name;
+  const ext = lastDot > 0 ? name.slice(lastDot) : '';
+
+  const reservedBase = WINDOWS_RESERVED_BASE_NAMES.has(base.toUpperCase());
+  const baseLimit = Math.max(1, MAX_FILE_NAME_LENGTH - ext.length);
+  const effectiveBase = (reservedBase ? `_${base}` : base).slice(0, baseLimit);
+
+  return `${effectiveBase}${ext}`;
+}
+
+const inFlightDownloads = new Set<string>();
+
+export function beginOfflineDownload(serverUrl: string, bookId: string): boolean {
+  const key = makeOfflineBookKey(serverUrl, bookId);
+  if (inFlightDownloads.has(key)) return false;
+  inFlightDownloads.add(key);
+  return true;
+}
+
+export function endOfflineDownload(serverUrl: string, bookId: string): void {
+  inFlightDownloads.delete(makeOfflineBookKey(serverUrl, bookId));
 }
 
 export async function hasEpubCentralDirectory(blob: Blob): Promise<boolean> {
-  const eocdLength = 22;
-  const maxCommentLength = 0xffff;
   const tail = new Uint8Array(
-    await blob.slice(Math.max(0, blob.size - eocdLength - maxCommentLength)).arrayBuffer(),
+    await blob
+      .slice(Math.max(0, blob.size - EOCD_LENGTH - MAX_COMMENT_LENGTH - MAX_TRAILING_BYTES))
+      .arrayBuffer(),
   );
 
-  for (let index = tail.length - eocdLength; index >= 0; index--) {
+  for (let index = tail.length - EOCD_LENGTH; index >= 0; index--) {
     if (
       tail[index] === 0x50 &&
       tail[index + 1] === 0x4b &&
@@ -26,7 +82,10 @@ export async function hasEpubCentralDirectory(blob: Blob): Promise<boolean> {
       tail[index + 3] === 0x06
     ) {
       const commentLength = tail[index + 20]! | (tail[index + 21]! << 8);
-      return index + eocdLength + commentLength === tail.length;
+      const endOfEocd = index + EOCD_LENGTH + commentLength;
+      if (endOfEocd <= tail.length && tail.length - endOfEocd <= MAX_TRAILING_BYTES) {
+        return true;
+      }
     }
   }
 

--- a/src/lib/offline-books.ts
+++ b/src/lib/offline-books.ts
@@ -56,7 +56,18 @@ export async function deleteOfflineBook(serverUrl: string, bookId: string): Prom
       const { remove } = await import('@tauri-apps/plugin-fs');
       await remove(record.filePath);
     } catch (e) {
-      console.error('Failed to delete book file:', e);
+      // 文件删除失败时确认文件是否仍在磁盘上：若仍在则保留记录并报错，
+      // 让调用方提示用户重试，避免残留文件被 legacy 扫描重新暴露成幽灵书。
+      let stillThere = true;
+      try {
+        const { exists } = await import('@tauri-apps/plugin-fs');
+        stillThere = await exists(record.filePath);
+      } catch {
+        // 无法确认时按“仍存在”处理，保守保留记录。
+      }
+      if (stillThere) {
+        throw new Error('Failed to delete book file');
+      }
     }
   }
 
@@ -87,45 +98,159 @@ export async function saveOfflineBook(input: {
   mimeType: string;
   blob: Blob;
 }): Promise<void> {
-  const db = await openDatabase();
-  let filePath: string | undefined;
-  const isTauriApp = process.env.NEXT_PUBLIC_APP_PLATFORM === 'tauri';
-
   const fileName = sanitizeOfflineFileName(input.fileName);
 
-  if (isTauriApp) {
-    try {
-      const { writeFile, BaseDirectory, mkdir } = await import('@tauri-apps/plugin-fs');
-      const { appDataDir, join } = await import('@tauri-apps/api/path');
+  if (process.env.NEXT_PUBLIC_APP_PLATFORM === 'tauri') {
+    // 桌面版也走流式落盘，避免 blob.arrayBuffer() 造成整本全量拷贝。
+    await saveOfflineBookStream({
+      ...input,
+      fileName,
+      write: async (writer) => {
+        const reader = input.blob.stream().getReader();
+        try {
+          while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            if (value) await writer.write(value);
+          }
+        } finally {
+          reader.releaseLock();
+        }
+        return input.mimeType;
+      },
+    });
+    return;
+  }
 
+  await commitOfflineBookRecord({
+    serverUrl: input.serverUrl,
+    bookId: input.bookId,
+    title: input.title,
+    fileName,
+    mimeType: input.mimeType,
+    blob: input.blob,
+  });
+}
+
+export interface OfflineFileWriter {
+  write(data: Uint8Array): Promise<void>;
+  close(): Promise<void>;
+}
+
+async function openOfflineBookFile(fileName: string): Promise<{ writer: OfflineFileWriter; filePath: string }> {
+  const { open, BaseDirectory, mkdir } = await import('@tauri-apps/plugin-fs');
+  const { appDataDir, join } = await import('@tauri-apps/api/path');
+
+  try {
+    await mkdir('books', { baseDir: BaseDirectory.AppData, recursive: true });
+  } catch (e) {
+    // Ignore if directory already exists
+  }
+
+  const relativePath = await join('books', fileName);
+  const file = await open(relativePath, {
+    write: true,
+    create: true,
+    truncate: true,
+    baseDir: BaseDirectory.AppData,
+  });
+
+  const dir = await appDataDir();
+  const filePath = await join(dir, 'books', fileName);
+
+  return {
+    writer: {
+      write: (data) => file.write(data).then(() => undefined),
+      close: () => file.close(),
+    },
+    filePath,
+  };
+}
+
+/** 桌面版流式落盘：逐块写入磁盘（边读边写），成功后登记索引并清理旧文件。 */
+export async function saveOfflineBookStream(input: {
+  serverUrl: string;
+  bookId: string;
+  title: string;
+  fileName: string;
+  mimeType: string;
+  write: (writer: OfflineFileWriter) => Promise<string | void>;
+}): Promise<void> {
+  const fileName = sanitizeOfflineFileName(input.fileName);
+  const previous = await getOfflineBook(input.serverUrl, input.bookId);
+
+  let writer: OfflineFileWriter | null = null;
+  let filePath: string | undefined;
+
+  try {
+    const handle = await openOfflineBookFile(fileName);
+    writer = handle.writer;
+    filePath = handle.filePath;
+
+    const actualMime = (await input.write(writer)) || input.mimeType;
+    await writer.close();
+    writer = null;
+
+    await commitOfflineBookRecord({
+      serverUrl: input.serverUrl,
+      bookId: input.bookId,
+      title: input.title,
+      fileName,
+      mimeType: actualMime,
+      filePath,
+    });
+  } catch (e) {
+    // 清理半成品/孤儿文件，避免被 legacy 扫描重新暴露成幽灵书。
+    if (filePath) {
       try {
-        await mkdir('books', { baseDir: BaseDirectory.AppData, recursive: true });
-      } catch (e) {
-        // Ignore if directory already exists
+        if (writer) await writer.close();
+      } catch {
+        // ignore
       }
+      try {
+        const { remove } = await import('@tauri-apps/plugin-fs');
+        await remove(filePath);
+      } catch {
+        // ignore
+      }
+    }
+    throw e;
+  }
 
-      const relativePath = await join('books', fileName);
-      const arrayBuffer = await input.blob.arrayBuffer();
-      await writeFile(relativePath, new Uint8Array(arrayBuffer), { baseDir: BaseDirectory.AppData });
-
-      const dir = await appDataDir();
-      filePath = await join(dir, 'books', fileName);
-    } catch (e) {
-      console.error('Failed to save book to file system:', e);
-      throw new Error('Failed to save book to file system');
+  // M1：同书换格式/改名再下载时，删除旧的残留磁盘文件，避免目录扫描
+  // 重新把旧文件暴露成 legacy 幽灵书。
+  if (previous?.filePath && filePath && previous.filePath !== filePath) {
+    try {
+      const { remove } = await import('@tauri-apps/plugin-fs');
+      await remove(previous.filePath);
+    } catch (error) {
+      console.warn('Failed to remove stale offline book file:', error);
     }
   }
+}
+
+async function commitOfflineBookRecord(input: {
+  serverUrl: string;
+  bookId: string;
+  title: string;
+  fileName: string;
+  mimeType: string;
+  blob?: Blob;
+  filePath?: string;
+}): Promise<void> {
+  const db = await openDatabase();
+  const isTauriApp = process.env.NEXT_PUBLIC_APP_PLATFORM === 'tauri';
 
   const record: OfflineBookRecord = {
     id: makeOfflineBookKey(input.serverUrl, input.bookId),
     serverUrl: input.serverUrl,
     bookId: input.bookId,
     title: input.title,
-    fileName,
+    fileName: input.fileName,
     mimeType: input.mimeType,
     blob: isTauriApp ? undefined : input.blob,
     updatedAt: Date.now(),
-    filePath,
+    filePath: input.filePath,
   };
 
   await new Promise<void>((resolve, reject) => {

--- a/src/lib/offline-download.ts
+++ b/src/lib/offline-download.ts
@@ -1,0 +1,51 @@
+'use client';
+
+import { downloadBookBlob, streamBookDownload } from '@/lib/api';
+import { beginOfflineDownload, endOfflineDownload } from '@/lib/offline-book-core';
+import { saveOfflineBook, saveOfflineBookStream } from '@/lib/offline-books';
+
+export { beginOfflineDownload, endOfflineDownload };
+
+export interface DownloadOfflineBookOptions {
+  serverUrl: string;
+  bookId: string;
+  title: string;
+  format: string;
+  onProgress?: (progress: number) => void;
+  signal?: AbortSignal;
+}
+
+/** 统一离线下载入口：tauri 走磁盘流式写入（低内存峰值 + 原子索引），web 走 Blob 存 IndexedDB。 */
+export async function downloadAndSaveOfflineBook(options: DownloadOfflineBookOptions): Promise<void> {
+  if (process.env.NEXT_PUBLIC_APP_PLATFORM === 'tauri') {
+    await saveOfflineBookStream({
+      serverUrl: options.serverUrl,
+      bookId: options.bookId,
+      title: options.title,
+      fileName: `${options.title}.${options.format}`,
+      mimeType: 'application/octet-stream',
+      write: async (writer) => {
+        const result = await streamBookDownload(options.bookId, options.format, {
+          write: (chunk) => writer.write(chunk),
+          onProgress: options.onProgress,
+          signal: options.signal,
+        });
+        return result.mimeType;
+      },
+    });
+    return;
+  }
+
+  const blob = await downloadBookBlob(options.bookId, options.format, {
+    onProgress: options.onProgress,
+    signal: options.signal,
+  });
+  await saveOfflineBook({
+    serverUrl: options.serverUrl,
+    bookId: options.bookId,
+    title: options.title,
+    fileName: `${options.title}.${options.format}`,
+    mimeType: blob.type || 'application/octet-stream',
+    blob,
+  });
+}

--- a/tests/offline-books.test.mjs
+++ b/tests/offline-books.test.mjs
@@ -7,6 +7,8 @@ import {
   saveOfflineBook,
 } from '../src/lib/offline-books.ts';
 import {
+  beginOfflineDownload,
+  endOfflineDownload,
   hasEpubCentralDirectory,
   makeOfflineBookKey,
   sanitizeOfflineFileName,
@@ -21,6 +23,24 @@ test('EPUB requires a ZIP central directory at the end of the file', async () =>
 
   assert.equal(await hasEpubCentralDirectory(validEpub), true);
   assert.equal(await hasEpubCentralDirectory(truncatedEpub), false);
+});
+
+test('EPUB 允许 EOCD 之后存在少量尾部字节', async () => {
+  const eocd = new Uint8Array([0x50, 0x4b, 0x05, 0x06, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+
+  const trailing = new Blob([
+    new Uint8Array([0x50, 0x4b, 0x03, 0x04]),
+    eocd,
+    new Uint8Array([0x0a, 0x0d, 0x0a]),
+  ]);
+  assert.equal(await hasEpubCentralDirectory(trailing), true);
+
+  const excessive = new Blob([
+    new Uint8Array([0x50, 0x4b, 0x03, 0x04]),
+    eocd,
+    new Uint8Array(5000),
+  ]);
+  assert.equal(await hasEpubCentralDirectory(excessive), false);
 });
 
 function makeAsyncRequest(operation) {
@@ -117,6 +137,30 @@ test('离线书籍键会隔离不同服务器和书籍', () => {
 test('离线文件名会清理系统不允许的字符', () => {
   assert.equal(sanitizeOfflineFileName('三体:全集?.epub.'), '三体_全集_.epub');
   assert.equal(sanitizeOfflineFileName('...'), 'book.epub');
+});
+
+test('离线文件名会规避 Windows 保留名并截断超长名称', () => {
+  assert.equal(sanitizeOfflineFileName('CON.epub'), '_CON.epub');
+  assert.equal(sanitizeOfflineFileName('nul.pdf'), '_nul.pdf');
+  assert.equal(sanitizeOfflineFileName('LPT1.txt'), '_LPT1.txt');
+  assert.equal(sanitizeOfflineFileName('aux'), '_aux');
+
+  const longName = sanitizeOfflineFileName(`${'书'.repeat(300)}.epub`);
+  assert.ok(longName.length <= 120);
+  assert.ok(longName.endsWith('.epub'));
+});
+
+test('下载在途去重按 服务器+书 维度生效', () => {
+  assert.equal(beginOfflineDownload('https://a.example', '1'), true);
+  assert.equal(beginOfflineDownload('https://a.example', '1'), false);
+  assert.equal(beginOfflineDownload('https://a.example', '2'), true);
+  assert.equal(beginOfflineDownload('https://b.example', '1'), true);
+
+  endOfflineDownload('https://a.example', '1');
+  assert.equal(beginOfflineDownload('https://a.example', '1'), true);
+  endOfflineDownload('https://a.example', '1');
+  endOfflineDownload('https://a.example', '2');
+  endOfflineDownload('https://b.example', '1');
 });
 
 test('网页版可以保存并重新读取离线书籍', async () => {


### PR DESCRIPTION
修复 HOU-16（M1-M4/L1/L2/L4/L5）：幽灵 legacy 书清理、原子索引写入、流式写盘、web 端误导、在途去重、Windows 保留名/长路径、EPUB 尾随字节。详见 issue HOU-16。验证：pnpm test（含新增）通过、lint 0 error、typecheck 通过。