### PR TITLE
fix: HOU-17 日志脱敏与 URL 协议校验（L3/L9）

### DIFF
--- a/src/app/access/page.tsx
+++ b/src/app/access/page.tsx
@@ -5,6 +5,7 @@ import { useState, useEffect, Suspense } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { KeyRound } from 'lucide-react';
 import { submitWelcomeCode } from '@/lib/api';
+import { isHttpUrl } from '@/lib/server-url';
 import { useServerStore } from '@/lib/store/server';
 import { CaptchaModal } from '@/components/auth/CaptchaModal';
 import { debugLog } from '@/lib/debug-log';
@@ -38,6 +39,10 @@ function AccessPageInner() {
 
     if (candidate) {
       try {
+        if (!isHttpUrl(candidate)) {
+          debugLog('warn', 'access', `server 值协议非法，已忽略: ${new URL(candidate).protocol}`);
+          return;
+        }
         const url = new URL(candidate);
         const current = useServerStore.getState().serverUrl;
         if (current !== url.origin) {
@@ -66,7 +71,7 @@ function AccessPageInner() {
     if (!effectiveUrl) {
       try {
         const fromLs = localStorage.getItem('moke_server_url') || '';
-        if (fromLs) {
+        if (fromLs && isHttpUrl(fromLs)) {
           const url = new URL(fromLs);
           useServerStore.setState({
             serverUrl: url.origin,

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -34,6 +34,12 @@ interface UserInfoResponse {
 const appPlatform = resolveAppPlatform(process.env.NEXT_PUBLIC_APP_PLATFORM);
 const isTauriApp = appPlatform === 'tauri';
 
+/**
+ * 服务器原始响应可能携带邮箱/昵称/头像等个人信息。生产构建不输出原始正文，
+ * 仅在开发环境（dev server）保留全文，避免敏感信息无条件进入 devtools 与调试面板。
+ */
+const isDev = process.env.NODE_ENV !== 'production';
+
 function isRequestCancelled(error: unknown): boolean {
   if (error instanceof DOMException && error.name === 'AbortError') return true;
   const message = error instanceof Error ? error.message : String(error);
@@ -331,8 +337,12 @@ export async function validateServerConnection(serverUrl: string): Promise<{ err
     console.log('[validateServerConnection] status=%s content-type=%s', response.status, response.headers.get('content-type'));
 
     const rawText = await response.text();
-    console.log('[validateServerConnection] raw (first 500):', rawText.substring(0, 500));
-    debugLog('info', 'validate', `服务器返回正文 (${rawText.length} 字节)`, rawText.substring(0, 800));
+    if (isDev) {
+      console.log('[validateServerConnection] raw (first 500):', rawText.substring(0, 500));
+      debugLog('info', 'validate', `服务器返回正文 (${rawText.length} 字节)`, rawText.substring(0, 800));
+    } else {
+      debugLog('info', 'validate', `服务器返回正文 (${rawText.length} 字节)`);
+    }
 
     let data: UserInfoResponse;
     try {
@@ -409,7 +419,8 @@ export async function checkWelcomeRequirement(serverUrl: string): Promise<{ err:
     };
   }
 
-  console.log('[checkWelcomeRequirement]', data.err, data);
+  if (isDev) console.log('[checkWelcomeRequirement]', data.err, data);
+  else console.log('[checkWelcomeRequirement] err=%s', data.err);
 
   if (data.err === 'ok') {
     return {
@@ -449,7 +460,8 @@ export async function submitWelcomeCode(code: string, captchaData?: any): Promis
   });
 
   const result = await response.json();
-  console.log('[submitWelcomeCode]', result);
+  if (isDev) console.log('[submitWelcomeCode]', result);
+  else console.log('[submitWelcomeCode] err=%s', result.err);
   return result;
 }
 

--- a/src/lib/server-url.ts
+++ b/src/lib/server-url.ts
@@ -1,0 +1,15 @@
+/**
+ * 校验字符串是否是合法 http(s) URL。
+ *
+ * `/access` 页会把 URL 参数 / localStorage 里的服务器地址直接写进 store，
+ * 必须拒绝 `javascript:` 等非 http 协议——`new URL(candidate).origin` 对
+ * 这类输入返回 `"null"`，会把 serverUrl 设成 `"null"` 导致应用需重连。
+ */
+export function isHttpUrl(candidate: string): boolean {
+  try {
+    const protocol = new URL(candidate).protocol;
+    return protocol === 'http:' || protocol === 'https:';
+  } catch {
+    return false;
+  }
+}

--- a/tests/server-url.test.mjs
+++ b/tests/server-url.test.mjs
@@ -1,0 +1,24 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { isHttpUrl } from '../src/lib/server-url.ts';
+
+test('accepts http and https URLs', () => {
+  assert.equal(isHttpUrl('http://192.168.1.5:8080'), true);
+  assert.equal(isHttpUrl('https://books.example.com'), true);
+  assert.equal(isHttpUrl('https://user:pass@example.com/path?q=1#frag'), true);
+});
+
+test('rejects non-http protocols', () => {
+  assert.equal(isHttpUrl('javascript:alert(1)'), false);
+  assert.equal(isHttpUrl('data:text/html,<script>alert(1)</script>'), false);
+  assert.equal(isHttpUrl('file:///etc/passwd'), false);
+  assert.equal(isHttpUrl('ftp://example.com'), false);
+  assert.equal(isHttpUrl('about:blank'), false);
+});
+
+test('rejects malformed input instead of throwing', () => {
+  assert.equal(isHttpUrl(''), false);
+  assert.equal(isHttpUrl('not a url'), false);
+  assert.equal(isHttpUrl('//no-scheme'), false);
+});


### PR DESCRIPTION
修复 HOU-17（L3/L9）：服务器响应日志脱敏、access URL 协议白名单。含 readest 子模块更新。详见 issue HOU-17。验证：单测通过、lint 0 error、typecheck 通过。