### PR TITLE
fix: HOU-21 请求竞态与轮询取消（M1/M2）

### DIFF
--- a/src/app/detail/page.tsx
+++ b/src/app/detail/page.tsx
@@ -64,6 +64,10 @@ function DetailContent() {
   const [message, setMessage] = useState('');
   const downloadControllerRef = useRef<AbortController | null>(null);
   const isTauriApp = process.env.NEXT_PUBLIC_APP_PLATFORM === 'tauri';
+  // 请求序号 + abort：详情页 id 跳转（同一组件实例复用）或卸载时终止在途请求，
+  // 防止 A 的慢响应把 B 的书显示在页面上。
+  const loadBookSeqRef = useRef(0);
+  const loadBookControllerRef = useRef<AbortController | null>(null);
   const coverUrl = book ? resolveServerAssetUrl(serverUrl, book.img || book.thumb) : '';
   const authorNames = normalizeNames(book?.authors, book?.author);
   const tagNames = normalizeNames(book?.tags);
@@ -75,7 +79,16 @@ function DetailContent() {
   const ratingValue = typeof book?.rating === 'number' ? book.rating : book?.rating?.value;
 
   useEffect(() => {
-    if (id) loadBook();
+    if (!id) return;
+    // id 变化时 abort 上一本在途请求，避免旧详情覆盖新详情。
+    loadBookControllerRef.current?.abort();
+    const controller = new AbortController();
+    loadBookControllerRef.current = controller;
+    loadBook(controller);
+    return () => {
+      controller.abort();
+      if (loadBookControllerRef.current === controller) loadBookControllerRef.current = null;
+    };
   }, [id]);
 
   useEffect(() => {
@@ -107,33 +120,39 @@ function DetailContent() {
     return () => downloadControllerRef.current?.abort();
   }, []);
 
-  const loadBook = async () => {
+  const loadBook = async (controller: AbortController) => {
+    const seq = ++loadBookSeqRef.current;
     setLoading(true);
     try {
-      const res = await request(`${serverUrl}/api/book/${id}`, { credentials: 'include' });
+      const res = await request(`${serverUrl}/api/book/${id}`, { credentials: 'include', signal: controller.signal });
       const data = await readApiJson<{ err?: string; msg?: string; book?: BookDetail; data?: BookDetail }>(res, '书籍详情解析失败。');
+      if (controller.signal.aborted || seq !== loadBookSeqRef.current) return;
       const nextBook = data.book || data.data;
       if (data.err === 'ok' && nextBook) {
         setBook(nextBook);
         setInShelf(Boolean(nextBook?.state?.wants));
         const format = (nextBook?.files?.[0]?.format || 'epub').toLowerCase();
         setSelectedFormat(format);
-        loadReadingState(nextBook?.id || String(id));
+        loadReadingState(nextBook?.id || String(id), seq);
       } else {
         throw new Error(data.msg || '书籍详情加载失败。');
       }
     } catch (error) {
+      if (controller.signal.aborted || seq !== loadBookSeqRef.current) return;
       setBook(null);
       setMessage(getErrorMessage(error, '书籍详情加载失败，请检查服务器连接。'));
-    } finally { setLoading(false); }
+    } finally {
+      if (!controller.signal.aborted && seq === loadBookSeqRef.current) setLoading(false);
+    }
   };
 
-  const loadReadingState = async (bookId: string | number) => {
+  const loadReadingState = async (bookId: string | number, seq: number) => {
     try {
       const res = await request(`${serverUrl}/api/book/${bookId}/readstate`, {
         credentials: 'include',
       });
       const data = await res.json();
+      if (seq !== loadBookSeqRef.current) return;
       if (data.err === 'ok') {
         setInShelf(Boolean(data.wants));
       }

--- a/src/app/library/page.tsx
+++ b/src/app/library/page.tsx
@@ -10,7 +10,7 @@ import { getErrorMessage, MokeApiError, readApiJson, request } from '@/lib/api';
 import { cn, resolveServerAssetUrl } from '@/lib/utils';
 import { AuthImage } from '@/components/ui/AuthImage';
 import { BookTable, type BookRow, type SortState } from '@/components/book/BookTable';
-import { buildNetworkBookHref } from '@/lib/network-book-core';
+import { buildNetworkBookHref, pollNetworkSearch, type NetworkSearchStatusResponse } from '@/lib/network-book-core';
 import { pollNetworkSaveForBook, saveNetworkBook } from '@/lib/network-books';
 import { ViewModeToggle, type ViewMode } from '@/components/book/ViewModeToggle';
 import { BatchActionBar, type BatchAction } from '@/components/book/BatchActionBar';
@@ -148,6 +148,23 @@ export default function LibraryPage() {
   const [networkSearchResults, setNetworkSearchResults] = useState<NetworkBook[]>([]);
   const [networkSearchLoading, setNetworkSearchLoading] = useState(false);
 
+  // 请求序号：每个数据请求在发起时取号，回写 setState 前校验仍是当前最新，
+  // 慢的旧请求即使后返回也不会覆盖新结果（翻页/切 tab/连搜/详情跳转的竞态保护）。
+  const booksSeqRef = useRef(0);
+  const categoriesSeqRef = useRef(0);
+  const networkBooksSeqRef = useRef(0);
+  const networkSearchSeqRef = useRef(0);
+  // 在途网络搜索的控制句柄：新搜索/卸载时 abort，防止并行轮询与卸载后后台空转。
+  const networkSearchControllerRef = useRef<AbortController | null>(null);
+
+  // 卸载时终止在途的网络搜索轮询，避免离开页面后仍在后台每 1s 打 status。
+  useEffect(() => {
+    return () => {
+      networkSearchControllerRef.current?.abort();
+      networkSearchControllerRef.current = null;
+    };
+  }, []);
+
   // ── Local tab effects ────────────────────────────────────────────────────────
   useEffect(() => {
     if (activeTab === 'local') loadBooks(currentPage);
@@ -159,6 +176,7 @@ export default function LibraryPage() {
   }, [serverUrl]);
 
   const loadBooks = async (page: number) => {
+    const seq = ++booksSeqRef.current;
     setLocalLoading(true);
     try {
       const params = new URLSearchParams({
@@ -169,14 +187,16 @@ export default function LibraryPage() {
       if (selectedFormat !== '全部') params.set('format', selectedFormat.toLowerCase());
       const res = await request(`${serverUrl}/api/library?${params.toString()}`, { credentials: 'include' });
       const data = await readApiJson<{ err?: string; msg?: string; books?: BookItem[]; items?: BookItem[]; total?: number }>(res, '书库列表解析失败。', ['ok', 'user.need_login']);
+      if (seq !== booksSeqRef.current) return;
       if (data.err === 'user.need_login') { router.push('/login'); return; }
       setBooks(data.books || data.items || []);
       setTotal(data.total || 0);
     } catch (error) {
+      if (seq !== booksSeqRef.current) return;
       setBooks([]);
       setTotal(0);
       toast(getErrorMessage(error, '书库加载失败，请检查服务器连接。'));
-    } finally { setLocalLoading(false); }
+    } finally { if (seq === booksSeqRef.current) setLocalLoading(false); }
   };
 
   const loadTags = async () => {
@@ -226,72 +246,93 @@ export default function LibraryPage() {
   };
 
   const loadCategories = async (sourceId: number) => {
+    const seq = ++categoriesSeqRef.current;
     setCategoriesLoading(true);
     try {
       const res = await request(`${serverUrl}/api/network/categories?source_id=${sourceId}`, { credentials: 'include' });
       const data = await readApiJson<{ err?: string; msg?: string; items?: NetworkCategory[] }>(res, '分类解析失败。');
+      if (seq !== categoriesSeqRef.current) return;
       setCategories(data.items || []);
     } catch (error) {
+      if (seq !== categoriesSeqRef.current) return;
       setCategories([]);
       toast(getErrorMessage(error, '分类加载失败。'));
-    } finally { setCategoriesLoading(false); }
+    } finally { if (seq === categoriesSeqRef.current) setCategoriesLoading(false); }
   };
 
   const loadNetworkBooks = async (categoryUrl: string, page: number) => {
     if (!selectedSourceId) return;
+    const seq = ++networkBooksSeqRef.current;
     setNetworkBooksLoading(true);
     try {
       const params = new URLSearchParams({ source_id: String(selectedSourceId), url: categoryUrl, page: String(page) });
       const res = await request(`${serverUrl}/api/network/explore?${params.toString()}`, { credentials: 'include' });
       const data = await readApiJson<{ err?: string; msg?: string; books?: NetworkBook[] }>(res, '网络书籍解析失败。');
+      if (seq !== networkBooksSeqRef.current) return;
       setNetworkBooks((data.books || []).map((b) => ({ ...b, source_id: selectedSourceId })));
     } catch (error) {
+      if (seq !== networkBooksSeqRef.current) return;
       setNetworkBooks([]);
       toast(getErrorMessage(error, '网络书籍加载失败。'));
-    } finally { setNetworkBooksLoading(false); }
+    } finally { if (seq === networkBooksSeqRef.current) setNetworkBooksLoading(false); }
   };
 
   // ── Network search ───────────────────────────────────────────────────────────
   const doNetworkSearch = useCallback(async (q: string) => {
     if (!q.trim() || !serverUrl) return;
+    // 发起新搜索时终止上一路在途轮询，避免两条并行循环互相覆盖结果/loading 状态。
+    networkSearchControllerRef.current?.abort();
+    const controller = new AbortController();
+    networkSearchControllerRef.current = controller;
+    const seq = ++networkSearchSeqRef.current;
     setNetworkSearchMode(true);
     setNetworkSearchLoading(true);
     setNetworkSearchResults([]);
     try {
       const params = new URLSearchParams({ key: q.trim() });
-      const initRes = await request(`${serverUrl}/api/network/search?${params.toString()}`, { credentials: 'include' });
+      const initRes = await request(`${serverUrl}/api/network/search?${params.toString()}`, { credentials: 'include', signal: controller.signal });
       const initData = await readApiJson<{ err?: string; msg?: string; task_id?: string | number }>(initRes, '网络搜索任务解析失败。');
       const taskId = initData.task_id;
       if (taskId == null) throw new Error('网络搜索任务创建失败。');
-      // Poll until finished
-      let done = false;
-      let attempts = 0;
-      while (!done && attempts < 60) {
-        await new Promise((r) => setTimeout(r, 1000));
-        attempts++;
-        const pollRes = await request(`${serverUrl}/api/network/search/status?task_id=${taskId}`, { credentials: 'include' });
-        const pollData = await readApiJson<{ err?: string; msg?: string; results?: Array<{ source_id?: number; source_name?: string; books?: NetworkBook[]; items?: NetworkBook[] } | NetworkBook>; finished?: boolean }>(pollRes, '网络搜索结果解析失败。');
-        const partial: NetworkBook[] = (pollData.results || []).flatMap((r: { source_id?: number; source_name?: string; books?: NetworkBook[]; items?: NetworkBook[] } | NetworkBook) => {
-          if (Array.isArray(r)) return r;
-          if (typeof r === 'object' && r !== null) {
-            const asResult = r as { source_id?: number; source_name?: string; books?: NetworkBook[]; items?: NetworkBook[] };
-            const items = asResult.books || asResult.items || [];
-            // 保留来源书源 id/名称：后续点击进入网络书详情需要 source_id + book_url。
-            return items.map((b) => ({
-              ...b,
-              source_id: b.source_id ?? asResult.source_id,
-              source_name: b.source_name ?? asResult.source_name,
-            }));
-          }
-          return [];
-        });
-        setNetworkSearchResults(partial);
-        if (pollData.finished) done = true;
-      }
+      // 轮询在 abort（新搜索 / 卸载）时提前返回 null，不再继续打 status。
+      await pollNetworkSearch({
+        fetchStatus: async () => {
+          const pollRes = await request(`${serverUrl}/api/network/search/status?task_id=${taskId}`, { credentials: 'include', signal: controller.signal });
+          return readApiJson<NetworkSearchStatusResponse>(pollRes, '网络搜索结果解析失败。');
+        },
+        signal: controller.signal,
+        intervalMs: 1000,
+        maxAttempts: 60,
+        onPartial: (books) => {
+          if (seq !== networkSearchSeqRef.current) return;
+          setNetworkSearchResults(books);
+        },
+      });
     } catch (error) {
+      // 已取消（新搜索接管或组件卸载）时静默退出，不弹错误、不回写状态。
+      if (controller.signal.aborted) return;
+      if (seq !== networkSearchSeqRef.current) return;
       toast(getErrorMessage(error, '网络搜索失败。'));
-    } finally { setNetworkSearchLoading(false); }
+    } finally {
+      // 仅当仍是当前最新的一路时才收尾，避免旧的先结束时提前把 loading 置 false。
+      if (seq === networkSearchSeqRef.current && networkSearchControllerRef.current === controller) {
+        networkSearchControllerRef.current = null;
+        setNetworkSearchLoading(false);
+      }
+    }
   }, [serverUrl]);
+
+  // 返回浏览 / 切走在线 tab 时终止在途网络搜索轮询。
+  const cancelNetworkSearch = useCallback(() => {
+    networkSearchControllerRef.current?.abort();
+    networkSearchControllerRef.current = null;
+    networkSearchSeqRef.current++;
+    setNetworkSearchLoading(false);
+  }, []);
+
+  useEffect(() => {
+    if (activeTab !== 'online') cancelNetworkSearch();
+  }, [activeTab, cancelNetworkSearch]);
 
   const submitActiveSearch = () => {
     if (activeTab === 'local') {
@@ -302,7 +343,11 @@ export default function LibraryPage() {
   };
 
   const handleSearchKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'Enter') submitActiveSearch();
+    if (e.key === 'Enter') {
+      // 网络搜索进行中忽略 Enter，避免并行启动第二条轮询。
+      if (activeTab === 'online' && networkSearchLoading) return;
+      submitActiveSearch();
+    }
   };
 
   // ── Selection (local tab only — online books have no stable ids) ───────────
@@ -910,7 +955,7 @@ export default function LibraryPage() {
             <div className="flex-1 min-h-0 overflow-auto px-4 py-5 sm:px-6 md:px-8 md:py-8">
               <div className="flex items-center gap-3 mb-6">
                 <button
-                  onClick={() => { setNetworkSearchMode(false); setNetworkSearchQ(''); setNetworkSearchResults([]); }}
+                  onClick={() => { cancelNetworkSearch(); setNetworkSearchMode(false); setNetworkSearchQ(''); setNetworkSearchResults([]); }}
                   className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
                 >
                   <ArrowLeft className="w-4 h-4" />

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -58,6 +58,8 @@ function SearchContent() {
   const [batchMode, setBatchMode] = useState(false);
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number; bookId: string } | null>(null);
   const lastSelectedIdRef = useRef<string | null>(null);
+  // 请求序号：连续搜索 / URL 参数变化时，慢的旧响应不会覆盖新结果。
+  const searchSeqRef = useRef(0);
   const filteredResults = useMemo(
     () => results.filter((book) => hasFormat(book, activeFilter)),
     [activeFilter, results],
@@ -82,16 +84,19 @@ function SearchContent() {
   const handleSearch = async (q?: string) => {
     const term = (q || query).trim();
     if (!term) return;
+    const seq = ++searchSeqRef.current;
     setLoading(true);
     setSearched(true);
     try {
       const res = await request(`${serverUrl}/api/search?name=${encodeURIComponent(term)}`, { credentials: 'include' });
       const data = await readApiJson<{ err?: string; msg?: string; books?: BookItem[]; items?: BookItem[] }>(res, '搜索结果解析失败。');
+      if (seq !== searchSeqRef.current) return;
       if (data.err === 'ok') setResults(data.books || data.items || []);
     } catch (error) {
+      if (seq !== searchSeqRef.current) return;
       setResults([]);
       toast(getErrorMessage(error, '搜索失败，请检查服务器连接。'));
-    } finally { setLoading(false); }
+    } finally { if (seq === searchSeqRef.current) setLoading(false); }
   };
 
   // ── Selection ─────────────────────────────────────────────────────────────

--- a/src/lib/network-book-core.ts
+++ b/src/lib/network-book-core.ts
@@ -13,6 +13,54 @@ export function buildNetworkBookHref(sourceId: number, bookUrl: string): string 
   return `/network-book?${params.toString()}`;
 }
 
+/** 网络书（在线书库）通用字段。 */
+export interface NetworkBook {
+  title?: string;
+  name?: string;
+  author?: string;
+  authors?: string | Array<{ name: string }>;
+  book_url: string;
+  cover_url?: string;
+  img?: string;
+  thumb?: string;
+  /** 书籍来源的书源 id（搜索时按源分组，需要在扁平化时保留）。 */
+  source_id?: number;
+  source_name?: string;
+}
+
+/** 网络搜索状态查询（`/api/network/search/status`）的归一化响应。 */
+export interface NetworkSearchStatusResponse {
+  err?: string;
+  msg?: string;
+  results?: Array<
+    | { source_id?: number; source_name?: string; books?: NetworkBook[]; items?: NetworkBook[] }
+    | NetworkBook
+  >;
+  finished?: boolean;
+}
+
+/**
+ * 把按来源分组（或散装）的搜索结果扁平化为单本书列表，并在扁平化时保留
+ * 每本书所属的书源 id/名称（后续进入网络书详情需要 `source_id` + `book_url`）。
+ */
+export function flattenNetworkSearchResults(
+  results?: NetworkSearchStatusResponse['results'],
+): NetworkBook[] {
+  return (results || []).flatMap((r: { source_id?: number; source_name?: string; books?: NetworkBook[]; items?: NetworkBook[] } | NetworkBook) => {
+    if (Array.isArray(r)) return r;
+    if (typeof r === 'object' && r !== null) {
+      const asResult = r as { source_id?: number; source_name?: string; books?: NetworkBook[]; items?: NetworkBook[] };
+      const items = asResult.books || asResult.items || [];
+      return items.map((b) => ({
+        ...b,
+        source_id: b.source_id ?? asResult.source_id,
+        source_name: b.source_name ?? asResult.source_name,
+      }));
+    }
+    return [];
+  });
+}
+
 /** `/api/network/save/status` 的归一化响应（`readApiJson` 返回的原始字段）。 */
 export interface NetworkSaveStatusResponse {
   err?: string;
@@ -143,4 +191,44 @@ export async function pollNetworkSave({
     onUpdate?.(failed);
     return failed;
   }
+}
+
+/**
+ * 轮询网络搜索任务直到 `finished`，或达到 `maxAttempts` 上限，或收到取消信号。
+ *
+ * - 每次轮询返回的中间结果通过 `onPartial` 回调上报（由调用方决定是否回写 UI）。
+ * - `fetchStatus` 抛错会向上传播（调用方据此提示错误并停止，与原实现一致）。
+ * - `signal` 已中止时，在 sleep 前后与 `fetchStatus` 之后都会提前返回 `null`，
+ *   调用方据此判断是"取消"而不是"失败"，从而避免陈旧结果覆盖 / 后台空转。
+ */
+export async function pollNetworkSearch({
+  fetchStatus,
+  signal,
+  intervalMs = 1000,
+  maxAttempts = 60,
+  sleep = defaultSleep,
+  onPartial,
+}: {
+  fetchStatus: () => Promise<NetworkSearchStatusResponse | null>;
+  signal?: AbortSignal;
+  intervalMs?: number;
+  maxAttempts?: number;
+  sleep?: (ms: number) => Promise<void>;
+  onPartial?: (books: NetworkBook[]) => void;
+}): Promise<NetworkSearchStatusResponse | null> {
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    if (signal?.aborted) return null;
+    await sleep(intervalMs);
+    if (signal?.aborted) return null;
+
+    const status = await fetchStatus();
+    if (signal?.aborted) return null;
+    if (!status) continue;
+
+    const books = flattenNetworkSearchResults(status.results);
+    if (books.length > 0) onPartial?.(books);
+
+    if (status.finished) return status;
+  }
+  return null;
 }

--- a/tests/network-book-core.test.mjs
+++ b/tests/network-book-core.test.mjs
@@ -3,7 +3,9 @@ import assert from 'node:assert/strict';
 
 import {
   buildNetworkBookHref,
+  flattenNetworkSearchResults,
   pollNetworkSave,
+  pollNetworkSearch,
 } from '../src/lib/network-book-core.ts';
 
 function noopSleep() {
@@ -198,4 +200,125 @@ test('pollNetworkSave 超时上限后未知状态也返回 timeout（防无限�
     maxMisses: 100,
   });
   assert.deepEqual(state, { status: 'timeout' });
+});
+
+test('flattenNetworkSearchResults 保留分组的 source_id/source_name', () => {
+  const books = flattenNetworkSearchResults([
+    {
+      source_id: 1,
+      source_name: '源A',
+      books: [{ title: '书A', book_url: 'u1' }],
+    },
+    {
+      source_id: 2,
+      source_name: '源B',
+      items: [{ title: '书B', book_url: 'u2' }],
+    },
+  ]);
+  assert.deepEqual(books, [
+    { title: '书A', book_url: 'u1', source_id: 1, source_name: '源A' },
+    { title: '书B', book_url: 'u2', source_id: 2, source_name: '源B' },
+  ]);
+});
+
+test('flattenNetworkSearchResults 单本自带的 source_id 优先于分组', () => {
+  const books = flattenNetworkSearchResults([
+    {
+      source_id: 1,
+      source_name: '源A',
+      books: [{ title: '书A', book_url: 'u1', source_id: 9, source_name: '源X' }],
+    },
+  ]);
+  assert.deepEqual(books, [{ title: '书A', book_url: 'u1', source_id: 9, source_name: '源X' }]);
+});
+
+test('flattenNetworkSearchResults 空/散装条目安全返回空数组', () => {
+  assert.deepEqual(flattenNetworkSearchResults(undefined), []);
+  assert.deepEqual(flattenNetworkSearchResults([]), []);
+  assert.deepEqual(flattenNetworkSearchResults([{}, null, 'x']), []);
+});
+
+test('pollNetworkSearch 直到 finished 才返回，中间结果通过 onPartial 上报', async () => {
+  const partials = [];
+  const responses = [
+    { results: [{ source_id: 1, books: [{ title: 'A', book_url: 'u' }] }], finished: false },
+    { results: [{ source_id: 2, books: [{ title: 'B', book_url: 'v' }] }], finished: true },
+  ];
+  const result = await pollNetworkSearch({
+    fetchStatus: async () => responses.shift() ?? null,
+    sleep: noopSleep,
+    onPartial: (books) => partials.push(books),
+  });
+  assert.equal(result?.finished, true);
+  assert.equal(partials.length, 2);
+  assert.equal(partials[0][0].title, 'A');
+  assert.equal(partials[1][0].title, 'B');
+});
+
+test('pollNetworkSearch 达到 maxAttempts 未完成时返回 null', async () => {
+  const { calls, sleep } = makeFakeSleep();
+  const result = await pollNetworkSearch({
+    fetchStatus: async () => ({ results: [], finished: false }),
+    sleep,
+    maxAttempts: 3,
+  });
+  assert.equal(result, null);
+  assert.equal(calls(), 3);
+});
+
+test('pollNetworkSearch 已中止的 signal 立即返回 null', async () => {
+  const controller = new AbortController();
+  controller.abort();
+  let fetches = 0;
+  const result = await pollNetworkSearch({
+    fetchStatus: async () => {
+      fetches++;
+      return { results: [], finished: false };
+    },
+    signal: controller.signal,
+    sleep: noopSleep,
+  });
+  assert.equal(result, null);
+  assert.equal(fetches, 0);
+});
+
+test('pollNetworkSearch 轮询途中 abort 后不再回写 onPartial', async () => {
+  const controller = new AbortController();
+  const partials = [];
+  let fetches = 0;
+  let sleeps = 0;
+  const result = await pollNetworkSearch({
+    fetchStatus: async () => {
+      fetches++;
+      if (fetches === 1) {
+        return { results: [{ source_id: 1, books: [{ title: 'A', book_url: 'u' }] }], finished: false };
+      }
+      return { results: [{ source_id: 2, books: [{ title: 'B', book_url: 'v' }] }], finished: true };
+    },
+    signal: controller.signal,
+    sleep: async () => {
+      sleeps++;
+      if (sleeps === 2) controller.abort();
+    },
+    onPartial: (books) => partials.push(books),
+  });
+  // 第一次轮询已回写 partial A；第二次 sleep 中 abort → 立即返回 null，不再发起第二次轮询。
+  assert.equal(result, null);
+  assert.equal(fetches, 1);
+  assert.equal(sleeps, 2);
+  assert.equal(partials.length, 1);
+  assert.equal(partials[0][0].title, 'A');
+});
+
+test('pollNetworkSearch 轮询错误向上传播，不吞异常', async () => {
+  await assert.rejects(
+    () => pollNetworkSearch({
+      fetchStatus: async () => {
+        throw new Error('network down');
+      },
+      sleep: noopSleep,
+      maxAttempts: 2,
+    }),
+    (error) => error instanceof Error && error.message === 'network down',
+  );
 });


### PR DESCRIPTION
修复 HOU-21（M1/M2）：书库/搜索/详情请求防旧响应覆盖、网络搜索轮询可取消/Enter 去重。详见 issue HOU-21。验证：pnpm test（含新增 123 行单测）通过、lint 0 error、typecheck 通过。