### PR TITLE
fix: HOU-22 会话/UI/交互修复（M3/M4/M5/L5）

### DIFF
--- a/src/app/detail/page.tsx
+++ b/src/app/detail/page.tsx
@@ -4,7 +4,7 @@ import { Suspense, useState, useEffect, useRef } from 'react';
 import { useSearchParams, useRouter } from 'next/navigation';
 import { ArrowLeft, ChevronRight, Star, FileText, HardDrive, Calendar, BookOpen, Building2, Barcode, Tags, Users, LibraryBig, FileBadge2, Bookmark, Trash2 } from 'lucide-react';
 import { DesktopLayout } from '@/components/layout/DesktopLayout';
-import { getErrorMessage, readApiJson, request } from '@/lib/api';
+import { getErrorMessage, MokeApiError, readApiJson, request } from '@/lib/api';
 import { deleteOfflineBook, getOfflineBook } from '@/lib/offline-books';
 import {
   beginOfflineDownload,
@@ -125,7 +125,11 @@ function DetailContent() {
     setLoading(true);
     try {
       const res = await request(`${serverUrl}/api/book/${id}`, { credentials: 'include', signal: controller.signal });
-      const data = await readApiJson<{ err?: string; msg?: string; book?: BookDetail; data?: BookDetail }>(res, '书籍详情解析失败。');
+      const data = await readApiJson<{ err?: string; msg?: string; book?: BookDetail; data?: BookDetail }>(res, '书籍详情解析失败。', ['ok', 'user.need_login']);
+      if (data.err === 'user.need_login') {
+        router.push('/login');
+        return;
+      }
       if (controller.signal.aborted || seq !== loadBookSeqRef.current) return;
       const nextBook = data.book || data.data;
       if (data.err === 'ok' && nextBook) {
@@ -140,6 +144,10 @@ function DetailContent() {
     } catch (error) {
       if (controller.signal.aborted || seq !== loadBookSeqRef.current) return;
       setBook(null);
+      if (error instanceof MokeApiError && error.code === 'user.need_login') {
+        router.push('/login');
+        return;
+      }
       setMessage(getErrorMessage(error, '书籍详情加载失败，请检查服务器连接。'));
     } finally {
       if (!controller.signal.aborted && seq === loadBookSeqRef.current) setLoading(false);
@@ -153,6 +161,10 @@ function DetailContent() {
       });
       const data = await res.json();
       if (seq !== loadBookSeqRef.current) return;
+      if (data.err === 'user.need_login') {
+        router.push('/login');
+        return;
+      }
       if (data.err === 'ok') {
         setInShelf(Boolean(data.wants));
       }

--- a/src/app/library/page.tsx
+++ b/src/app/library/page.tsx
@@ -22,6 +22,7 @@ import {
   downloadAndSaveOfflineBook,
   endOfflineDownload,
 } from '@/lib/offline-download';
+import { useLongPressRegistry } from '@/lib/long-press';
 import { useToast } from '@/lib/toast';
 import { BookOpen, Check, Download, ListChecks } from 'lucide-react';
 
@@ -102,6 +103,7 @@ export default function LibraryPage() {
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number; bookId: string } | null>(null);
   const [networkContextMenu, setNetworkContextMenu] = useState<{ x: number; y: number; book: NetworkBook } | null>(null);
   const lastSelectedIdRef = useRef<string | null>(null);
+  const { makeHandlers: makeLongPressHandlers } = useLongPressRegistry();
 
   const networkSaveAbortRef = useRef<Set<AbortController>>(new Set());
   const [networkSavingKeys, setNetworkSavingKeys] = useState<Set<string>>(new Set());
@@ -770,10 +772,6 @@ export default function LibraryPage() {
                   const selected = selectedIds.has(bookId);
                   // Build interaction handlers: batch mode toggles selection; otherwise
                   // right-click / long-press opens the context menu.
-                  const pressTimerRef = { current: null as number | null };
-                  const didLongPressRef = { current: false };
-                  let touchX = 0;
-                  let touchY = 0;
                   const cardHandlers = batchMode
                     ? {
                         onClick: (e: React.MouseEvent) => {
@@ -786,32 +784,7 @@ export default function LibraryPage() {
                           toggleSelect(bookId, { shiftKey: e.shiftKey, metaKey: e.metaKey, ctrlKey: e.ctrlKey });
                         },
                       }
-                    : {
-                        onContextMenu: (e: React.MouseEvent) => {
-                          e.preventDefault();
-                          openContextMenu(bookId, e.clientX, e.clientY);
-                        },
-                        onTouchStart: (e: React.TouchEvent) => {
-                          didLongPressRef.current = false;
-                          const t = e.touches[0];
-                          touchX = t?.clientX ?? 0;
-                          touchY = t?.clientY ?? 0;
-                          pressTimerRef.current = window.setTimeout(() => {
-                            didLongPressRef.current = true;
-                            if (typeof navigator !== 'undefined' && navigator.vibrate) navigator.vibrate(50);
-                            openContextMenu(bookId, touchX, touchY);
-                          }, 500);
-                        },
-                        onTouchEnd: () => {
-                          if (pressTimerRef.current) { clearTimeout(pressTimerRef.current); pressTimerRef.current = null; }
-                        },
-                        onTouchMove: () => {
-                          if (pressTimerRef.current) { clearTimeout(pressTimerRef.current); pressTimerRef.current = null; }
-                        },
-                        onClick: (e: React.MouseEvent) => {
-                          if (didLongPressRef.current) { e.preventDefault(); e.stopPropagation(); }
-                        },
-                      };
+                    : makeLongPressHandlers(bookId, openContextMenu);
                   return viewMode === 'grid' ? (
                     <Link key={bookId} href={`/detail?id=${bookId}`} {...cardHandlers} className={`book-card-motion group relative flex flex-col gap-3 rounded-[22px] p-2.5 transition-all duration-300 hover:bg-white/65 hover:shadow-[0_18px_45px_-30px_rgba(74,57,35,0.65)] ${selected ? 'ring-2 ring-primary/60 bg-white/70' : batchMode ? 'cursor-pointer' : ''}`}>
                       <div className="book-cover-motion relative w-full overflow-hidden rounded-[18px] bg-white book-cover-shadow ring-1 ring-black/5 transition-all duration-300 ease-out group-hover:-translate-y-1.5" style={{ aspectRatio: '2/3' }}>

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -3,10 +3,10 @@
 import { Suspense, useState, useEffect, useMemo, useRef } from 'react';
 import { useServerStore } from '@/lib/store/server';
 import Link from 'next/link';
-import { useSearchParams } from 'next/navigation';
+import { useSearchParams, useRouter } from 'next/navigation';
 import { Search } from 'lucide-react';
 import { DesktopLayout } from '@/components/layout/DesktopLayout';
-import { getErrorMessage, readApiJson, request } from '@/lib/api';
+import { getErrorMessage, MokeApiError, readApiJson, request } from '@/lib/api';
 import { cn, resolveServerAssetUrl } from '@/lib/utils';
 import { AuthImage } from '@/components/ui/AuthImage';
 import { BookTable, type BookRow } from '@/components/book/BookTable';
@@ -20,6 +20,7 @@ import {
   endOfflineDownload,
 } from '@/lib/offline-download';
 import { useToast } from '@/lib/toast';
+import { useLongPressRegistry } from '@/lib/long-press';
 import { Check, Download, ListChecks } from 'lucide-react';
 
 interface BookItem {
@@ -44,6 +45,7 @@ function hasFormat(book: BookItem, filter: string) {
 
 function SearchContent() {
   const searchParams = useSearchParams();
+  const router = useRouter();
   const { serverUrl } = useServerStore();
   const isTauriApp = process.env.NEXT_PUBLIC_APP_PLATFORM === 'tauri';
   const [query, setQuery] = useState(searchParams.get('q') || '');
@@ -60,6 +62,7 @@ function SearchContent() {
   const lastSelectedIdRef = useRef<string | null>(null);
   // 请求序号：连续搜索 / URL 参数变化时，慢的旧响应不会覆盖新结果。
   const searchSeqRef = useRef(0);
+  const { makeHandlers: makeLongPressHandlers } = useLongPressRegistry();
   const filteredResults = useMemo(
     () => results.filter((book) => hasFormat(book, activeFilter)),
     [activeFilter, results],
@@ -89,12 +92,20 @@ function SearchContent() {
     setSearched(true);
     try {
       const res = await request(`${serverUrl}/api/search?name=${encodeURIComponent(term)}`, { credentials: 'include' });
-      const data = await readApiJson<{ err?: string; msg?: string; books?: BookItem[]; items?: BookItem[] }>(res, '搜索结果解析失败。');
+      const data = await readApiJson<{ err?: string; msg?: string; books?: BookItem[]; items?: BookItem[] }>(res, '搜索结果解析失败。', ['ok', 'user.need_login']);
+      if (data.err === 'user.need_login') {
+        router.push('/login');
+        return;
+      }
       if (seq !== searchSeqRef.current) return;
       if (data.err === 'ok') setResults(data.books || data.items || []);
     } catch (error) {
       if (seq !== searchSeqRef.current) return;
       setResults([]);
+      if (error instanceof MokeApiError && error.code === 'user.need_login') {
+        router.push('/login');
+        return;
+      }
       toast(getErrorMessage(error, '搜索失败，请检查服务器连接。'));
     } finally { if (seq === searchSeqRef.current) setLoading(false); }
   };
@@ -148,7 +159,7 @@ function SearchContent() {
   };
 
   // ── Single-item actions (from right-click / long-press menu) ────────────
-  const addToShelf = async (id: string) => {
+  const setShelf = async (id: string, inShelf: boolean) => {
     const book = results.find((b) => String(b.id) === id);
     if (!book) return;
     try {
@@ -156,13 +167,23 @@ function SearchContent() {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',
-        body: JSON.stringify({ shelf: true }),
+        body: JSON.stringify({ shelf: inShelf }),
       });
       const data = await res.json();
-      if (data.err === 'ok') toast(`《${book.title}》已加入书架`);
-      else toast(data.msg || '加入失败');
+      if (data.err === 'user.need_login') {
+        router.push('/login');
+        return;
+      }
+      if (data.err === 'ok') {
+        setResults((prev) => prev.map((b) =>
+          String(b.id) === id ? { ...b, state: { ...(b as any).state, wants: inShelf } } : b,
+        ));
+        toast(inShelf ? `《${book.title}》已加入书架` : `《${book.title}》已移出书架`);
+      } else {
+        toast(data.msg || (inShelf ? '加入失败' : '移出失败'));
+      }
     } catch {
-      toast('加入失败，请检查网络');
+      toast(inShelf ? '加入失败，请检查网络' : '移出失败，请检查网络');
     }
   };
 
@@ -196,7 +217,7 @@ function SearchContent() {
         key: inShelf ? 'remove' : 'add',
         label: inShelf ? '移出书架' : '加入书架',
         icon: <Check className="w-3.5 h-3.5" />,
-        onClick: () => addToShelf(String(book.id)),
+        onClick: () => setShelf(String(book.id), !inShelf),
       },
       ...(isTauriApp
         ? [{
@@ -216,8 +237,22 @@ function SearchContent() {
     ];
   };
 
-  const openContextMenu = (bookId: string, x: number, y: number) => {
+  const openContextMenu = async (bookId: string, x: number, y: number) => {
     setContextMenu({ x, y, bookId });
+    // 搜索结果不带 state，菜单打开时回查 /readstate 刷新真实书架状态（L5）。
+    try {
+      const res = await request(`${serverUrl}/api/book/${bookId}/readstate`, { credentials: 'include' });
+      const data = await res.json();
+      if (data.err === 'ok') {
+        setResults((prev) => prev.map((b) =>
+          String(b.id) === bookId ? { ...b, state: { ...(b as any).state, wants: Boolean(data.wants) } } : b,
+        ));
+      } else if (data.err === 'user.need_login') {
+        router.push('/login');
+      }
+    } catch {
+      // 回查失败时保持当前展示状态，菜单仍可打开
+    }
   };
 
   useEffect(() => {
@@ -233,7 +268,7 @@ function SearchContent() {
     let fail = 0;
 
     if (action === 'add-shelf') {
-      const results = await Promise.allSettled(
+      const settled = await Promise.allSettled(
         ids.map((id) => request(`${serverUrl}/api/book/${id}/shelf`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
@@ -241,9 +276,17 @@ function SearchContent() {
           body: JSON.stringify({ shelf: true }),
         }).then((r) => r.json())),
       );
-      for (const r of results) {
-        if (r.status === 'fulfilled' && r.value?.err === 'ok') ok++;
+      const succeeded: string[] = [];
+      for (let i = 0; i < ids.length; i++) {
+        const r = settled[i];
+        if (r.status === 'fulfilled' && r.value?.err === 'ok') { ok++; succeeded.push(ids[i]); }
         else fail++;
+      }
+      if (succeeded.length > 0) {
+        const done = new Set(succeeded);
+        setResults((prev) => prev.map((b) =>
+          done.has(String(b.id)) ? { ...b, state: { ...(b as any).state, wants: true } } : b,
+        ));
       }
       exitBatchMode();
       if (ok > 0) toast(`已加入 ${ok} 本到书架`);
@@ -356,10 +399,6 @@ function SearchContent() {
                   const coverUrl = resolveServerAssetUrl(serverUrl, book.img || book.thumb);
                   const authorName = book.author || book.authors?.[0]?.name || '';
                   const selected = selectedIds.has(bookId);
-                  const pressTimerRef = { current: null as number | null };
-                  const didLongPressRef = { current: false };
-                  let touchX = 0;
-                  let touchY = 0;
                   const cardHandlers = batchMode
                     ? {
                         onClick: (e: React.MouseEvent) => {
@@ -372,32 +411,7 @@ function SearchContent() {
                           toggleSelect(bookId, { shiftKey: e.shiftKey, metaKey: e.metaKey, ctrlKey: e.ctrlKey });
                         },
                       }
-                    : {
-                        onContextMenu: (e: React.MouseEvent) => {
-                          e.preventDefault();
-                          openContextMenu(bookId, e.clientX, e.clientY);
-                        },
-                        onTouchStart: (e: React.TouchEvent) => {
-                          didLongPressRef.current = false;
-                          const t = e.touches[0];
-                          touchX = t?.clientX ?? 0;
-                          touchY = t?.clientY ?? 0;
-                          pressTimerRef.current = window.setTimeout(() => {
-                            didLongPressRef.current = true;
-                            if (typeof navigator !== 'undefined' && navigator.vibrate) navigator.vibrate(50);
-                            openContextMenu(bookId, touchX, touchY);
-                          }, 500);
-                        },
-                        onTouchEnd: () => {
-                          if (pressTimerRef.current) { clearTimeout(pressTimerRef.current); pressTimerRef.current = null; }
-                        },
-                        onTouchMove: () => {
-                          if (pressTimerRef.current) { clearTimeout(pressTimerRef.current); pressTimerRef.current = null; }
-                        },
-                        onClick: (e: React.MouseEvent) => {
-                          if (didLongPressRef.current) { e.preventDefault(); e.stopPropagation(); }
-                        },
-                      };
+                    : makeLongPressHandlers(bookId, openContextMenu);
 
                   if (viewMode === 'grid') {
                   return (

--- a/src/app/shelf/page.tsx
+++ b/src/app/shelf/page.tsx
@@ -20,6 +20,7 @@ import {
   endOfflineDownload,
 } from '@/lib/offline-download';
 import { useToast } from '@/lib/toast';
+import { useLongPressRegistry } from '@/lib/long-press';
 import { Check, Download, ListChecks } from 'lucide-react';
 
 interface BookItem {
@@ -61,6 +62,7 @@ function BookCard({
   const authorName = book.author || book.authors?.[0]?.name || '';
   const bookId = String(book.id);
   const coverUrl = resolveServerAssetUrl(serverUrl, book.img || book.thumb);
+  const { makeHandlers: makeLongPressHandlers } = useLongPressRegistry();
   const colors = [
     'from-emerald-800/20 via-teal-700/15 to-cyan-700/20',
     'from-amber-700/20 via-yellow-600/15 to-orange-700/20',
@@ -91,36 +93,7 @@ function BookCard({
       };
     }
     if (onContextAction) {
-      let pressTimer: number | null = null;
-      let didLongPress = false;
-      let touchX = 0;
-      let touchY = 0;
-      return {
-        onContextMenu: (e: React.MouseEvent) => {
-          e.preventDefault();
-          onContextAction(bookId, e.clientX, e.clientY);
-        },
-        onTouchStart: (e: React.TouchEvent) => {
-          didLongPress = false;
-          const t = e.touches[0];
-          touchX = t?.clientX ?? 0;
-          touchY = t?.clientY ?? 0;
-          pressTimer = window.setTimeout(() => {
-            didLongPress = true;
-            if (typeof navigator !== 'undefined' && navigator.vibrate) navigator.vibrate(50);
-            onContextAction(bookId, touchX, touchY);
-          }, 500);
-        },
-        onTouchEnd: () => {
-          if (pressTimer) { clearTimeout(pressTimer); pressTimer = null; }
-        },
-        onTouchMove: () => {
-          if (pressTimer) { clearTimeout(pressTimer); pressTimer = null; }
-        },
-        onClick: (e: React.MouseEvent) => {
-          if (didLongPress) { e.preventDefault(); e.stopPropagation(); }
-        },
-      };
+      return makeLongPressHandlers(bookId, onContextAction);
     }
     return {};
   }

--- a/src/components/book/BookTable.tsx
+++ b/src/components/book/BookTable.tsx
@@ -4,6 +4,7 @@ import { useMemo, useState } from 'react';
 import Link from 'next/link';
 import { ArrowDown, ArrowUp, ArrowUpDown, Bookmark, Check, Download } from 'lucide-react';
 import { useServerStore } from '@/lib/store/server';
+import { useLongPressRegistry } from '@/lib/long-press';
 import { resolveServerAssetUrl } from '@/lib/utils';
 import { AuthImage } from '@/components/ui/AuthImage';
 
@@ -207,6 +208,7 @@ export function BookTable({
 }: BookTableProps) {
   const { serverUrl } = useServerStore();
   const [sort, setSort] = useState<SortState | null>(null);
+  const { makeHandlers: makeLongPressHandlers } = useLongPressRegistry();
   const selectable = Boolean(batchMode && selectedIds && onToggleSelect);
   const contextual = Boolean(!batchMode && onContextAction);
 
@@ -242,36 +244,7 @@ export function BookTable({
       };
     }
     if (contextual) {
-      let pressTimer: number | null = null;
-      let didLongPress = false;
-      let touchX = 0;
-      let touchY = 0;
-      return {
-        onContextMenu: (e: React.MouseEvent) => {
-          e.preventDefault();
-          onContextAction!(id, e.clientX, e.clientY);
-        },
-        onTouchStart: (e: React.TouchEvent) => {
-          didLongPress = false;
-          const t = e.touches[0];
-          touchX = t?.clientX ?? 0;
-          touchY = t?.clientY ?? 0;
-          pressTimer = window.setTimeout(() => {
-            didLongPress = true;
-            if (typeof navigator !== 'undefined' && navigator.vibrate) navigator.vibrate(50);
-            onContextAction!(id, touchX, touchY);
-          }, 500);
-        },
-        onTouchEnd: () => {
-          if (pressTimer) { clearTimeout(pressTimer); pressTimer = null; }
-        },
-        onTouchMove: () => {
-          if (pressTimer) { clearTimeout(pressTimer); pressTimer = null; }
-        },
-        onClick: (e: React.MouseEvent) => {
-          if (didLongPress) { e.preventDefault(); e.stopPropagation(); }
-        },
-      };
+      return makeLongPressHandlers(id, onContextAction!);
     }
     return {};
   }

--- a/src/lib/long-press.ts
+++ b/src/lib/long-press.ts
@@ -1,0 +1,126 @@
+import { useEffect, useState } from 'react';
+import type * as React from 'react';
+
+export type SetTimerFn = (fn: () => void, delay: number) => ReturnType<typeof setTimeout>;
+export type ClearTimerFn = (id: ReturnType<typeof setTimeout>) => void;
+
+export const LONG_PRESS_MS = 500;
+
+/**
+ * 单个卡片/行的触摸长按状态机。
+ *
+ * 关键点：状态放在实例字段里（didLongPress/pressTimer），而不是渲染期闭包变量。
+ * 渲染期闭包变量在长按触发菜单、setState 引起重渲染后会被新闭包替换，导致
+ * 手指抬起时 click 落入新闭包、防护失效（长按后仍跳转详情 / 切换选中）。
+ * 实例字段跨渲染保持，click 防护始终生效。
+ */
+export class LongPressController {
+  /** 最近一次长按是否已触发（供随后的 click 防护读取）。 */
+  didLongPress = false;
+  /** 由调用方在每个渲染周期刷新，避免捕获过期的 onContextAction。 */
+  onLongPress: (x: number, y: number) => void = () => {};
+
+  private pressTimer: ReturnType<typeof setTimeout> | null = null;
+  private x = 0;
+  private y = 0;
+  private readonly setTimer: SetTimerFn;
+  private readonly clearTimer: ClearTimerFn;
+
+  constructor(
+    onLongPress?: (x: number, y: number) => void,
+    setTimer?: SetTimerFn,
+    clearTimer?: ClearTimerFn,
+  ) {
+    if (onLongPress) this.onLongPress = onLongPress;
+    this.setTimer = setTimer ?? ((fn, delay) => setTimeout(fn, delay));
+    this.clearTimer = clearTimer ?? ((id) => clearTimeout(id));
+  }
+
+  start(x: number, y: number): void {
+    this.didLongPress = false;
+    this.x = x;
+    this.y = y;
+    this.cancel();
+    this.pressTimer = this.setTimer(() => {
+      this.pressTimer = null;
+      this.didLongPress = true;
+      if (typeof navigator !== 'undefined' && navigator.vibrate) navigator.vibrate(50);
+      this.onLongPress(this.x, this.y);
+    }, LONG_PRESS_MS);
+  }
+
+  cancel(): void {
+    if (this.pressTimer !== null) {
+      this.clearTimer(this.pressTimer);
+      this.pressTimer = null;
+    }
+  }
+
+  /** 长按触发后，随后的 click 应被吞掉；返回 true 表示本次 click 由长按产生。 */
+  consumeClick(): boolean {
+    if (!this.didLongPress) return false;
+    this.didLongPress = false;
+    return true;
+  }
+}
+
+export interface LongPressHandlers {
+  onContextMenu: (e: React.MouseEvent) => void;
+  onTouchStart: (e: React.TouchEvent) => void;
+  onTouchEnd: () => void;
+  onTouchMove: () => void;
+  onClick: (e: React.MouseEvent) => void;
+}
+
+export interface LongPressRegistry {
+  /** 为某个 bookId 生成事件处理器；跨渲染复用同一份长按状态。 */
+  makeHandlers: (id: string, onContextAction: (id: string, x: number, y: number) => void) => LongPressHandlers;
+}
+
+/**
+ * 统一的长按菜单 hook。按 bookId 保存 LongPressController，状态跨渲染保持，
+ * 长按打开菜单引起的重渲染不会丢失 didLongPress 防护。组件卸载时清理计时器。
+ */
+export function useLongPressRegistry(): LongPressRegistry {
+  const [states] = useState(() => new Map<string, LongPressController>());
+
+  useEffect(() => {
+    return () => {
+      for (const controller of states.values()) controller.cancel();
+    };
+  }, [states]);
+
+  const makeHandlers = (
+    id: string,
+    onContextAction: (id: string, x: number, y: number) => void,
+  ): LongPressHandlers => {
+    let controller = states.get(id);
+    if (!controller) {
+      controller = new LongPressController();
+      states.set(id, controller);
+    }
+    // 每次渲染刷新回调，避免捕获过期闭包
+    controller.onLongPress = (x, y) => onContextAction(id, x, y);
+
+    return {
+      onContextMenu: (e: React.MouseEvent) => {
+        e.preventDefault();
+        onContextAction(id, e.clientX, e.clientY);
+      },
+      onTouchStart: (e: React.TouchEvent) => {
+        const t = e.touches[0];
+        controller.start(t?.clientX ?? 0, t?.clientY ?? 0);
+      },
+      onTouchEnd: () => controller.cancel(),
+      onTouchMove: () => controller.cancel(),
+      onClick: (e: React.MouseEvent) => {
+        if (controller.consumeClick()) {
+          e.preventDefault();
+          e.stopPropagation();
+        }
+      },
+    };
+  };
+
+  return { makeHandlers };
+}

--- a/src/lib/toast.ts
+++ b/src/lib/toast.ts
@@ -10,7 +10,7 @@ export const useToast = create<{
 }>((set) => ({
   message: null,
   type: 'info',
-  show: (msg, type = 'error') => {
+  show: (msg, type = 'info') => {
     if (timer) clearTimeout(timer);
     set({ message: msg, type });
     timer = setTimeout(() => set({ message: null }), 5000);

--- a/tests/api-core.test.mjs
+++ b/tests/api-core.test.mjs
@@ -57,6 +57,21 @@ test('API 的无效 JSON 和业务错误会转换成统一错误', async () => {
   );
 });
 
+test('need_login 未列入 okErrs 时抛 MokeApiError（会话失效场景）', async () => {
+  await assert.rejects(
+    () => readApiJson(
+      new Response(JSON.stringify({ err: 'user.need_login', msg: '请先登录' }), { status: 200 }),
+      '响应无效',
+    ),
+    (error) => {
+      assert.ok(error instanceof MokeApiError);
+      assert.equal(error.code, 'user.need_login');
+      assert.equal(error.message, '请先登录');
+      return true;
+    },
+  );
+});
+
 test('错误提示映射覆盖地址丢失、HTTP 错误和未知错误', () => {
   assert.equal(getErrorMessage(new Error('server.url.missing')), '服务器地址丢失，请重新连接书库。');
   assert.equal(getErrorMessage(new Error('http.502')), '服务器返回 502。');

--- a/tests/long-press.test.mjs
+++ b/tests/long-press.test.mjs
@@ -1,0 +1,82 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { LongPressController, LONG_PRESS_MS } from '../src/lib/long-press.ts';
+
+test('长按达到阈值触发菜单回调，并吞掉随后的 click', (t) => {
+  t.mock.timers.enable({ apis: ['setTimeout'] });
+  const opened = [];
+  const controller = new LongPressController((x, y) => opened.push([x, y]));
+
+  controller.start(10, 20);
+  assert.equal(controller.didLongPress, false);
+
+  t.mock.timers.tick(LONG_PRESS_MS);
+  assert.equal(controller.didLongPress, true);
+  assert.deepEqual(opened, [[10, 20]]);
+
+  // 长按后手指抬起触发的 click 应被吞掉
+  assert.equal(controller.consumeClick(), true);
+  assert.equal(controller.consumeClick(), false);
+
+  t.mock.timers.reset();
+});
+
+test('跨渲染复用同一 controller：长按防护在重渲染后仍有效', (t) => {
+  t.mock.timers.enable({ apis: ['setTimeout'] });
+  const controller = new LongPressController();
+  controller.start(0, 0);
+  t.mock.timers.tick(LONG_PRESS_MS);
+
+  // 模拟长按开菜单触发 setState 重渲染后生成的新闭包：
+  // 新闭包读取的是同一个 controller，didLongPress 仍为 true。
+  const newRenderOnClick = () => controller.consumeClick();
+  assert.equal(newRenderOnClick(), true);
+
+  t.mock.timers.reset();
+});
+
+test('短按（touchEnd 提前取消）不会触发菜单，click 不被吞', (t) => {
+  t.mock.timers.enable({ apis: ['setTimeout'] });
+  let opened = 0;
+  const controller = new LongPressController(() => opened++);
+
+  controller.start(0, 0);
+  controller.cancel();
+  t.mock.timers.tick(LONG_PRESS_MS + 100);
+
+  assert.equal(opened, 0);
+  assert.equal(controller.didLongPress, false);
+  assert.equal(controller.consumeClick(), false);
+
+  t.mock.timers.reset();
+});
+
+test('滑动（touchMove 取消）会取消长按计时', (t) => {
+  t.mock.timers.enable({ apis: ['setTimeout'] });
+  let opened = 0;
+  const controller = new LongPressController(() => opened++);
+
+  controller.start(0, 0);
+  controller.cancel();
+  t.mock.timers.tick(LONG_PRESS_MS);
+  assert.equal(opened, 0);
+
+  t.mock.timers.reset();
+});
+
+test('短按后立即长按：上一次的计时器不会残留误触', (t) => {
+  t.mock.timers.enable({ apis: ['setTimeout'] });
+  let opened = 0;
+  const controller = new LongPressController(() => opened++);
+
+  controller.start(0, 0);
+  controller.cancel();
+  controller.start(1, 1);
+  t.mock.timers.tick(LONG_PRESS_MS - 100);
+  assert.equal(opened, 0);
+  t.mock.timers.tick(200);
+  assert.equal(opened, 1);
+
+  t.mock.timers.reset();
+});

--- a/tests/toast.test.mjs
+++ b/tests/toast.test.mjs
@@ -1,0 +1,27 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { useToast } from '../src/lib/toast.ts';
+
+test('toast 默认类型是 info，成功提示不再走红色 error 样式', () => {
+  useToast.setState({ message: null, type: 'info' });
+  useToast.getState().show('《书》已加入书架');
+  assert.equal(useToast.getState().message, '《书》已加入书架');
+  assert.equal(useToast.getState().type, 'info');
+});
+
+test('toast 显式传入 error 时仍使用错误类型', () => {
+  useToast.setState({ message: null, type: 'info' });
+  useToast.getState().show('下载失败', 'error');
+  assert.equal(useToast.getState().message, '下载失败');
+  assert.equal(useToast.getState().type, 'error');
+});
+
+test('toast 新消息会覆盖旧消息并重置类型', () => {
+  useToast.setState({ message: null, type: 'info' });
+  useToast.getState().show('先失败', 'error');
+  assert.equal(useToast.getState().type, 'error');
+  useToast.getState().show('后成功');
+  assert.equal(useToast.getState().type, 'info');
+  assert.equal(useToast.getState().message, '后成功');
+});


### PR DESCRIPTION
修复 HOU-22（M3/M4/M5/L5）：need_login 统一跳登录、toast 默认 info、长按防护跨渲染保持、搜索书架状态回查。详见 issue HOU-22。验证：pnpm test 34 通过、lint 0 error、typecheck 通过。