### PR TITLE
fix: HOU-25 连接层命令通道与生命周期（H20-M3/M4/L2/L4/L5）

### DIFF
--- a/packages/moke-ext/DEVELOPMENT.md
+++ b/packages/moke-ext/DEVELOPMENT.md
@@ -79,17 +79,77 @@ X-Extension-Token: {token}    // 启用拓展时由主程序分配
 
 | 端点 | 方法 | 说明 |
 |---|---|---|
-| `/api/v1/info` | GET | 宿主和服务器信息 |
+| `/api/v1/info` | GET | 宿主和服务器信息（含运行时形态与阅读器窗口） |
 | `/api/v1/books` | POST | 查询书库（分页/搜索） |
 | `/api/v1/books/{id}` | GET | 书籍详情 |
 | `/api/v1/user` | GET | 当前用户 |
 | `/api/v1/server` | GET | 服务器信息 |
 | `/api/v1/reader/windows` | GET | 活跃的阅读器窗口列表 |
 | `/api/v1/reader/{label}/state` | GET | 阅读器状态 |
-| `/api/v1/reader/{label}/command` | POST | 向阅读器发指令 |
+| `/api/v1/reader/{label}/command` | POST | 向阅读器发指令（可阻塞等待回执） |
 | `/api/v1/extension/sidebar/add` | POST | 动态添加侧边栏 |
 | `/api/v1/extension/page/register` | POST | 注册自定义页面 |
 | `/api/v1/extension/storage/{key}` | GET/PUT/DELETE | 持久化存储 |
+
+### 阅读器窗口寻址
+
+- `/api/v1/info` 的 `runtime` 字段返回 `multi_window`（桌面多窗口）或 `single_webview`（OHOS / Android / iOS 单 WebView）。
+- 多窗口形态下，阅读器窗口 label 以 `reader-` 开头；单 WebView 形态下阅读器运行在 `main` 窗口中，`/api/v1/reader/windows` 与 `reader_windows` 会把 `main` 一并列出，直接用 `main` 作为 `{label}` 寻址即可。
+
+### 命令与回执（request_id 关联）
+
+`POST /api/v1/reader/{label}/command` 的 body 是透传给阅读器的命令对象。推荐带上 `request_id`，并**订阅 WS 的 `reader:command:result` 事件**接收回执（未订阅则收不到回执，属正常订阅过滤）：
+
+```json
+{
+  "request_id": "ext-abc-123",
+  "command": "go_to_fraction",
+  "fraction": 0.42
+}
+```
+
+响应：
+
+```json
+{ "sent": true, "request_id": "ext-abc-123" }
+```
+
+若需要**同步拿到执行结果**，可在 body 里加 `wait_ms`（毫秒）启用阻塞等待。服务端会在超时内等待 `reader:command:result` 回执并按 `request_id` 关联返回：
+
+```json
+{
+  "request_id": "ext-abc-123",
+  "command": "get_position",
+  "wait_ms": 5000
+}
+```
+
+成功时返回阅读器回执（含 `result` 或 `error`），超时返回 `timed_out: true`：
+
+```json
+{ "sent": true, "request_id": "ext-abc-123", "result": { "view_key": "...", "progress": { "page": 42, "fraction": 0.42 } } }
+```
+
+```json
+{ "sent": true, "request_id": "ext-abc-123", "timed_out": true }
+```
+
+阅读器侧的命令回执示例（WS 事件 `reader:command:result`）：
+
+```json
+{
+  "event": "reader:command:result",
+  "timestamp": 1719777601000,
+  "data": {
+    "request_id": "ext-abc-123",
+    "command": "go_to_fraction",
+    "success": true,
+    "result": { "fraction": 0.42 }
+  }
+}
+```
+
+失败时 `success` 为 `false`，并带 `error` 字段说明原因（如 `No active reader view`）。
 
 ### WebSocket 事件 — `ws://127.0.0.1:19556`
 
@@ -129,6 +189,7 @@ X-Extension-Token: {token}    // 启用拓展时由主程序分配
 | `reader:page:changed` | 翻页 |
 | `reader:highlight:created` | 创建划线 |
 | `reader:annotation:created` | 创建笔记 |
+| `reader:command:result` | `/command` 命令的执行回执（`data.request_id` 关联请求） |
 
 ## 三种拓展类型
 

--- a/src-tauri/src/extensions/api_server.rs
+++ b/src-tauri/src/extensions/api_server.rs
@@ -10,6 +10,32 @@ use tauri::Emitter;
 use tauri::Manager;
 
 // ---------------------------------------------------------------------------
+// 运行时形态
+// ---------------------------------------------------------------------------
+
+/// 当前是否为单 WebView 运行时（OHOS / Android / iOS）。
+/// 与前端 `src/lib/moke-reader.ts` 的 `isSingleWebviewRuntime` 保持一致：
+/// 这些平台上阅读器运行在唯一 WebView（label 为 `main`）里，而不是独立的
+/// `reader-*` 窗口，扩展必须能把 `main` 当作阅读器寻址。
+pub(crate) fn is_single_webview_runtime() -> bool {
+    #[cfg(target_env = "ohos")]
+    {
+        return true;
+    }
+    #[cfg(not(target_env = "ohos"))]
+    {
+        matches!(std::env::consts::OS, "android" | "ios")
+    }
+}
+
+/// 判断一个窗口 label 是否代表阅读器窗口。
+/// - 桌面多窗口形态：`reader-*` 前缀（含独立阅读器窗口）；
+/// - 单 WebView 形态：`main` 窗口即阅读器宿主。
+pub(crate) fn is_reader_window_label(label: &str) -> bool {
+    label.starts_with("reader-") || (is_single_webview_runtime() && label == "main")
+}
+
+// ---------------------------------------------------------------------------
 // 共享上下文
 // ---------------------------------------------------------------------------
 
@@ -18,6 +44,10 @@ pub struct ServerContext {
     pub enabled: Arc<Mutex<HashMap<String, EnabledExtension>>>,
     pub extensions_dir: std::path::PathBuf,
     pub app_handle: tauri::AppHandle,
+    /// 阻塞等待命令回执的注册表：request_id → 回执发送端。
+    /// 由 `ext_reader_event`（收到 `command:result` 时）向对应发送端投递结果，
+    /// `/command` 的阻塞等待模式通过它做 request_id 关联。
+    pub pending_commands: Arc<Mutex<HashMap<String, std::sync::mpsc::Sender<serde_json::Value>>>>,
 }
 
 // ---------------------------------------------------------------------------
@@ -214,12 +244,13 @@ fn handle_info(ctx: &ServerContext, _ext_name: &str) -> Result<String, String> {
 
     let windows: Vec<String> = all_windows
         .into_iter()
-        .filter(|l| l.starts_with("reader-"))
+        .filter(|l| is_reader_window_label(l))
         .collect();
 
     let info = serde_json::json!({
         "host_version": env!("CARGO_PKG_VERSION"),
         "reader_windows": windows,
+        "runtime": if is_single_webview_runtime() { "single_webview" } else { "multi_window" },
     });
 
     Ok(info.to_string())
@@ -239,7 +270,7 @@ fn handle_reader(
             .app_handle
             .webview_windows()
             .keys()
-            .filter(|l| l.starts_with("reader-"))
+            .filter(|l| is_reader_window_label(l))
             .cloned()
             .collect();
         return Ok(serde_json::json!({"windows": windows}).to_string());
@@ -274,10 +305,69 @@ fn handle_reader(
                 // 注：此处只是透传；阅读器前端需要监听此事件
                 let payload: serde_json::Value = serde_json::from_str(body)
                     .unwrap_or(serde_json::Value::Null);
+
+                // request_id 关联：若调用方携带 request_id，回显到响应中，
+                // 并支持阻塞等待（wait_ms>0 时）直到 `reader:command:result`
+                // 回执到达或超时，供扩展做请求/响应匹配。
+                let request_id = payload
+                    .get("request_id")
+                    .and_then(|v| v.as_str())
+                    .map(String::from);
+                let wait_ms = payload
+                    .get("wait_ms")
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or(0);
+
+                // 阻塞等待模式：先注册一个 request_id → 结果通道，再转发命令，
+                // 由 ext_reader_event 在收到 command:result 时投递回执。
+                let result_rx = if wait_ms > 0 {
+                    if let Some(rid) = &request_id {
+                        let (tx, rx) = std::sync::mpsc::channel::<serde_json::Value>();
+                        ctx.pending_commands
+                            .lock()
+                            .unwrap()
+                            .insert(rid.clone(), tx);
+                        Some((rid.clone(), rx))
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                };
+
                 if let Err(e) = window.emit("reader:command", &payload) {
+                    if let Some((rid, _)) = &result_rx {
+                        ctx.pending_commands.lock().unwrap().remove(rid);
+                    }
                     return Err(format!("发送命令失败: {e}"));
                 }
-                return Ok(serde_json::json!({"sent": true}).to_string());
+
+                if let Some((rid, rx)) = result_rx {
+                    let timeout = std::time::Duration::from_millis(wait_ms);
+                    return match rx.recv_timeout(timeout) {
+                        Ok(result) => Ok(serde_json::json!({
+                            "sent": true,
+                            "request_id": rid,
+                            "result": result,
+                        })
+                        .to_string()),
+                        Err(_) => {
+                            ctx.pending_commands.lock().unwrap().remove(&rid);
+                            Ok(serde_json::json!({
+                                "sent": true,
+                                "request_id": rid,
+                                "timed_out": true,
+                            })
+                            .to_string())
+                        }
+                    };
+                }
+
+                let mut response = serde_json::json!({"sent": true});
+                if let Some(rid) = request_id {
+                    response["request_id"] = serde_json::Value::String(rid);
+                }
+                return Ok(response.to_string());
             } else {
                 return Err(format!("阅读器窗口「{label}」不存在"));
             }

--- a/src-tauri/src/extensions/mod.rs
+++ b/src-tauri/src/extensions/mod.rs
@@ -38,6 +38,11 @@ pub struct ExtensionRuntime {
     pub ws_port: u16,
     /// WebSocket 广播发送端，供 ext_reader_event 等向外广播事件
     pub ws_broadcast: Sender<events::WsBroadcast>,
+    /// 阻塞等待命令回执的注册表：request_id → 回执发送端。
+    /// 与 api_server 的 ServerContext 共享同一份，ext_reader_event 收到
+    /// `command:result` 时按 request_id 投递给等待中的 /command 调用。
+    pub pending_commands:
+        Arc<Mutex<HashMap<String, std::sync::mpsc::Sender<serde_json::Value>>>>,
     /// 端口分配的起始值（wrap 时回到这里）
     pub port_range_start: u16,
 }
@@ -438,7 +443,7 @@ fn ext_diagnostics(
     let all_windows: Vec<String> = app.webview_windows().keys().cloned().collect();
     let reader_windows: Vec<String> = all_windows
         .iter()
-        .filter(|l| l.starts_with("reader-"))
+        .filter(|l| api_server::is_reader_window_label(l))
         .cloned()
         .collect();
 
@@ -462,6 +467,21 @@ fn ext_reader_event(
     event: String,
     data: serde_json::Value,
 ) -> Result<(), String> {
+    // 命令回执投递：若有 REST /command 正在阻塞等待该 request_id，
+    // 先把回执发给等待方（不改变原有的 WS/Tauri 广播路径）。
+    if event == "command:result" {
+        if let Some(request_id) = data.get("request_id").and_then(|v| v.as_str()) {
+            if let Some(tx) = state
+                .pending_commands
+                .lock()
+                .unwrap()
+                .remove(request_id)
+            {
+                let _ = tx.send(data.clone());
+            }
+        }
+    }
+
     // 通过 WS 广播给已连接的后端拓展（Tauri emit 和 WS broadcast 统一使用 reader: 前缀）
     let full_event = format!("reader:{}", event);
     let data_str = serde_json::to_string(&data).unwrap_or_default();
@@ -580,11 +600,17 @@ pub fn init(app: &AppHandle) {
     // 1. 先启动 WebSocket 服务器（先占端口），保留 sender 用于事件广播
     let (ws_port, ws_sender) = events::start(enabled.clone(), WS_SERVER_PORT);
 
+    // 命令回执等待注册表：api_server 与 ext_reader_event 共享同一份 Arc
+    let pending_commands: Arc<
+        Mutex<HashMap<String, std::sync::mpsc::Sender<serde_json::Value>>>,
+    > = Arc::new(Mutex::new(HashMap::new()));
+
     // 2. 再启动 REST API Server（如果 WS 回退了端口，REST 继续往后试）
     let api_ctx = Arc::new(api_server::ServerContext {
         enabled: enabled.clone(),
         extensions_dir: extensions_dir.clone(),
         app_handle: app.clone(),
+        pending_commands: pending_commands.clone(),
     });
     let api_port = api_server::start(api_ctx, API_SERVER_PORT);
 
@@ -622,6 +648,7 @@ pub fn init(app: &AppHandle) {
         api_port,
         ws_port,
         ws_broadcast: ws_sender,
+        pending_commands,
         port_range_start,
     };
 

--- a/src/lib/moke-reader.ts
+++ b/src/lib/moke-reader.ts
@@ -83,6 +83,15 @@ export async function navigateFullDocument(
   }
 }
 
+/**
+ * 桌面 reader-home（书库首页）窗口的 label。
+ * 不能落入扩展的 `reader-*` 枚举（H20-L4）：该书库窗口不代表阅读器，
+ * 扩展不应把它当作阅读器寻址/列出来。
+ */
+export function buildReaderHomeWindowLabel(timestamp: number = Date.now()): string {
+  return `moke-home-${timestamp}`;
+}
+
 export async function openEmbeddedReaderHome({
   eink,
   serverUrl,
@@ -113,7 +122,8 @@ export async function openEmbeddedReaderHome({
 
   try {
     const { WebviewWindow } = await import('@tauri-apps/api/webviewWindow');
-    const label = `reader-${Date.now()}`;
+    // 书库首页窗口不代表阅读器，不能落入扩展的 `reader-*` 枚举（H20-L4）。
+    const label = buildReaderHomeWindowLabel();
     const readerWindow = new WebviewWindow(label, {
       url: href,
       title: 'Readest',

--- a/tests/moke-reader.test.mjs
+++ b/tests/moke-reader.test.mjs
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 
 import {
   buildEmbeddedReaderUrl,
+  buildReaderHomeWindowLabel,
   isSingleWebviewRuntime,
   resolveRuntimeCategory,
   runtimeCategoryFromPlatform,
@@ -51,6 +52,14 @@ test('resolveRuntimeCategory resolves desktop outside the tauri platform', async
   } finally {
     if (prev !== undefined) process.env.NEXT_PUBLIC_APP_PLATFORM = prev;
   }
+});
+
+test('reader-home window label never matches the extension reader-* enumeration', () => {
+  // H20-L4: 书库首页窗口不能被扩展当成阅读器窗口寻址。
+  const label = buildReaderHomeWindowLabel(1234);
+  assert.equal(label, 'moke-home-1234');
+  assert.ok(!label.startsWith('reader-'));
+  assert.ok(label.startsWith('moke-home-'));
 });
 
 test('buildEmbeddedReaderUrl preserves the mobile reader launch context', () => {


### PR DESCRIPTION
修复 HOU-25（H20-M3/M4/L2/L4/L5）：移动端窗口枚举/命令回执契约/全文档导航统一/恢复重试/监听泄漏。含 readest 子模块更新。详见 issue HOU-25。验证：单测通过、lint 0 error、typecheck 通过。