### PR TITLE
TAL-15: pin wry OpenHarmony ability dependency

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -67,11 +67,10 @@ tauri-plugin-updater = "2"
 [target.'cfg(target_env = "ohos")'.dependencies]
 napi-ohos = "1.1"
 napi-derive-ohos = "1.1"
-# Vendored at vendor/openharmony-ability (pinned to 6c52bb4), the last
-# pre-pluginize release that still exposes the `webview` feature the wry
-# feat/open-harmony branch requires. wry depends on this crate via git without
-# a rev; the [patch] below points that git source at this vendored path so both
-# resolve to the same pinned commit.
+# Vendored at vendor/openharmony-ability (pinned to 16719fc), which exposes the
+# `webview` navigation API required by the wry feat/open-harmony branch. The
+# [patch] below points wry's matching pinned Git dependency at this vendored
+# path so both resolve to the same commit.
 openharmony-ability = { path = "../vendor/openharmony-ability/crates/ability" }
 openharmony-ability-derive = { path = "../vendor/openharmony-ability/crates/derive" }
 
@@ -100,10 +99,10 @@ tauri-utils = { path = "../vendor/tauri/crates/tauri-utils" }
 wry = { path = "../vendor/wry" }
 tao = { git = "https://github.com/tauri-apps/tao", branch = "feat/open-harmony" }
 
-# wry (feat/open-harmony) depends on openharmony-ability via git without a rev
-# and requires its `webview` feature, which the upstream default branch removed
-# after the 6c52bb4 pluginize refactor. Point that git source at the vendored
-# copy (pinned to 6c52bb4) so the `webview` feature resolves.
+# wry (feat/open-harmony) requires openharmony-ability's `webview` feature,
+# which the upstream default branch removed after its pluginization. Point the
+# pinned Git source at the vendored copy (also 16719fc) so Cargo resolves the
+# feature and the navigation API from the same revision.
 [patch."https://github.com/harmony-contrib/openharmony-ability.git"]
 openharmony-ability = { path = "../vendor/openharmony-ability/crates/ability" }
 openharmony-ability-derive = { path = "../vendor/openharmony-ability/crates/derive" }


### PR DESCRIPTION
## Summary

- bump `vendor/wry` to a commit that pins its OpenHarmony ability dependencies
- use the same `openharmony-ability` revision (`16719fc`) as Moke's vendored copy
- correct the dependency comments in `src-tauri/Cargo.toml`

## Root cause

The wry fork requested `openharmony-ability` from an unpinned Git default branch while enabling its `webview` feature. That branch advanced to `1.0.0-beta.0`, which no longer exposes the feature, so all three upstream bench jobs failed during Cargo dependency resolution before compiling.

## Validation

- `cargo metadata --manifest-path bench/tests/Cargo.toml --format-version 1`
- `cargo check --manifest-path bench/tests/Cargo.toml`
- `cargo fmt --all --check`
- `cargo metadata --manifest-path src-tauri/Cargo.toml --format-version 1 --no-deps`
- `git diff --check`

Closes TAL-15
