### PR TITLE
Fix mobile safe area and demo library action

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -83,6 +83,21 @@
     -moz-osx-font-smoothing: grayscale;
   }
 
+  .moke-app-root {
+    min-height: 100dvh;
+  }
+
+  /* Keep the page background edge-to-edge, but move its actual contents below
+     the Android/iOS status bar. OHOS never receives the runtime attribute and
+     therefore keeps its native, already-inset layout unchanged. */
+  [data-moke-top-safe-area] {
+    --moke-top-safe-area: env(safe-area-inset-top, 0px);
+  }
+
+  [data-moke-top-safe-area] .moke-app-root > :first-child {
+    padding-top: var(--moke-top-safe-area);
+  }
+
   ::selection {
     background: rgba(184, 149, 106, 0.25);
   }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,80 +1,18 @@
-'use client';
-
 import '@/app/globals.css';
-import { useEffect } from 'react';
-import { ServerProvider } from '@/components/providers/ServerProvider';
-import { ReaderProgressProvider } from '@/components/providers/ReaderProgressProvider';
-import { DebugLogPanel } from '@/components/ui/DebugLogPanel';
-import { installConsoleCapture, uninstallConsoleCapture } from '@/lib/debug-log';
-import { useDeveloperStore } from '@/lib/store/developer';
-import { resolveTheme, useSettingsStore } from '@/lib/store/settings';
+import type { Viewport } from 'next';
+import { AppShell } from '@/components/providers/AppShell';
 
-// 开发环境尽早 patch console，使 console.error/warn/log 也进入调试面板。
-// 生产环境默认不启用（见下方 useEffect 的开发者解锁门控），避免为所有用户
-// 全局 patch console 并缓存日志（内存/性能与敏感信息暴露考量）。
-if (process.env.NODE_ENV !== 'production') {
-  installConsoleCapture();
-}
+export const viewport: Viewport = {
+  width: 'device-width',
+  initialScale: 1,
+  viewportFit: 'cover',
+};
 
 export default function RootLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  const eink = useSettingsStore((s) => s.eink);
-  const theme = useSettingsStore((s) => s.theme);
-  const developerUnlocked = useDeveloperStore((s) => s.unlocked);
-
-  // Manual override: set the [data-eink='true'] attribute (same signal readest
-  // uses) so Moke + the embedded reader share one convention. Auto e-ink
-  // styling is applied via CSS media queries regardless. Use set/remove so the
-  // attribute is absent when e-ink is off (matching the inline head script and
-  // the auto media-query path, which never set it) — a lingering
-  // data-eink="false" would be read as "present" by any hasAttribute/truthy
-  // check (e.g. window.__MOKE_EINK in the reader bridge).
-  useEffect(() => {
-    const el = document.documentElement;
-    if (eink) el.setAttribute('data-eink', 'true');
-    else el.removeAttribute('data-eink');
-  }, [eink]);
-
-  // Appearance theme: 'light' | 'dark' | 'system'. 'system' resolves through
-  // prefers-color-scheme and stays in sync while the app is running. The inline
-  // head script below applies the theme before first paint to avoid a flash.
-  //
-  // E-ink mode is its own standalone theme: while it's on we never add the
-  // 'dark' class (nor switch color-scheme), so the black/white e-ink rules are
-  // the only ones in play and never fight the dark palette (see globals.css).
-  // This includes the *auto* e-ink path — devices that match the slow-refresh /
-  // monochrome media query but never get the manual data-eink toggle (e.g. a
-  // Kindle-class screen with the OS set to dark). We fold that media query into
-  // the same gate so auto-e-ink also suppresses the dark palette.
-  useEffect(() => {
-    const darkMq = window.matchMedia('(prefers-color-scheme: dark)');
-    const autoEinkMq = window.matchMedia('(update: slow), (max-color: 1)');
-    const apply = () => {
-      const resolved = resolveTheme(theme, darkMq.matches);
-      const dark = !eink && !autoEinkMq.matches && resolved === 'dark';
-      const el = document.documentElement;
-      el.classList.toggle('dark', dark);
-      el.style.colorScheme = dark ? 'dark' : 'light';
-    };
-    apply();
-    darkMq.addEventListener('change', apply);
-    autoEinkMq.addEventListener('change', apply);
-    return () => {
-      darkMq.removeEventListener('change', apply);
-      autoEinkMq.removeEventListener('change', apply);
-    };
-  }, [theme, eink]);
-
-  // 生产环境仅在开发者解锁后安装 console 捕获；锁定后撤销。
-  useEffect(() => {
-    if (process.env.NODE_ENV !== 'production') return;
-    if (developerUnlocked) installConsoleCapture();
-    else uninstallConsoleCapture();
-  }, [developerUnlocked]);
-
   return (
     <html lang="zh-CN" suppressHydrationWarning>
       <head>
@@ -101,12 +39,7 @@ export default function RootLayout({
             request on LAN/Tauri deployments. */}
       </head>
       <body className="min-h-screen bg-background text-foreground antialiased">
-        <ServerProvider>
-          <ReaderProgressProvider>
-            {children}
-          </ReaderProgressProvider>
-        </ServerProvider>
-        <DebugLogPanel />
+        <AppShell>{children}</AppShell>
       </body>
     </html>
   );

--- a/src/app/welcome/page.tsx
+++ b/src/app/welcome/page.tsx
@@ -2,7 +2,7 @@
 
 import { useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { BookOpen } from 'lucide-react';
+import { BookOpen, Check, Copy } from 'lucide-react';
 import { checkWelcomeRequirement, validateServerConnection } from '@/lib/api';
 import { useServerStore } from '@/lib/store/server';
 import { useDeveloperStore } from '@/lib/store/developer';
@@ -10,7 +10,10 @@ import { useSettingsStore } from '@/lib/store/settings';
 import { safeGetLocalStorageItem, safeSetLocalStorageItem } from '@/lib/browser-storage';
 import { debugLog } from '@/lib/debug-log';
 import { APP_VERSION } from '@/lib/app-version';
+import { copyTextToClipboard } from '@/lib/clipboard';
 import { openEmbeddedReaderHome } from '@/lib/moke-reader';
+
+const DEMO_LIBRARY_URL = 'https://demo.talebook.org';
 
 export default function WelcomePage() {
   const router = useRouter();
@@ -18,6 +21,7 @@ export default function WelcomePage() {
   const [serverUrl, setServerUrl] = useState('');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
+  const [demoLinkCopied, setDemoLinkCopied] = useState(false);
 
   // 主页版本号连点 8 次：解锁并直接进入开发者选项（无任何提示）
   const versionClicksRef = useRef(0);
@@ -116,6 +120,17 @@ export default function WelcomePage() {
     }
   };
 
+  const handleCopyDemoLink = async () => {
+    setError('');
+    setDemoLinkCopied(false);
+    const copied = await copyTextToClipboard(DEMO_LIBRARY_URL);
+    if (copied) {
+      setDemoLinkCopied(true);
+      return;
+    }
+    setError(`复制链接失败，请手动复制：${DEMO_LIBRARY_URL}`);
+  };
+
   return (
     <main className="min-h-screen flex flex-col md:flex-row app-warm-bg">
         <div className="hidden flex-1 items-center justify-center bg-primary px-8 py-12 md:flex md:p-16">
@@ -173,12 +188,15 @@ export default function WelcomePage() {
             </div>
 
             <button
-              data-dom-id="btn-browse-demo"
-              onClick={() => handleConnect('https://demo.talebook.org')}
+              data-dom-id="btn-copy-demo-link"
+              onClick={() => void handleCopyDemoLink()}
               disabled={loading}
-              className="inline-flex items-center justify-center w-full h-11 rounded-2xl text-sm font-medium border border-amber-950/10 bg-white/50 text-foreground cursor-pointer transition hover:opacity-80 active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-50"
+              className="inline-flex items-center justify-center gap-2 w-full h-11 rounded-2xl text-sm font-medium border border-amber-950/10 bg-white/50 text-foreground cursor-pointer transition hover:opacity-80 active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-50"
             >
-              浏览演示书库
+              {demoLinkCopied
+                ? <Check className="h-4 w-4" />
+                : <Copy className="h-4 w-4" />}
+              {demoLinkCopied ? '已复制' : '复制链接'}
             </button>
 
             <button

--- a/src/components/layout/DesktopLayout.tsx
+++ b/src/components/layout/DesktopLayout.tsx
@@ -14,13 +14,13 @@ export function DesktopLayout({ children }: { children: React.ReactNode }) {
   return (
     <div className="flex h-dvh overflow-hidden app-warm-bg">
       <Sidebar />
-      <div className="flex-1 min-w-0 h-dvh flex flex-col overflow-hidden pb-[calc(3.5rem+env(safe-area-inset-bottom,0px))] lg:ml-[220px] lg:pb-0">
+      <div className="flex-1 min-w-0 h-full flex flex-col overflow-hidden pb-[calc(3.5rem+env(safe-area-inset-bottom,0px))] lg:ml-[220px] lg:pb-0">
         {children}
       </div>
       <TabBar />
       <UpdateChecker />
       {toast && (
-        <div className="fixed top-4 left-1/2 z-[130] w-[min(400px,calc(100vw-2rem))] -translate-x-1/2">
+        <div className="fixed top-[calc(1rem+var(--moke-top-safe-area,0px))] left-1/2 z-[130] w-[min(400px,calc(100vw-2rem))] -translate-x-1/2">
           <div className={`flex items-start gap-3 px-4 py-3 rounded-xl shadow-lg border ${
             type === 'error'
               ? 'bg-destructive/10 border-destructive/30 text-destructive'

--- a/src/components/providers/AppShell.tsx
+++ b/src/components/providers/AppShell.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+import { useEffect } from 'react';
+import { DebugLogPanel } from '@/components/ui/DebugLogPanel';
+import { installConsoleCapture, uninstallConsoleCapture } from '@/lib/debug-log';
+import { getMokeRuntimePlatform, shouldApplyTopSafeArea } from '@/lib/moke-reader';
+import { useDeveloperStore } from '@/lib/store/developer';
+import { resolveTheme, useSettingsStore } from '@/lib/store/settings';
+import { ReaderProgressProvider } from './ReaderProgressProvider';
+import { ServerProvider } from './ServerProvider';
+
+// 开发环境尽早 patch console，使 console.error/warn/log 也进入调试面板。
+// 生产环境默认不启用（见下方 useEffect 的开发者解锁门控），避免为所有用户
+// 全局 patch console 并缓存日志（内存/性能与敏感信息暴露考量）。
+if (process.env.NODE_ENV !== 'production') {
+  installConsoleCapture();
+}
+
+export function AppShell({ children }: { children: React.ReactNode }) {
+  const eink = useSettingsStore((s) => s.eink);
+  const theme = useSettingsStore((s) => s.theme);
+  const developerUnlocked = useDeveloperStore((s) => s.unlocked);
+
+  // Manual override: set the [data-eink='true'] attribute (same signal readest
+  // uses) so Moke + the embedded reader share one convention. Auto e-ink
+  // styling is applied via CSS media queries regardless.
+  useEffect(() => {
+    const el = document.documentElement;
+    if (eink) el.setAttribute('data-eink', 'true');
+    else el.removeAttribute('data-eink');
+  }, [eink]);
+
+  // Appearance theme: 'light' | 'dark' | 'system'. E-ink mode suppresses the
+  // dark palette, including the auto-detected slow-refresh/monochrome path.
+  useEffect(() => {
+    const darkMq = window.matchMedia('(prefers-color-scheme: dark)');
+    const autoEinkMq = window.matchMedia('(update: slow), (max-color: 1)');
+    const apply = () => {
+      const resolved = resolveTheme(theme, darkMq.matches);
+      const dark = !eink && !autoEinkMq.matches && resolved === 'dark';
+      const el = document.documentElement;
+      el.classList.toggle('dark', dark);
+      el.style.colorScheme = dark ? 'dark' : 'light';
+    };
+    apply();
+    darkMq.addEventListener('change', apply);
+    autoEinkMq.addEventListener('change', apply);
+    return () => {
+      darkMq.removeEventListener('change', apply);
+      autoEinkMq.removeEventListener('change', apply);
+    };
+  }, [theme, eink]);
+
+  // 生产环境仅在开发者解锁后安装 console 捕获；锁定后撤销。
+  useEffect(() => {
+    if (process.env.NODE_ENV !== 'production') return;
+    if (developerUnlocked) installConsoleCapture();
+    else uninstallConsoleCapture();
+  }, [developerUnlocked]);
+
+  // Android/iOS use edge-to-edge WebViews, while OHOS already lays the WebView
+  // out below its status bar. Mark only the runtimes that need the CSS top
+  // inset; the inset is applied to each page shell so its background still
+  // paints behind the status bar and only the page content moves down.
+  useEffect(() => {
+    const el = document.documentElement;
+    let cancelled = false;
+
+    void getMokeRuntimePlatform()
+      .then((platform) => {
+        if (cancelled) return;
+        el.dataset.mokeRuntimePlatform = platform;
+        el.toggleAttribute('data-moke-top-safe-area', shouldApplyTopSafeArea(platform));
+      })
+      .catch((error) => {
+        console.warn('Unable to detect runtime platform for the top safe area:', error);
+      });
+
+    return () => {
+      cancelled = true;
+      delete el.dataset.mokeRuntimePlatform;
+      el.removeAttribute('data-moke-top-safe-area');
+    };
+  }, []);
+
+  return (
+    <>
+      <div className="moke-app-root">
+        <ServerProvider>
+          <ReaderProgressProvider>{children}</ReaderProgressProvider>
+        </ServerProvider>
+      </div>
+      <DebugLogPanel />
+    </>
+  );
+}

--- a/src/lib/moke-reader.ts
+++ b/src/lib/moke-reader.ts
@@ -4,6 +4,14 @@ export const isSingleWebviewRuntime = (platform: string): boolean =>
   platform === 'ohos' || platform === 'android' || platform === 'ios';
 
 /**
+ * Android/iOS render the main WebView edge-to-edge, so Moke's controls need
+ * the top safe-area inset. OHOS already keeps the WebView below its status bar
+ * and must not receive a second offset.
+ */
+export const shouldApplyTopSafeArea = (platform: string): boolean =>
+  platform === 'android' || platform === 'ios';
+
+/**
  * Whether the reader itself must save progress to the server (and therefore the
  * embedded reader URL should carry `mokeServerUrl`).
  *

--- a/tests/moke-reader.test.mjs
+++ b/tests/moke-reader.test.mjs
@@ -8,6 +8,7 @@ import {
   isSingleWebviewRuntime,
   resolveRuntimeCategory,
   runtimeCategoryFromPlatform,
+  shouldApplyTopSafeArea,
   shouldIncludeServerUrl,
 } from '../src/lib/moke-reader.ts';
 
@@ -26,6 +27,15 @@ test('runtimeCategoryFromPlatform classifies each runtime', () => {
   assert.equal(runtimeCategoryFromPlatform('linux'), 'desktop');
   assert.equal(runtimeCategoryFromPlatform('windows'), 'desktop');
   assert.equal(runtimeCategoryFromPlatform('macos'), 'desktop');
+});
+
+test('top safe area applies to edge-to-edge mobile runtimes except OHOS', () => {
+  assert.equal(shouldApplyTopSafeArea('android'), true);
+  assert.equal(shouldApplyTopSafeArea('ios'), true);
+  assert.equal(shouldApplyTopSafeArea('ohos'), false);
+  assert.equal(shouldApplyTopSafeArea('linux'), false);
+  assert.equal(shouldApplyTopSafeArea('windows'), false);
+  assert.equal(shouldApplyTopSafeArea('web'), false);
 });
 
 test('resolveRuntimeCategory falls back to mobile when the probe is unavailable', async () => {

--- a/tests/welcome-demo-link.test.mjs
+++ b/tests/welcome-demo-link.test.mjs
@@ -1,0 +1,19 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const welcomeSource = readFileSync(
+  fileURLToPath(new URL('../src/app/welcome/page.tsx', import.meta.url)),
+  'utf8',
+);
+
+test('连接页只复制演示书库链接，不再直接连接或打开站点', () => {
+  assert.match(welcomeSource, /copyTextToClipboard\(DEMO_LIBRARY_URL\)/);
+  assert.match(welcomeSource, /data-dom-id="btn-copy-demo-link"/);
+  assert.match(welcomeSource, /'复制链接'/);
+  assert.doesNotMatch(
+    welcomeSource,
+    /handleConnect\(['"]https:\/\/demo\.talebook\.org['"]\)/,
+  );
+});


### PR DESCRIPTION
## What changed

- Apply the top safe-area inset to Android and iOS content while keeping page backgrounds edge-to-edge.
- Explicitly leave OHOS unchanged because its WebView is already inset below the status bar.
- Keep the main content height and toast position aligned with the safe area.
- Replace the welcome-page demo-library connection action with a copy-link action and user feedback.

## Why

The Android/iOS edge-to-edge WebView allowed controls to overlap the system status bar. The demo-library button also connected to an external demo site inside the app, which is undesirable for the no-ICP app-store submission path.

## Validation

- `pnpm test` — 133 tests passed
- `pnpm typecheck`
- `pnpm lint` — 0 errors (existing warnings only)
- `pnpm build`
