### PR TITLE
fix: address Claude review findings on TB-3

### DIFF
--- a/src/app/detail/page.tsx
+++ b/src/app/detail/page.tsx
@@ -18,7 +18,7 @@ import { buildEmbeddedReaderUrl, getMokeRuntimePlatform, isSingleWebviewRuntime,
 import { resolveServerAssetUrl } from '@/lib/utils';
 import { AuthImage } from '@/components/ui/AuthImage';
 import { bookSummaryText } from '@/lib/book-detail-core';
-import { openAndRecordBookRead, recordAndOpenBookRead, recordBookRead } from '@/lib/book-read';
+import { openAndRecordBookRead, recordAndOpenBookRead, recordBookRead, READ_RECORD_NAV_TIMEOUT_MS } from '@/lib/book-read';
 import {
   getOfflineDownloadSnapshot,
   startOfflineDownload,
@@ -303,7 +303,13 @@ function DetailContent() {
   };
 
   const handleOfflineRead = async () => {
-    if (!book || openingReaderRef.current) return;
+    if (!book) return;
+    // 打开/记录在途时拦截重复点击：按钮只在阅读器窗口已打开后恢复可点，
+    // 记录请求仍在途，此时放行会造成重复打开窗口和重复计数。
+    if (openingReaderRef.current) {
+      setMessage('正在打开书籍，请稍候。');
+      return;
+    }
 
     openingReaderRef.current = true;
     setOpeningReader(true);
@@ -334,8 +340,10 @@ function DetailContent() {
 
           // Navigation replaces this WebView and destroys the current JS
           // context, so dispatch and await the bounded record request first.
+          // Use a short timeout: the record is best-effort and must not hold
+          // up opening the reader for long.
           await recordAndOpenBookRead({
-            record: () => recordBookRead(request, serverUrl, book.id),
+            record: () => recordBookRead(request, serverUrl, book.id, READ_RECORD_NAV_TIMEOUT_MS),
             open: () => openEmbeddedReaderBook(href, router.push, currentPlatform),
             onRecordError: (error) => {
               console.warn('Read record could not be saved before navigation:', error);
@@ -354,9 +362,10 @@ function DetailContent() {
               restoreProgress,
             });
           },
-          // Recording is best-effort and must not hold the desktop UI lock once
-          // the independent reader window has opened successfully.
-          onOpened: finishOpening,
+          // The independent reader window is open now, so unlock the button
+          // right away; the re-entry ref stays held until the record settles
+          // so a second click cannot duplicate the open or the count.
+          onOpened: () => setOpeningReader(false),
           record: () => recordBookRead(request, serverUrl, book.id),
           onRecordError: (error) => {
             console.warn('Reader opened, but the read record could not be saved:', error);

--- a/src/lib/book-detail-core.ts
+++ b/src/lib/book-detail-core.ts
@@ -25,21 +25,53 @@ const BLOCK_TAGS = new Set(['blockquote', 'div', 'h1', 'h2', 'h3', 'h4', 'h5', '
 function htmlToPlainText(value: string): string {
   let output = '';
   let hiddenTag: 'script' | 'style' | null = null;
+  const lower = value.toLowerCase();
 
   for (let index = 0; index < value.length;) {
+    if (hiddenTag) {
+      // Inside script/style, `<` may be plain code (`if (a < b)`); scanning for
+      // the next `>` would misread the closing tag and hide the rest of the
+      // description. Locate the real closing tag instead.
+      const closeStart = lower.indexOf(`</${hiddenTag}`, index);
+      if (closeStart === -1) break;
+      const closeEnd = value.indexOf('>', closeStart + 2);
+      index = closeEnd === -1 ? value.length : closeEnd + 1;
+      hiddenTag = null;
+      continue;
+    }
+
     if (value[index] !== '<') {
-      if (!hiddenTag) output += value[index];
+      output += value[index];
       index += 1;
+      continue;
+    }
+
+    // HTML comments (and other `<!...>` declarations) are not content.
+    if (value.startsWith('<!--', index)) {
+      const commentEnd = value.indexOf('-->', index + 4);
+      if (commentEnd === -1) break;
+      index = commentEnd + 3;
+      continue;
+    }
+    if (value.startsWith('<!', index)) {
+      const declEnd = value.indexOf('>', index + 2);
+      index = declEnd === -1 ? value.length : declEnd + 1;
       continue;
     }
 
     const tagEnd = value.indexOf('>', index + 1);
     if (tagEnd === -1) {
-      if (!hiddenTag) output += value.slice(index);
+      output += value.slice(index);
       break;
     }
 
-    const rawTag = value.slice(index + 1, tagEnd).trim();
+    // A nested `<` inside the scanned span (e.g. `<scr<script>`) means the
+    // outer tag text was cut short; parse only up to that point so the inner
+    // tag gets its own pass instead of being folded into the outer name.
+    const rawTagFull = value.slice(index + 1, tagEnd);
+    const innerTagAt = rawTagFull.indexOf('<');
+    const rawTag = (innerTagAt === -1 ? rawTagFull : rawTagFull.slice(0, innerTagAt)).trim();
+    const scanEnd = innerTagAt === -1 ? tagEnd : index + 1 + innerTagAt;
     const closing = rawTag.startsWith('/');
     const tagName = rawTag
       .slice(closing ? 1 : 0)
@@ -47,22 +79,20 @@ function htmlToPlainText(value: string): string {
       ?.toLowerCase();
 
     if (!tagName) {
-      if (!hiddenTag) output += '<';
+      output += '<';
       index += 1;
       continue;
     }
 
-    if (hiddenTag) {
-      if (closing && tagName === hiddenTag) hiddenTag = null;
-    } else if (!closing && (tagName === 'script' || tagName === 'style')) {
+    if (!closing && (tagName === 'script' || tagName === 'style')) {
       hiddenTag = tagName;
-    } else if (tagName === 'br' || (closing && tagName && BLOCK_TAGS.has(tagName))) {
+    } else if (tagName === 'br' || (closing && BLOCK_TAGS.has(tagName))) {
       output += '\n';
     } else if (!closing && tagName === 'li') {
       output += '• ';
     }
 
-    index = tagEnd + 1;
+    index = scanEnd === tagEnd ? tagEnd + 1 : scanEnd;
   }
 
   return output;
@@ -75,6 +105,9 @@ export function bookSummaryText(value: string | null | undefined): string {
 
   // Decode once, then parse once more so encoded markup is treated exactly like
   // literal markup without deleting comparison operators from ordinary text.
+  // Trade-off: decoded text that merely resembles a tag (a tutorial writing
+  // "&lt;div&gt;") is stripped like real markup; this is the accepted cost of
+  // treating encoded hostile markup the same as literal hostile markup.
   return htmlToPlainText(decodeHtmlEntities(text))
     .replace(/[\t\f\v ]+/g, ' ')
     .replace(/ *\n */g, '\n')

--- a/src/lib/book-read.ts
+++ b/src/lib/book-read.ts
@@ -1,5 +1,33 @@
 type RequestLike = (url: string, init?: RequestInit) => Promise<Response>;
 const READ_RECORD_TIMEOUT_MS = 10_000;
+/**
+ * Record-before-navigation must not noticeably delay opening the reader: the
+ * request is best-effort, so bound it much tighter than the desktop path.
+ */
+export const READ_RECORD_NAV_TIMEOUT_MS = 3_000;
+
+/**
+ * Build a record timeout signal that also works on WebViews without
+ * `AbortSignal.timeout` (some OHOS / older iOS WebViews); without any abort
+ * mechanism the request runs unbounded, which is still better than throwing
+ * and losing the record silently.
+ */
+function buildTimeoutSignal(timeoutMs: number): AbortSignal | undefined {
+  if (typeof AbortSignal.timeout === 'function') return AbortSignal.timeout(timeoutMs);
+  if (typeof AbortController !== 'function') return undefined;
+  const controller = new AbortController();
+  setTimeout(() => controller.abort(), timeoutMs);
+  return controller.signal;
+}
+
+/** Pathname of an absolute URL with trailing slashes stripped; null if unparseable. */
+function pathnameOf(url: string): string | null {
+  try {
+    return new URL(url).pathname.replace(/\/+$/, '');
+  } catch {
+    return null;
+  }
+}
 
 /**
  * Notify Talebook through its canonical reader route after the local reader
@@ -12,12 +40,30 @@ export async function recordBookRead(
   bookId: string | number,
   timeoutMs = READ_RECORD_TIMEOUT_MS,
 ): Promise<void> {
-  const response = await requestLike(`${serverUrl}/read/${encodeURIComponent(String(bookId))}`, {
+  const readUrl = `${serverUrl}/read/${encodeURIComponent(String(bookId))}`;
+  const response = await requestLike(readUrl, {
     credentials: 'include',
-    signal: AbortSignal.timeout(timeoutMs),
+    signal: buildTimeoutSignal(timeoutMs),
   });
+
+  // Drain the body promptly so the underlying connection is released; the
+  // online-reader page can be hundreds of KB of HTML this client never uses.
+  try {
+    await response.arrayBuffer();
+  } catch {
+    // A body-read failure does not invalidate an otherwise successful record.
+  }
+
   if (!response.ok) {
     throw new Error(`book.read_record.http.${response.status}`);
+  }
+
+  // A 200 from a login page means the session expired and the server
+  // redirected `/read/{id}` away — the record was never persisted.
+  const finalUrl = response.url || readUrl;
+  const finalPath = pathnameOf(finalUrl);
+  if (finalPath && finalPath !== pathnameOf(readUrl)) {
+    throw new Error('book.read_record.redirect');
   }
 }
 

--- a/tests/book-detail-core.test.mjs
+++ b/tests/book-detail-core.test.mjs
@@ -22,7 +22,21 @@ test('书籍简介不会让嵌套或编码的输入重新组成 HTML 标签', ()
   const encoded = '&lt;script&gt;alert(2)&lt;/script&gt;';
 
   assert.doesNotMatch(bookSummaryText(nested), /<\/?(?:script|style)\b/i);
+  // 脚本载荷不能以纯文本形式泄漏：即使输出只渲染为 React 文本节点，
+  // 也要防止未来被用于 dangerouslySetInnerHTML 之类的场景。
+  assert.doesNotMatch(bookSummaryText(nested), /alert/i);
   assert.equal(bookSummaryText(encoded), '');
+});
+
+test('书籍简介会跳过 HTML 注释内容', () => {
+  assert.equal(bookSummaryText('<!-- 隐藏注释 -->正文'), '正文');
+  assert.equal(bookSummaryText('前言<!-- 多行\n注释 -->正文'), '前言正文');
+});
+
+test('脚本或样式代码中的比较符号不会吞掉后续正文', () => {
+  assert.equal(bookSummaryText('<script>if (a < b) x()</script>正文'), '正文');
+  assert.equal(bookSummaryText('<style>a < b { color: red }</style>正文'), '正文');
+  assert.equal(bookSummaryText('<script>未闭合的脚本'), '');
 });
 
 test('书籍简介保留正文中的比较符号和非标签尖括号内容', () => {

--- a/tests/book-read.test.mjs
+++ b/tests/book-read.test.mjs
@@ -82,3 +82,60 @@ test('单 WebView 在导航前记录，记录失败仍继续打开阅读器', as
   assert.equal(errors.length, 1);
   assert.match(errors[0].message, /network failed/);
 });
+
+test('会话失效被重定向到登录页时不误报记录成功', async () => {
+  const fake = {
+    ok: true,
+    status: 200,
+    url: 'https://books.example/login',
+    arrayBuffer: async () => new ArrayBuffer(0),
+  };
+
+  await assert.rejects(
+    recordBookRead(async () => fake, 'https://books.example', 'a'),
+    /book\.read_record\.redirect/,
+  );
+});
+
+test('仍落在阅读路由上的重定向视为记录成功', async () => {
+  const fake = {
+    ok: true,
+    status: 200,
+    url: 'https://books.example/read/a/',
+    arrayBuffer: async () => new ArrayBuffer(0),
+  };
+
+  await recordBookRead(async () => fake, 'https://books.example', 'a');
+});
+
+test('记录请求会排空响应体以尽早释放连接', async () => {
+  let drained = false;
+
+  await recordBookRead(async () => ({
+    ok: true,
+    status: 200,
+    url: 'https://books.example/read/1',
+    arrayBuffer: async () => {
+      drained = true;
+      return new ArrayBuffer(0);
+    },
+  }), 'https://books.example', '1');
+
+  assert.equal(drained, true);
+});
+
+test('WebView 缺少 AbortSignal.timeout 时仍会携带超时信号', async () => {
+  const original = AbortSignal.timeout;
+  delete AbortSignal.timeout;
+  try {
+    let capturedSignal;
+    await recordBookRead(async (url, init) => {
+      capturedSignal = init.signal;
+      return new Response('', { status: 200 });
+    }, 'https://books.example', 'a', 100);
+
+    assert.ok(capturedSignal instanceof AbortSignal);
+  } finally {
+    AbortSignal.timeout = original;
+  }
+});


### PR DESCRIPTION
## 变更内容

- 完善阅读记录请求：限制导航前等待时间、兼容旧 WebView 的超时信号，并识别会话失效重定向
- 防止阅读器打开与记录请求在途时重复点击造成重复窗口和重复计数
- 加强书籍简介 HTML 清理，正确跳过注释、脚本和样式内容
- 补充阅读记录及简介清理的回归测试

## 原因与影响

处理 TB-3 在 Claude 评审中发现的边界问题，避免失效会话被误判为记录成功、重复打开阅读器，以及恶意或异常 HTML 内容泄漏到简介文本。

## 验证

- `pnpm test`（148 项通过）
- `pnpm typecheck`
- `pnpm lint`（0 errors，25 个既有 warnings）
