### PR TITLE
Fix top safe area on mobile cold start

### DIFF
--- a/src/components/providers/AppShell.tsx
+++ b/src/components/providers/AppShell.tsx
@@ -3,7 +3,11 @@
 import { useEffect } from 'react';
 import { DebugLogPanel } from '@/components/ui/DebugLogPanel';
 import { installConsoleCapture, uninstallConsoleCapture } from '@/lib/debug-log';
-import { getMokeRuntimePlatform, shouldApplyTopSafeArea } from '@/lib/moke-reader';
+import {
+  getMokeRuntimePlatform,
+  getNativeTopSafeAreaInset,
+  shouldApplyTopSafeArea,
+} from '@/lib/moke-reader';
 import { useDeveloperStore } from '@/lib/store/developer';
 import { resolveTheme, useSettingsStore } from '@/lib/store/settings';
 import { ReaderProgressProvider } from './ReaderProgressProvider';
@@ -60,26 +64,85 @@ export function AppShell({ children }: { children: React.ReactNode }) {
 
   // Android/iOS use edge-to-edge WebViews, while OHOS already lays the WebView
   // out below its status bar. Mark only the runtimes that need the CSS top
-  // inset; the inset is applied to each page shell so its background still
-  // paints behind the status bar and only the page content moves down.
+  // inset. Native values avoid Android WebView cold-start bugs where the CSS
+  // safe-area env remains 0; a bounded retry covers the native bridge/window
+  // insets not being ready during the first frames of app startup.
   useEffect(() => {
     const el = document.documentElement;
     let cancelled = false;
+    let runtimePlatform: string | null = null;
+    let retryTimer: number | undefined;
+    const maxAttempts = 12;
 
-    void getMokeRuntimePlatform()
-      .then((platform) => {
+    const clearRetry = () => {
+      if (retryTimer !== undefined) {
+        window.clearTimeout(retryTimer);
+        retryTimer = undefined;
+      }
+    };
+
+    const detectSafeArea = async (attempt = 0): Promise<void> => {
+      clearRetry();
+      try {
+        const platform = runtimePlatform ?? await getMokeRuntimePlatform();
         if (cancelled) return;
+        runtimePlatform = platform;
+        const enabled = shouldApplyTopSafeArea(platform);
         el.dataset.mokeRuntimePlatform = platform;
-        el.toggleAttribute('data-moke-top-safe-area', shouldApplyTopSafeArea(platform));
-      })
-      .catch((error) => {
-        console.warn('Unable to detect runtime platform for the top safe area:', error);
-      });
+        el.toggleAttribute('data-moke-top-safe-area', enabled);
+
+        if (!enabled) {
+          el.style.removeProperty('--moke-top-safe-area');
+          return;
+        }
+
+        const top = await getNativeTopSafeAreaInset(platform, window.devicePixelRatio);
+        if (cancelled) return;
+        if (top > 0) {
+          el.style.setProperty('--moke-top-safe-area', `${top}px`);
+          return;
+        }
+
+        // Keep CSS env(...) as the fallback while native insets initialize.
+        el.style.removeProperty('--moke-top-safe-area');
+        if (attempt + 1 < maxAttempts) {
+          retryTimer = window.setTimeout(() => {
+            void detectSafeArea(attempt + 1);
+          }, 250);
+        }
+      } catch (error) {
+        if (cancelled) return;
+        if (attempt + 1 < maxAttempts) {
+          retryTimer = window.setTimeout(() => {
+            void detectSafeArea(attempt + 1);
+          }, 250);
+        } else {
+          console.warn('Unable to initialize the top safe area:', error);
+        }
+      }
+    };
+
+    const refreshSafeArea = () => {
+      if (!cancelled) void detectSafeArea();
+    };
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'visible') refreshSafeArea();
+    };
+
+    void detectSafeArea();
+    window.addEventListener('pageshow', refreshSafeArea);
+    window.addEventListener('orientationchange', refreshSafeArea);
+    document.addEventListener('visibilitychange', handleVisibilityChange);
 
     return () => {
       cancelled = true;
+      clearRetry();
+      window.removeEventListener('pageshow', refreshSafeArea);
+      window.removeEventListener('orientationchange', refreshSafeArea);
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
       delete el.dataset.mokeRuntimePlatform;
       el.removeAttribute('data-moke-top-safe-area');
+      el.style.removeProperty('--moke-top-safe-area');
     };
   }, []);
 

--- a/src/lib/moke-reader.ts
+++ b/src/lib/moke-reader.ts
@@ -11,6 +11,51 @@ export const isSingleWebviewRuntime = (platform: string): boolean =>
 export const shouldApplyTopSafeArea = (platform: string): boolean =>
   platform === 'android' || platform === 'ios';
 
+type RuntimeInvoke = <T>(command: string) => Promise<T>;
+
+interface StatusBarHeightResponse {
+  height: number;
+  error?: string;
+}
+
+interface SafeAreaInsetsResponse {
+  top: number;
+  error?: string;
+}
+
+/**
+ * Read the top inset from the native bridge instead of relying only on CSS
+ * env(safe-area-inset-top). Some Android WebView versions report that CSS env
+ * value as 0 during a cold start. Android returns physical pixels, while the
+ * iOS safe-area command already returns logical pixels.
+ */
+export async function getNativeTopSafeAreaInset(
+  platform: string,
+  devicePixelRatio = 1,
+  invokeOverride?: RuntimeInvoke,
+): Promise<number> {
+  if (!shouldApplyTopSafeArea(platform)) return 0;
+
+  const invoke = invokeOverride ?? (await import('@tauri-apps/api/core')).invoke;
+  if (platform === 'android') {
+    const response = await invoke<StatusBarHeightResponse>(
+      'plugin:native-bridge|get_status_bar_height',
+    );
+    if (response.error) throw new Error(response.error);
+    const ratio = Number.isFinite(devicePixelRatio) && devicePixelRatio > 0
+      ? devicePixelRatio
+      : 1;
+    const height = response.height / ratio;
+    return Number.isFinite(height) && height > 0 ? height : 0;
+  }
+
+  const response = await invoke<SafeAreaInsetsResponse>(
+    'plugin:native-bridge|get_safe_area_insets',
+  );
+  if (response.error) throw new Error(response.error);
+  return Number.isFinite(response.top) && response.top > 0 ? response.top : 0;
+}
+
 /**
  * Whether the reader itself must save progress to the server (and therefore the
  * embedded reader URL should carry `mokeServerUrl`).

--- a/tests/moke-reader.test.mjs
+++ b/tests/moke-reader.test.mjs
@@ -5,6 +5,7 @@ import {
   buildEmbeddedReaderHomeUrl,
   buildEmbeddedReaderUrl,
   buildReaderHomeWindowLabel,
+  getNativeTopSafeAreaInset,
   isSingleWebviewRuntime,
   resolveRuntimeCategory,
   runtimeCategoryFromPlatform,
@@ -36,6 +37,40 @@ test('top safe area applies to edge-to-edge mobile runtimes except OHOS', () => 
   assert.equal(shouldApplyTopSafeArea('linux'), false);
   assert.equal(shouldApplyTopSafeArea('windows'), false);
   assert.equal(shouldApplyTopSafeArea('web'), false);
+});
+
+test('native top safe area uses status-bar pixels on Android and safe insets on iOS', async () => {
+  const commands = [];
+  const invoke = async (command) => {
+    commands.push(command);
+    if (command === 'plugin:native-bridge|get_status_bar_height') {
+      return { height: 72 };
+    }
+    return { top: 47 };
+  };
+
+  assert.equal(await getNativeTopSafeAreaInset('android', 3, invoke), 24);
+  assert.equal(await getNativeTopSafeAreaInset('ios', 2, invoke), 47);
+  assert.equal(await getNativeTopSafeAreaInset('ohos', 3, invoke), 0);
+  assert.deepEqual(commands, [
+    'plugin:native-bridge|get_status_bar_height',
+    'plugin:native-bridge|get_safe_area_insets',
+  ]);
+});
+
+test('native top safe area rejects errors and normalizes invalid values', async () => {
+  await assert.rejects(
+    getNativeTopSafeAreaInset('android', 3, async () => ({ height: -1, error: 'not ready' })),
+    /not ready/,
+  );
+  assert.equal(
+    await getNativeTopSafeAreaInset('android', 0, async () => ({ height: -1 })),
+    0,
+  );
+  assert.equal(
+    await getNativeTopSafeAreaInset('ios', 2, async () => ({ top: Number.NaN })),
+    0,
+  );
 });
 
 test('resolveRuntimeCategory falls back to mobile when the probe is unavailable', async () => {


### PR DESCRIPTION
## What changed

- Read the Android top inset from the native status-bar-height bridge and convert physical pixels to CSS pixels.
- Read the iOS top inset from the native safe-area bridge.
- Keep CSS `env(safe-area-inset-top)` as a fallback.
- Retry initialization while the native bridge/window insets are still unavailable during cold start.
- Refresh the inset after page restore, app foregrounding, and orientation changes.
- Continue excluding OHOS from the extra top offset.

## Root cause

Some Android WebView versions report `env(safe-area-inset-top)` as `0px` during a cold start. Entering the home page from the connection screen gave the WebView enough time to initialize, while restoring a saved server and launching directly into the home page exposed the zero-inset race.

## Validation

- `pnpm test` — 144 tests passed
- `pnpm typecheck`
- Targeted ESLint passed
- `pnpm build` — 21 static pages generated
