### PR TITLE
fix: 完善 Android 返回键和隐私确认

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -5,6 +5,11 @@ const exportOutput = appPlatform !== 'web' && !isDev;
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: exportOutput ? 'export' : undefined,
+  // CI and local device smoke tests access the dev server through the
+  // loopback IP. Next 16 blocks dev assets from that origin unless it is
+  // explicitly trusted, which would leave client-only startup gates stuck at
+  // their server-rendered loading state.
+  allowedDevOrigins: ['127.0.0.1'],
   images: {
     unoptimized: true,
   },

--- a/src-tauri/android/MainActivity.kt
+++ b/src-tauri/android/MainActivity.kt
@@ -14,9 +14,12 @@
 
 package org.houheya.moke
 
+import android.net.Uri
 import android.os.Bundle
+import android.os.SystemClock
 import android.view.KeyEvent
 import android.webkit.WebView
+import android.widget.Toast
 import androidx.activity.enableEdgeToEdge
 import com.readest.native_bridge.KeyDownInterceptor
 
@@ -26,6 +29,11 @@ class MainActivity : TauriActivity(), KeyDownInterceptor {
     private var interceptBackKeyEnabled = false
     private var interceptPageTurnerKeysEnabled = false
     private var keyLearnModeEnabled = false
+    private var lastExitBackPressedAt = 0L
+
+    companion object {
+        private const val EXIT_CONFIRM_WINDOW_MS = 2_000L
+    }
 
     // DOWN 已被本 Activity 消费（并转发到 webview）的按键集合。被拦截的按键
     // 必须把配套的 ACTION_UP 也一并消费，否则按键组合会泄漏到
@@ -57,6 +65,45 @@ class MainActivity : TauriActivity(), KeyDownInterceptor {
             """try { window.onNativeKeyDown("$keyName", $keyCode); } catch (_) {}""",
             null,
         )
+        return true
+    }
+
+    /**
+     * Tauri's default Android BACK handling delegates to WebView history. In a
+     * statically-exported Next app that can perform a document reload instead
+     * of a client-side route transition. Non-root Moke pages therefore send a
+     * dedicated event to AppShell, which calls Next's router.back().
+     */
+    private fun forwardAppBackToWebView(): Boolean {
+        val webView = wv ?: return false
+        webView.evaluateJavascript(
+            """window.dispatchEvent(new Event("moke:native-back"));""",
+            null,
+        )
+        return true
+    }
+
+    private fun isAppExitRoute(): Boolean {
+        val path = wv?.url?.let { Uri.parse(it).path }?.trimEnd('/') ?: return true
+        return path in setOf(
+            "",
+            "/",
+            "/index.html",
+            "/welcome",
+            "/welcome/index.html",
+            "/shelf",
+            "/shelf/index.html",
+        )
+    }
+
+    private fun handleExitBack(): Boolean {
+        val now = SystemClock.elapsedRealtime()
+        if (lastExitBackPressedAt != 0L && now - lastExitBackPressedAt <= EXIT_CONFIRM_WINDOW_MS) {
+            finishAndRemoveTask()
+        } else {
+            lastExitBackPressedAt = now
+            Toast.makeText(this, "再按一次退出应用", Toast.LENGTH_SHORT).show()
+        }
         return true
     }
 
@@ -103,6 +150,21 @@ class MainActivity : TauriActivity(), KeyDownInterceptor {
     override fun dispatchKeyEvent(event: KeyEvent): Boolean {
         when (event.action) {
             KeyEvent.ACTION_DOWN -> {
+                // The embedded reader owns BACK while its interception flag is
+                // enabled. Everywhere else, keep root-page exit behavior
+                // native and route nested pages through Next's client router.
+                if (event.keyCode == KeyEvent.KEYCODE_BACK && !interceptBackKeyEnabled) {
+                    if (event.repeatCount > 0) return true
+                    val handled = if (isAppExitRoute()) {
+                        handleExitBack()
+                    } else {
+                        lastExitBackPressedAt = 0L
+                        forwardAppBackToWebView()
+                    }
+                    if (!handled) return super.dispatchKeyEvent(event)
+                    interceptedKeyCodes.add(event.keyCode)
+                    return true
+                }
                 if (!shouldIntercept(event.keyCode)) {
                     return super.dispatchKeyEvent(event)
                 }

--- a/src-tauri/android/MainActivity.kt
+++ b/src-tauri/android/MainActivity.kt
@@ -33,6 +33,7 @@ class MainActivity : TauriActivity(), KeyDownInterceptor {
 
     companion object {
         private const val EXIT_CONFIRM_WINDOW_MS = 2_000L
+        private val APP_EXIT_ROUTES = setOf("/", "/welcome", "/shelf")
     }
 
     // DOWN 已被本 Activity 消费（并转发到 webview）的按键集合。被拦截的按键
@@ -83,18 +84,20 @@ class MainActivity : TauriActivity(), KeyDownInterceptor {
         return true
     }
 
-    private fun isAppExitRoute(): Boolean {
-        val path = wv?.url?.let { Uri.parse(it).path }?.trimEnd('/') ?: return true
-        return path in setOf(
-            "",
-            "/",
-            "/index.html",
-            "/welcome",
-            "/welcome/index.html",
-            "/shelf",
-            "/shelf/index.html",
-        )
+    private fun currentAppPath(): String {
+        val rawPath = wv?.url?.let { Uri.parse(it).path }.orEmpty()
+        val withoutDocument = when {
+            rawPath.endsWith("/index.html") -> rawPath.removeSuffix("/index.html")
+            rawPath.endsWith(".html") -> rawPath.removeSuffix(".html")
+            else -> rawPath
+        }
+        return withoutDocument.trimEnd('/').ifEmpty { "/" }
     }
+
+    private fun isAppExitRoute(): Boolean = currentAppPath() in APP_EXIT_ROUTES
+
+    private fun isEmbeddedReaderRoute(): Boolean =
+        currentAppPath() == "/readest" || currentAppPath().startsWith("/readest/")
 
     private fun handleExitBack(): Boolean {
         val now = SystemClock.elapsedRealtime()
@@ -155,6 +158,13 @@ class MainActivity : TauriActivity(), KeyDownInterceptor {
                 // native and route nested pages through Next's client router.
                 if (event.keyCode == KeyEvent.KEYCODE_BACK && !interceptBackKeyEnabled) {
                     if (event.repeatCount > 0) return true
+                    // Android uses an in-place Readest WebView. During its
+                    // startup there is a short interval before Readest enables
+                    // interception; never interpret BACK in that interval as a
+                    // Moke root-page exit.
+                    if (isEmbeddedReaderRoute()) {
+                        return super.dispatchKeyEvent(event)
+                    }
                     val handled = if (isAppExitRoute()) {
                         handleExitBack()
                     } else {

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,11 +1,82 @@
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import type { ReactNode } from 'react';
 import { PrivacyBackButton } from './privacy-back-button';
 
+export const dynamic = 'force-static';
+
+const POLICY_FALLBACK = `# Moke 隐私政策
+
+完整隐私政策暂时无法载入。Moke 不会在你同意前连接 Talebook 服务器或同步个人信息。
+
+如需帮助，请联系 shangzhen0831@163.com，或访问 https://github.com/talebook/moke。`;
+
 function readPrivacyPolicy(): string {
-  return readFileSync(join(process.cwd(), 'PRIVACY.md'), 'utf8')
-    .replace(/^---[\s\S]*?---\s*/, '')
-    .trim();
+  try {
+    return readFileSync(join(process.cwd(), 'PRIVACY.md'), 'utf8')
+      .replace(/^---[\s\S]*?---\s*/, '')
+      .trim();
+  } catch (error) {
+    console.warn('Unable to load PRIVACY.md during static generation:', error);
+    return POLICY_FALLBACK;
+  }
+}
+
+function renderInline(text: string): ReactNode[] {
+  const tokens = text.split(/(\*\*[^*]+\*\*|<https?:\/\/[^>]+>|<[^<>\s]+@[^<>\s]+>)/g);
+  return tokens.filter(Boolean).map((token, index) => {
+    if (token.startsWith('**') && token.endsWith('**')) {
+      return <strong key={index}>{token.slice(2, -2)}</strong>;
+    }
+    if (token.startsWith('<http') && token.endsWith('>')) {
+      const href = token.slice(1, -1);
+      return <a key={index} href={href} target="_blank" rel="noopener noreferrer" className="text-primary underline">{href}</a>;
+    }
+    if (token.startsWith('<') && token.endsWith('>') && token.includes('@')) {
+      const email = token.slice(1, -1);
+      return <a key={index} href={`mailto:${email}`} className="text-primary underline">{email}</a>;
+    }
+    return token;
+  });
+}
+
+function renderPolicy(markdown: string): ReactNode[] {
+  const lines = markdown.split('\n');
+  const blocks: ReactNode[] = [];
+
+  for (let index = 0; index < lines.length;) {
+    const line = lines[index].trim();
+    if (!line) {
+      index += 1;
+      continue;
+    }
+
+    const heading = /^(#{1,3})\s+(.+)$/.exec(line);
+    if (heading) {
+      const level = heading[1].length;
+      const content = renderInline(heading[2]);
+      if (level === 1) blocks.push(<h1 key={index} className="text-2xl font-semibold text-foreground">{content}</h1>);
+      else if (level === 2) blocks.push(<h2 key={index} className="pt-4 text-xl font-semibold text-foreground">{content}</h2>);
+      else blocks.push(<h3 key={index} className="pt-2 text-base font-semibold text-foreground">{content}</h3>);
+      index += 1;
+      continue;
+    }
+
+    if (line.startsWith('- ')) {
+      const items: ReactNode[] = [];
+      while (index < lines.length && lines[index].trim().startsWith('- ')) {
+        items.push(<li key={index}>{renderInline(lines[index].trim().slice(2))}</li>);
+        index += 1;
+      }
+      blocks.push(<ul key={`list-${index}`} className="list-disc space-y-1 pl-5">{items}</ul>);
+      continue;
+    }
+
+    blocks.push(<p key={index}>{renderInline(line)}</p>);
+    index += 1;
+  }
+
+  return blocks;
 }
 
 export default function PrivacyPage() {
@@ -15,8 +86,8 @@ export default function PrivacyPage() {
     <main className="min-h-dvh app-warm-bg px-4 py-6 sm:px-6 sm:py-10">
       <article className="mx-auto max-w-3xl rounded-[28px] border border-amber-950/10 bg-background p-6 shadow-xl sm:p-10">
         <PrivacyBackButton />
-        <div className="mt-6 whitespace-pre-wrap text-sm leading-7 text-foreground/90">
-          {policy}
+        <div className="mt-6 space-y-4 text-sm leading-7 text-foreground/90">
+          {renderPolicy(policy)}
         </div>
       </article>
     </main>

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,0 +1,24 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { PrivacyBackButton } from './privacy-back-button';
+
+function readPrivacyPolicy(): string {
+  return readFileSync(join(process.cwd(), 'PRIVACY.md'), 'utf8')
+    .replace(/^---[\s\S]*?---\s*/, '')
+    .trim();
+}
+
+export default function PrivacyPage() {
+  const policy = readPrivacyPolicy();
+
+  return (
+    <main className="min-h-dvh app-warm-bg px-4 py-6 sm:px-6 sm:py-10">
+      <article className="mx-auto max-w-3xl rounded-[28px] border border-amber-950/10 bg-background p-6 shadow-xl sm:p-10">
+        <PrivacyBackButton />
+        <div className="mt-6 whitespace-pre-wrap text-sm leading-7 text-foreground/90">
+          {policy}
+        </div>
+      </article>
+    </main>
+  );
+}

--- a/src/app/privacy/privacy-back-button.tsx
+++ b/src/app/privacy/privacy-back-button.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import { ArrowLeft } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+
+export function PrivacyBackButton() {
+  const router = useRouter();
+
+  return (
+    <button
+      type="button"
+      onClick={() => router.back()}
+      className="inline-flex h-10 items-center gap-2 rounded-2xl border border-amber-950/10 bg-white/60 px-4 text-sm text-foreground"
+    >
+      <ArrowLeft className="h-4 w-4" />
+      返回
+    </button>
+  );
+}

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { ArrowRight, BookOpen, Copy, Download, LogOut, Moon, Package, PlugZap, RefreshCw, Settings2, ShieldAlert, Sun, User, Code2 } from 'lucide-react';
+import { ArrowRight, BookOpen, Copy, Download, LogOut, Moon, Package, PlugZap, RefreshCw, Settings2, ShieldAlert, ShieldCheck, Sun, User, Code2 } from 'lucide-react';
 import { DesktopLayout } from '@/components/layout/DesktopLayout';
 import { fetchServerInfo, request } from '@/lib/api';
 import { useServerStore } from '@/lib/store/server';
@@ -144,6 +144,12 @@ export default function SettingsPage() {
               label="关于应用"
               description="查看应用介绍、版本说明与贡献者信息"
               href="/about"
+            />
+            <SettingsLinkRow
+              icon={ShieldCheck}
+              label="隐私政策"
+              description="查看 Moke 如何处理和保护相关信息"
+              href="/privacy"
             />
             <ToggleRow
               icon={Settings2}

--- a/src/app/welcome/page.tsx
+++ b/src/app/welcome/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { BookOpen, Check, Copy } from 'lucide-react';
 import { checkWelcomeRequirement, validateServerConnection } from '@/lib/api';
@@ -14,6 +14,7 @@ import { copyTextToClipboard } from '@/lib/clipboard';
 import { openEmbeddedReaderHome } from '@/lib/moke-reader';
 
 const DEMO_LIBRARY_URL = 'https://demo.talebook.org';
+const COPY_FEEDBACK_DURATION_MS = 2000;
 
 export default function WelcomePage() {
   const router = useRouter();
@@ -22,6 +23,11 @@ export default function WelcomePage() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
   const [demoLinkCopied, setDemoLinkCopied] = useState(false);
+  const copyFeedbackTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => () => {
+    if (copyFeedbackTimerRef.current) clearTimeout(copyFeedbackTimerRef.current);
+  }, []);
 
   // 主页版本号连点 8 次：解锁并直接进入开发者选项（无任何提示）
   const versionClicksRef = useRef(0);
@@ -123,9 +129,17 @@ export default function WelcomePage() {
   const handleCopyDemoLink = async () => {
     setError('');
     setDemoLinkCopied(false);
+    if (copyFeedbackTimerRef.current) {
+      clearTimeout(copyFeedbackTimerRef.current);
+      copyFeedbackTimerRef.current = null;
+    }
     const copied = await copyTextToClipboard(DEMO_LIBRARY_URL);
     if (copied) {
       setDemoLinkCopied(true);
+      copyFeedbackTimerRef.current = setTimeout(() => {
+        setDemoLinkCopied(false);
+        copyFeedbackTimerRef.current = null;
+      }, COPY_FEEDBACK_DURATION_MS);
       return;
     }
     setError(`复制链接失败，请手动复制：${DEMO_LIBRARY_URL}`);

--- a/src/components/providers/AppShell.tsx
+++ b/src/components/providers/AppShell.tsx
@@ -10,8 +10,6 @@ import {
 } from '@/lib/moke-reader';
 import { useDeveloperStore } from '@/lib/store/developer';
 import { resolveTheme, useSettingsStore } from '@/lib/store/settings';
-import { ReaderProgressProvider } from './ReaderProgressProvider';
-import { ServerProvider } from './ServerProvider';
 import { NativeBackNavigation } from './NativeBackNavigation';
 import { PrivacyConsentGate } from './PrivacyConsentGate';
 
@@ -152,11 +150,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
     <>
       <div className="moke-app-root">
         <NativeBackNavigation />
-        <PrivacyConsentGate>
-          <ServerProvider>
-            <ReaderProgressProvider>{children}</ReaderProgressProvider>
-          </ServerProvider>
-        </PrivacyConsentGate>
+        <PrivacyConsentGate>{children}</PrivacyConsentGate>
       </div>
       <DebugLogPanel />
     </>

--- a/src/components/providers/AppShell.tsx
+++ b/src/components/providers/AppShell.tsx
@@ -12,6 +12,8 @@ import { useDeveloperStore } from '@/lib/store/developer';
 import { resolveTheme, useSettingsStore } from '@/lib/store/settings';
 import { ReaderProgressProvider } from './ReaderProgressProvider';
 import { ServerProvider } from './ServerProvider';
+import { NativeBackNavigation } from './NativeBackNavigation';
+import { PrivacyConsentGate } from './PrivacyConsentGate';
 
 // 开发环境尽早 patch console，使 console.error/warn/log 也进入调试面板。
 // 生产环境默认不启用（见下方 useEffect 的开发者解锁门控），避免为所有用户
@@ -149,9 +151,12 @@ export function AppShell({ children }: { children: React.ReactNode }) {
   return (
     <>
       <div className="moke-app-root">
-        <ServerProvider>
-          <ReaderProgressProvider>{children}</ReaderProgressProvider>
-        </ServerProvider>
+        <NativeBackNavigation />
+        <PrivacyConsentGate>
+          <ServerProvider>
+            <ReaderProgressProvider>{children}</ReaderProgressProvider>
+          </ServerProvider>
+        </PrivacyConsentGate>
       </div>
       <DebugLogPanel />
     </>

--- a/src/components/providers/NativeBackNavigation.tsx
+++ b/src/components/providers/NativeBackNavigation.tsx
@@ -1,17 +1,32 @@
 'use client';
 
-import { useEffect } from 'react';
-import { useRouter } from 'next/navigation';
+import { useEffect, useRef } from 'react';
+import { usePathname, useRouter } from 'next/navigation';
+import { resolveNativeBackTarget } from '@/lib/native-back';
 
 /** Receives Android BACK events forwarded by MainActivity on nested pages. */
 export function NativeBackNavigation() {
   const router = useRouter();
+  const pathname = usePathname();
+  const routeStackRef = useRef<string[]>([]);
 
   useEffect(() => {
-    const handleNativeBack = () => router.back();
+    if (routeStackRef.current.at(-1) !== pathname) {
+      routeStackRef.current.push(pathname);
+    }
+  }, [pathname]);
+
+  useEffect(() => {
+    const handleNativeBack = () => {
+      const { target, nextStack } = resolveNativeBackTarget(pathname, routeStackRef.current);
+      routeStackRef.current = nextStack;
+      // Use a known app route instead of WebView/browser history. The latter
+      // can contain full-document entries and reload the static Tauri page.
+      router.replace(target);
+    };
     window.addEventListener('moke:native-back', handleNativeBack);
     return () => window.removeEventListener('moke:native-back', handleNativeBack);
-  }, [router]);
+  }, [pathname, router]);
 
   return null;
 }

--- a/src/components/providers/NativeBackNavigation.tsx
+++ b/src/components/providers/NativeBackNavigation.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+
+/** Receives Android BACK events forwarded by MainActivity on nested pages. */
+export function NativeBackNavigation() {
+  const router = useRouter();
+
+  useEffect(() => {
+    const handleNativeBack = () => router.back();
+    window.addEventListener('moke:native-back', handleNativeBack);
+    return () => window.removeEventListener('moke:native-back', handleNativeBack);
+  }, [router]);
+
+  return null;
+}
+
+declare global {
+  interface WindowEventMap {
+    'moke:native-back': Event;
+  }
+}

--- a/src/components/providers/PrivacyConsentGate.tsx
+++ b/src/components/providers/PrivacyConsentGate.tsx
@@ -7,6 +7,8 @@ import {
   acceptCurrentPrivacyPolicy,
   hasAcceptedCurrentPrivacyPolicy,
 } from '@/lib/privacy-consent';
+import { ReaderProgressProvider } from './ReaderProgressProvider';
+import { ServerProvider } from './ServerProvider';
 
 type ConsentState = 'loading' | 'pending' | 'accepted' | 'declined';
 
@@ -15,16 +17,24 @@ export function PrivacyConsentGate({ children }: { children: React.ReactNode }) 
   const router = useRouter();
   const [state, setState] = useState<ConsentState>('loading');
   const [isExiting, setIsExiting] = useState(false);
+  const isTauriApp = process.env.NEXT_PUBLIC_APP_PLATFORM === 'tauri';
 
   useEffect(() => {
     setState(hasAcceptedCurrentPrivacyPolicy() ? 'accepted' : 'pending');
   }, []);
 
-  // The local policy page must remain readable before consent. ServerProvider
-  // also treats this path as public, so opening it cannot start server sync.
+  // Keep the policy readable before consent without mounting ServerProvider.
+  // This makes the "no server sync before consent" boundary structural rather
+  // than dependent on ServerProvider's public-path list.
   if (pathname === '/privacy') return <>{children}</>;
 
-  if (state === 'accepted') return <>{children}</>;
+  if (state === 'accepted') {
+    return (
+      <ServerProvider>
+        <ReaderProgressProvider>{children}</ReaderProgressProvider>
+      </ServerProvider>
+    );
+  }
 
   const handleAccept = () => {
     acceptCurrentPrivacyPolicy();
@@ -33,7 +43,7 @@ export function PrivacyConsentGate({ children }: { children: React.ReactNode }) 
 
   const handleDecline = async () => {
     setIsExiting(true);
-    if (process.env.NEXT_PUBLIC_APP_PLATFORM === 'tauri') {
+    if (isTauriApp) {
       try {
         const { exit } = await import('@tauri-apps/plugin-process');
         await exit(0);
@@ -41,8 +51,6 @@ export function PrivacyConsentGate({ children }: { children: React.ReactNode }) 
       } catch (error) {
         console.warn('Unable to exit after privacy policy refusal:', error);
       }
-    } else {
-      window.close();
     }
     setIsExiting(false);
     setState('declined');
@@ -75,7 +83,9 @@ export function PrivacyConsentGate({ children }: { children: React.ReactNode }) 
         {state === 'declined' ? (
           <div className="space-y-5">
             <p className="text-sm leading-7 text-foreground/90">
-              你已拒绝隐私政策，Moke 不会连接书库或处理相关数据。你可以退出应用，或重新阅读后作出选择。
+              {isTauriApp
+                ? '你已拒绝隐私政策，Moke 不会连接书库或处理相关数据。你可以退出应用，或重新阅读后作出选择。'
+                : '你已拒绝隐私政策，Moke 不会连接书库或处理相关数据。你可以重新阅读后作出选择，或手动关闭此页面。'}
             </p>
             <div className="flex flex-col gap-3 sm:flex-row">
               <button
@@ -85,14 +95,16 @@ export function PrivacyConsentGate({ children }: { children: React.ReactNode }) 
               >
                 重新选择
               </button>
-              <button
-                type="button"
-                onClick={() => void handleDecline()}
-                disabled={isExiting}
-                className="h-11 flex-1 rounded-2xl bg-primary text-sm font-medium text-primary-foreground disabled:opacity-50"
-              >
-                {isExiting ? '正在退出…' : '退出应用'}
-              </button>
+              {isTauriApp && (
+                <button
+                  type="button"
+                  onClick={() => void handleDecline()}
+                  disabled={isExiting}
+                  className="h-11 flex-1 rounded-2xl bg-primary text-sm font-medium text-primary-foreground disabled:opacity-50"
+                >
+                  {isExiting ? '正在退出…' : '退出应用'}
+                </button>
+              )}
             </div>
           </div>
         ) : (

--- a/src/components/providers/PrivacyConsentGate.tsx
+++ b/src/components/providers/PrivacyConsentGate.tsx
@@ -1,0 +1,150 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { usePathname, useRouter } from 'next/navigation';
+import { ShieldCheck } from 'lucide-react';
+import {
+  acceptCurrentPrivacyPolicy,
+  hasAcceptedCurrentPrivacyPolicy,
+} from '@/lib/privacy-consent';
+
+type ConsentState = 'loading' | 'pending' | 'accepted' | 'declined';
+
+export function PrivacyConsentGate({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+  const router = useRouter();
+  const [state, setState] = useState<ConsentState>('loading');
+  const [isExiting, setIsExiting] = useState(false);
+
+  useEffect(() => {
+    setState(hasAcceptedCurrentPrivacyPolicy() ? 'accepted' : 'pending');
+  }, []);
+
+  // The local policy page must remain readable before consent. ServerProvider
+  // also treats this path as public, so opening it cannot start server sync.
+  if (pathname === '/privacy') return <>{children}</>;
+
+  if (state === 'accepted') return <>{children}</>;
+
+  const handleAccept = () => {
+    acceptCurrentPrivacyPolicy();
+    setState('accepted');
+  };
+
+  const handleDecline = async () => {
+    setIsExiting(true);
+    if (process.env.NEXT_PUBLIC_APP_PLATFORM === 'tauri') {
+      try {
+        const { exit } = await import('@tauri-apps/plugin-process');
+        await exit(0);
+        return;
+      } catch (error) {
+        console.warn('Unable to exit after privacy policy refusal:', error);
+      }
+    } else {
+      window.close();
+    }
+    setIsExiting(false);
+    setState('declined');
+  };
+
+  if (state === 'loading') {
+    return <div className="min-h-dvh app-warm-bg" aria-label="正在加载隐私设置" />;
+  }
+
+  return (
+    <div className="fixed inset-0 z-[200] flex items-center justify-center overflow-y-auto app-warm-bg px-4 py-8">
+      <section
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="privacy-consent-title"
+        className="w-full max-w-lg rounded-[28px] border border-amber-950/10 bg-background p-6 shadow-2xl sm:p-8"
+      >
+        <div className="mb-5 flex items-center gap-3">
+          <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-2xl bg-primary/10 text-primary">
+            <ShieldCheck className="h-6 w-6" />
+          </div>
+          <div>
+            <h1 id="privacy-consent-title" className="text-xl font-semibold text-foreground">
+              隐私政策提示
+            </h1>
+            <p className="mt-0.5 text-xs text-muted-foreground">请在使用 Moke 前仔细阅读</p>
+          </div>
+        </div>
+
+        {state === 'declined' ? (
+          <div className="space-y-5">
+            <p className="text-sm leading-7 text-foreground/90">
+              你已拒绝隐私政策，Moke 不会连接书库或处理相关数据。你可以退出应用，或重新阅读后作出选择。
+            </p>
+            <div className="flex flex-col gap-3 sm:flex-row">
+              <button
+                type="button"
+                onClick={() => setState('pending')}
+                className="h-11 flex-1 rounded-2xl border border-amber-950/10 bg-white/60 text-sm font-medium text-foreground"
+              >
+                重新选择
+              </button>
+              <button
+                type="button"
+                onClick={() => void handleDecline()}
+                disabled={isExiting}
+                className="h-11 flex-1 rounded-2xl bg-primary text-sm font-medium text-primary-foreground disabled:opacity-50"
+              >
+                {isExiting ? '正在退出…' : '退出应用'}
+              </button>
+            </div>
+          </div>
+        ) : (
+          <>
+            <div className="max-h-[45vh] space-y-3 overflow-y-auto rounded-2xl border border-border bg-muted/30 p-4 text-sm leading-6 text-foreground/90">
+              <p>
+                Moke 用于连接你自行选择的 Talebook 服务器。只有在你同意后，应用才会开始连接服务器并处理书库数据。
+              </p>
+              <ul className="list-disc space-y-2 pl-5">
+                <li>服务器地址、账号资料、书库内容和阅读进度仅用于连接及阅读功能。</li>
+                <li>离线书籍、阅读数据和应用设置主要保存在你的设备本地。</li>
+                <li>更新检查可能访问 GitHub；仅在服务器要求时加载验证码服务。</li>
+                <li>剪贴板、文件和系统语音等能力只在你主动使用对应功能时调用。</li>
+                <li>Moke 不集成广告、用户行为分析或跨应用追踪服务。</li>
+              </ul>
+              <p>
+                你可以在系统设置中撤回权限，或通过清除应用数据、卸载应用删除本地数据。服务器端数据由你所连接的服务器运营者管理。
+              </p>
+            </div>
+
+            <button
+              type="button"
+              onClick={() => router.push('/privacy')}
+              className="mt-4 text-sm font-medium text-primary underline-offset-4 hover:underline"
+            >
+              查看完整《Moke 隐私政策》
+            </button>
+
+            <p className="mt-4 text-xs leading-5 text-muted-foreground">
+              点击“同意并继续”表示你已阅读并同意隐私政策。点击“拒绝并退出”后，应用不会进入书库或发起服务器同步。
+            </p>
+
+            <div className="mt-6 flex flex-col-reverse gap-3 sm:flex-row">
+              <button
+                type="button"
+                onClick={() => void handleDecline()}
+                disabled={isExiting}
+                className="h-11 flex-1 rounded-2xl border border-amber-950/10 bg-white/60 text-sm font-medium text-foreground disabled:opacity-50"
+              >
+                {isExiting ? '正在退出…' : '拒绝并退出'}
+              </button>
+              <button
+                type="button"
+                onClick={handleAccept}
+                className="h-11 flex-1 rounded-2xl bg-primary text-sm font-medium text-primary-foreground shadow-lg shadow-primary/15"
+              >
+                同意并继续
+              </button>
+            </div>
+          </>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/components/providers/ServerProvider.tsx
+++ b/src/components/providers/ServerProvider.tsx
@@ -14,7 +14,7 @@ export function ServerProvider({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
   const { serverUrl, hasHydrated, capabilities, setServerTitle, setUser, setServerCapabilities } = useServerStore();
 
-  const publicPaths = ['/welcome', '/login', '/register', '/access', '/settings/developer'];
+  const publicPaths = ['/welcome', '/login', '/register', '/access', '/privacy', '/settings/developer'];
 
   // 拓展管理页面是本地功能，不需要连接服务器
   const isExtensionPath = pathname.startsWith('/extensions');

--- a/src/lib/native-back.ts
+++ b/src/lib/native-back.ts
@@ -1,0 +1,37 @@
+const FALLBACK_ROUTES: Record<string, string> = {
+  '/about': '/settings',
+  '/access': '/welcome',
+  '/detail': '/library',
+  '/extensions/detail': '/extensions',
+  '/extensions/view': '/extensions',
+  '/library': '/shelf',
+  '/login': '/welcome',
+  '/network-book': '/library',
+  '/privacy': '/',
+  '/register': '/welcome',
+  '/reset-password': '/login',
+  '/search': '/shelf',
+  '/settings': '/shelf',
+  '/settings/developer': '/settings',
+  '/user': '/shelf',
+  '/user/history': '/user',
+};
+
+export function nativeBackFallback(pathname: string): string {
+  return FALLBACK_ROUTES[pathname] ?? '/shelf';
+}
+
+export function resolveNativeBackTarget(
+  pathname: string,
+  routeStack: readonly string[],
+): { target: string; nextStack: string[] } {
+  const nextStack = [...routeStack];
+  if (nextStack.at(-1) !== pathname) nextStack.push(pathname);
+  if (nextStack.at(-1) === pathname) nextStack.pop();
+
+  const previous = nextStack.at(-1);
+  return {
+    target: previous && previous !== pathname ? previous : nativeBackFallback(pathname),
+    nextStack,
+  };
+}

--- a/src/lib/privacy-consent.ts
+++ b/src/lib/privacy-consent.ts
@@ -1,0 +1,15 @@
+import {
+  safeGetLocalStorageItem,
+  safeSetLocalStorageItem,
+} from './browser-storage.ts';
+
+export const PRIVACY_CONSENT_STORAGE_KEY = 'moke-privacy-consent';
+export const PRIVACY_POLICY_VERSION = '2026-08-14';
+
+export function hasAcceptedCurrentPrivacyPolicy(): boolean {
+  return safeGetLocalStorageItem(PRIVACY_CONSENT_STORAGE_KEY) === PRIVACY_POLICY_VERSION;
+}
+
+export function acceptCurrentPrivacyPolicy(): void {
+  safeSetLocalStorageItem(PRIVACY_CONSENT_STORAGE_KEY, PRIVACY_POLICY_VERSION);
+}

--- a/tests/android-back.test.mjs
+++ b/tests/android-back.test.mjs
@@ -1,0 +1,21 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const activitySource = readFileSync(
+  fileURLToPath(new URL('../src-tauri/android/MainActivity.kt', import.meta.url)),
+  'utf8',
+);
+
+test('Android 应用根页返回键提供二次确认并退出任务', () => {
+  assert.match(activitySource, /再按一次退出应用/);
+  assert.match(activitySource, /finishAndRemoveTask\(\)/);
+  assert.match(activitySource, /\/welcome/);
+  assert.match(activitySource, /\/shelf/);
+});
+
+test('Android 非根页返回键交给 Next 路由且不覆盖阅读器拦截', () => {
+  assert.match(activitySource, /moke:native-back/);
+  assert.match(activitySource, /!interceptBackKeyEnabled/);
+});

--- a/tests/android-back.test.mjs
+++ b/tests/android-back.test.mjs
@@ -13,9 +13,11 @@ test('Android 应用根页返回键提供二次确认并退出任务', () => {
   assert.match(activitySource, /finishAndRemoveTask\(\)/);
   assert.match(activitySource, /\/welcome/);
   assert.match(activitySource, /\/shelf/);
+  assert.match(activitySource, /removeSuffix\("\.html"\)/);
 });
 
 test('Android 非根页返回键交给 Next 路由且不覆盖阅读器拦截', () => {
   assert.match(activitySource, /moke:native-back/);
   assert.match(activitySource, /!interceptBackKeyEnabled/);
+  assert.match(activitySource, /isEmbeddedReaderRoute\(\)/);
 });

--- a/tests/native-back.test.mjs
+++ b/tests/native-back.test.mjs
@@ -1,0 +1,24 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  nativeBackFallback,
+  resolveNativeBackTarget,
+} from '../src/lib/native-back.ts';
+
+test('原生返回优先使用应用内路由栈，不依赖浏览器历史', () => {
+  assert.deepEqual(resolveNativeBackTarget('/detail', ['/shelf', '/library', '/detail']), {
+    target: '/library',
+    nextStack: ['/shelf', '/library'],
+  });
+});
+
+test('刷新后路由栈为空时返回确定的上级页面', () => {
+  assert.equal(nativeBackFallback('/settings/developer'), '/settings');
+  assert.equal(nativeBackFallback('/user/history'), '/user');
+  assert.equal(nativeBackFallback('/detail'), '/library');
+  assert.deepEqual(resolveNativeBackTarget('/search', []), {
+    target: '/shelf',
+    nextStack: [],
+  });
+});

--- a/tests/privacy-consent.test.mjs
+++ b/tests/privacy-consent.test.mjs
@@ -1,0 +1,49 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import {
+  acceptCurrentPrivacyPolicy,
+  hasAcceptedCurrentPrivacyPolicy,
+  PRIVACY_CONSENT_STORAGE_KEY,
+  PRIVACY_POLICY_VERSION,
+} from '../src/lib/privacy-consent.ts';
+
+const appShellSource = readFileSync(
+  fileURLToPath(new URL('../src/components/providers/AppShell.tsx', import.meta.url)),
+  'utf8',
+);
+const consentGateSource = readFileSync(
+  fileURLToPath(new URL('../src/components/providers/PrivacyConsentGate.tsx', import.meta.url)),
+  'utf8',
+);
+
+test('当前版本隐私政策只有明确同意后才会放行', () => {
+  const values = new Map();
+  globalThis.window = {
+    localStorage: {
+      getItem: (key) => values.get(key) ?? null,
+      setItem: (key, value) => values.set(key, value),
+      removeItem: (key) => values.delete(key),
+    },
+  };
+
+  assert.equal(hasAcceptedCurrentPrivacyPolicy(), false);
+  values.set(PRIVACY_CONSENT_STORAGE_KEY, 'old-policy-version');
+  assert.equal(hasAcceptedCurrentPrivacyPolicy(), false);
+
+  acceptCurrentPrivacyPolicy();
+  assert.equal(values.get(PRIVACY_CONSENT_STORAGE_KEY), PRIVACY_POLICY_VERSION);
+  assert.equal(hasAcceptedCurrentPrivacyPolicy(), true);
+});
+
+test('隐私确认门在服务器同步组件之外，且提供同意与拒绝操作', () => {
+  assert.match(
+    appShellSource,
+    /<PrivacyConsentGate>[\s\S]*<ServerProvider>[\s\S]*<\/ServerProvider>[\s\S]*<\/PrivacyConsentGate>/,
+  );
+  assert.match(consentGateSource, /同意并继续/);
+  assert.match(consentGateSource, /拒绝并退出/);
+  assert.match(consentGateSource, /@tauri-apps\/plugin-process/);
+});

--- a/tests/privacy-consent.test.mjs
+++ b/tests/privacy-consent.test.mjs
@@ -39,10 +39,9 @@ test('当前版本隐私政策只有明确同意后才会放行', () => {
 });
 
 test('隐私确认门在服务器同步组件之外，且提供同意与拒绝操作', () => {
-  assert.match(
-    appShellSource,
-    /<PrivacyConsentGate>[\s\S]*<ServerProvider>[\s\S]*<\/ServerProvider>[\s\S]*<\/PrivacyConsentGate>/,
-  );
+  assert.match(appShellSource, /<PrivacyConsentGate>\{children\}<\/PrivacyConsentGate>/);
+  assert.match(consentGateSource, /pathname === '\/privacy'[\s\S]*return <>\{children\}<\/>/);
+  assert.match(consentGateSource, /state === 'accepted'[\s\S]*<ServerProvider>/);
   assert.match(consentGateSource, /同意并继续/);
   assert.match(consentGateSource, /拒绝并退出/);
   assert.match(consentGateSource, /@tauri-apps\/plugin-process/);

--- a/tests/responsive-smoke.spec.mjs
+++ b/tests/responsive-smoke.spec.mjs
@@ -9,6 +9,12 @@ const states = [
 test('responsive navigation remains usable across device sizes', async ({ page }, testInfo) => {
   await page.goto('http://127.0.0.1:3000/settings/developer', { waitUntil: 'domcontentloaded' });
 
+  // First launch is intentionally blocked by the privacy consent gate. Verify
+  // that the prompt appears, then explicitly accept before testing app chrome.
+  const consentButton = page.getByRole('button', { name: '同意并继续' });
+  await expect(consentButton).toBeVisible();
+  await consentButton.click();
+
   for (const state of states) {
     await page.setViewportSize({ width: state.width, height: state.height });
     await page.reload({ waitUntil: 'domcontentloaded' });

--- a/tests/welcome-demo-link.test.mjs
+++ b/tests/welcome-demo-link.test.mjs
@@ -17,3 +17,9 @@ test('连接页只复制演示书库链接，不再直接连接或打开站点',
     /handleConnect\(['"]https:\/\/demo\.talebook\.org['"]\)/,
   );
 });
+
+test('复制成功提示会在短暂展示后自动复位', () => {
+  assert.match(welcomeSource, /COPY_FEEDBACK_DURATION_MS\s*=\s*2000/);
+  assert.match(welcomeSource, /setDemoLinkCopied\(false\)/);
+  assert.match(welcomeSource, /copyFeedbackTimerRef\.current\s*=\s*setTimeout/);
+});


### PR DESCRIPTION
## 修改内容

- 修复 Android 返回键被 WebView 默认历史处理导致页面刷新的问题：根页二次返回退出，其他页面走 Next 路由返回
- 增加首次启动隐私政策确认，同意前不启动服务器同步，拒绝后退出应用
- 增加本地完整隐私政策页面和设置入口
- 修复复制链接后“已复制”状态不自动复位的问题
- 补充返回键、隐私确认和复制状态测试

## 验证

- pnpm test（149/149）
- pnpm typecheck
- pnpm lint（0 errors，25 个既有 warnings）
- pnpm build

## 备注

- Android 原生返回键行为仍建议在实体设备上做一次 APK 冒烟验证。
