### PR TITLE
feat: 优化隐私确认与撤回交互

### DIFF
--- a/src/app/privacy/privacy-back-button.tsx
+++ b/src/app/privacy/privacy-back-button.tsx
@@ -1,19 +1,46 @@
 'use client';
 
-import { ArrowLeft } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { ArrowLeft, ShieldX } from 'lucide-react';
 import { useRouter } from 'next/navigation';
+import {
+  hasAcceptedCurrentPrivacyPolicy,
+  revokeCurrentPrivacyPolicy,
+} from '@/lib/privacy-consent';
 
 export function PrivacyBackButton() {
   const router = useRouter();
+  const [canRevoke, setCanRevoke] = useState(false);
+
+  useEffect(() => {
+    setCanRevoke(hasAcceptedCurrentPrivacyPolicy());
+  }, []);
+
+  const handleRevoke = () => {
+    revokeCurrentPrivacyPolicy();
+    router.replace('/welcome');
+  };
 
   return (
-    <button
-      type="button"
-      onClick={() => router.back()}
-      className="inline-flex h-10 items-center gap-2 rounded-2xl border border-amber-950/10 bg-white/60 px-4 text-sm text-foreground"
-    >
-      <ArrowLeft className="h-4 w-4" />
-      返回
-    </button>
+    <div className="flex flex-wrap items-center justify-between gap-3">
+      <button
+        type="button"
+        onClick={() => router.back()}
+        className="inline-flex h-11 items-center gap-2 rounded-2xl border border-amber-950/10 bg-white/60 px-4 text-sm text-foreground"
+      >
+        <ArrowLeft className="h-4 w-4" />
+        返回
+      </button>
+      {canRevoke && (
+        <button
+          type="button"
+          onClick={handleRevoke}
+          className="inline-flex min-h-11 items-center gap-2 rounded-2xl px-4 text-sm text-muted-foreground transition hover:bg-destructive/5 hover:text-destructive"
+        >
+          <ShieldX className="h-4 w-4" />
+          撤回同意
+        </button>
+      )}
+    </div>
   );
 }

--- a/src/components/providers/PrivacyConsentGate.tsx
+++ b/src/components/providers/PrivacyConsentGate.tsx
@@ -6,6 +6,7 @@ import { ShieldCheck } from 'lucide-react';
 import {
   acceptCurrentPrivacyPolicy,
   hasAcceptedCurrentPrivacyPolicy,
+  PRIVACY_CONSENT_CHANGED_EVENT,
 } from '@/lib/privacy-consent';
 import { ReaderProgressProvider } from './ReaderProgressProvider';
 import { ServerProvider } from './ServerProvider';
@@ -20,7 +21,12 @@ export function PrivacyConsentGate({ children }: { children: React.ReactNode }) 
   const isTauriApp = process.env.NEXT_PUBLIC_APP_PLATFORM === 'tauri';
 
   useEffect(() => {
-    setState(hasAcceptedCurrentPrivacyPolicy() ? 'accepted' : 'pending');
+    const syncConsent = () => {
+      setState(hasAcceptedCurrentPrivacyPolicy() ? 'accepted' : 'pending');
+    };
+    syncConsent();
+    window.addEventListener(PRIVACY_CONSENT_CHANGED_EVENT, syncConsent);
+    return () => window.removeEventListener(PRIVACY_CONSENT_CHANGED_EVENT, syncConsent);
   }, []);
 
   // Keep the policy readable before consent without mounting ServerProvider.
@@ -87,11 +93,11 @@ export function PrivacyConsentGate({ children }: { children: React.ReactNode }) 
                 ? '你已拒绝隐私政策，Moke 不会连接书库或处理相关数据。你可以退出应用，或重新阅读后作出选择。'
                 : '你已拒绝隐私政策，Moke 不会连接书库或处理相关数据。你可以重新阅读后作出选择，或手动关闭此页面。'}
             </p>
-            <div className="flex flex-col gap-3 sm:flex-row">
+            <div className="flex flex-col items-center gap-2">
               <button
                 type="button"
                 onClick={() => setState('pending')}
-                className="h-11 flex-1 rounded-2xl border border-amber-950/10 bg-white/60 text-sm font-medium text-foreground"
+                className="h-11 w-full rounded-2xl bg-primary text-base font-semibold text-primary-foreground shadow-lg shadow-primary/15 transition hover:opacity-90 active:opacity-80"
               >
                 重新选择
               </button>
@@ -100,7 +106,7 @@ export function PrivacyConsentGate({ children }: { children: React.ReactNode }) 
                   type="button"
                   onClick={() => void handleDecline()}
                   disabled={isExiting}
-                  className="h-11 flex-1 rounded-2xl bg-primary text-sm font-medium text-primary-foreground disabled:opacity-50"
+                  className="min-h-10 w-full text-center text-xs text-muted-foreground transition hover:text-foreground disabled:opacity-50"
                 >
                   {isExiting ? '正在退出…' : '退出应用'}
                 </button>
@@ -137,21 +143,21 @@ export function PrivacyConsentGate({ children }: { children: React.ReactNode }) 
               点击“同意并继续”表示你已阅读并同意隐私政策。点击“拒绝并退出”后，应用不会进入书库或发起服务器同步。
             </p>
 
-            <div className="mt-6 flex flex-col-reverse gap-3 sm:flex-row">
+            <div className="mt-6 flex flex-col items-center gap-2">
+              <button
+                type="button"
+                onClick={handleAccept}
+                className="h-11 w-full rounded-2xl bg-primary text-base font-semibold text-primary-foreground shadow-lg shadow-primary/15 transition hover:opacity-90 active:opacity-80"
+              >
+                同意并继续
+              </button>
               <button
                 type="button"
                 onClick={() => void handleDecline()}
                 disabled={isExiting}
-                className="h-11 flex-1 rounded-2xl border border-amber-950/10 bg-white/60 text-sm font-medium text-foreground disabled:opacity-50"
+                className="min-h-10 w-full text-center text-xs text-muted-foreground transition hover:text-foreground disabled:opacity-50"
               >
                 {isExiting ? '正在退出…' : '拒绝并退出'}
-              </button>
-              <button
-                type="button"
-                onClick={handleAccept}
-                className="h-11 flex-1 rounded-2xl bg-primary text-sm font-medium text-primary-foreground shadow-lg shadow-primary/15"
-              >
-                同意并继续
               </button>
             </div>
           </>

--- a/src/lib/privacy-consent.ts
+++ b/src/lib/privacy-consent.ts
@@ -1,10 +1,18 @@
 import {
   safeGetLocalStorageItem,
+  safeRemoveLocalStorageItem,
   safeSetLocalStorageItem,
 } from './browser-storage.ts';
 
 export const PRIVACY_CONSENT_STORAGE_KEY = 'moke-privacy-consent';
 export const PRIVACY_POLICY_VERSION = '2026-08-14';
+export const PRIVACY_CONSENT_CHANGED_EVENT = 'moke:privacy-consent-changed';
+
+function notifyPrivacyConsentChanged(): void {
+  if (typeof window !== 'undefined' && typeof window.dispatchEvent === 'function') {
+    window.dispatchEvent(new Event(PRIVACY_CONSENT_CHANGED_EVENT));
+  }
+}
 
 export function hasAcceptedCurrentPrivacyPolicy(): boolean {
   return safeGetLocalStorageItem(PRIVACY_CONSENT_STORAGE_KEY) === PRIVACY_POLICY_VERSION;
@@ -12,4 +20,10 @@ export function hasAcceptedCurrentPrivacyPolicy(): boolean {
 
 export function acceptCurrentPrivacyPolicy(): void {
   safeSetLocalStorageItem(PRIVACY_CONSENT_STORAGE_KEY, PRIVACY_POLICY_VERSION);
+  notifyPrivacyConsentChanged();
+}
+
+export function revokeCurrentPrivacyPolicy(): void {
+  safeRemoveLocalStorageItem(PRIVACY_CONSENT_STORAGE_KEY);
+  notifyPrivacyConsentChanged();
 }

--- a/tests/privacy-consent.test.mjs
+++ b/tests/privacy-consent.test.mjs
@@ -8,6 +8,7 @@ import {
   hasAcceptedCurrentPrivacyPolicy,
   PRIVACY_CONSENT_STORAGE_KEY,
   PRIVACY_POLICY_VERSION,
+  revokeCurrentPrivacyPolicy,
 } from '../src/lib/privacy-consent.ts';
 
 const appShellSource = readFileSync(
@@ -36,6 +37,10 @@ test('当前版本隐私政策只有明确同意后才会放行', () => {
   acceptCurrentPrivacyPolicy();
   assert.equal(values.get(PRIVACY_CONSENT_STORAGE_KEY), PRIVACY_POLICY_VERSION);
   assert.equal(hasAcceptedCurrentPrivacyPolicy(), true);
+
+  revokeCurrentPrivacyPolicy();
+  assert.equal(values.has(PRIVACY_CONSENT_STORAGE_KEY), false);
+  assert.equal(hasAcceptedCurrentPrivacyPolicy(), false);
 });
 
 test('隐私确认门在服务器同步组件之外，且提供同意与拒绝操作', () => {

--- a/tests/responsive-smoke.spec.mjs
+++ b/tests/responsive-smoke.spec.mjs
@@ -37,3 +37,16 @@ test('responsive navigation remains usable across device sizes', async ({ page }
     });
   }
 });
+
+test('privacy consent can be revoked from the policy page', async ({ page }) => {
+  await page.goto('http://127.0.0.1:3000/settings/developer', { waitUntil: 'domcontentloaded' });
+  await page.getByRole('button', { name: '同意并继续' }).click();
+
+  await page.goto('http://127.0.0.1:3000/privacy', { waitUntil: 'domcontentloaded' });
+  const revokeButton = page.getByRole('button', { name: '撤回同意' });
+  await expect(revokeButton).toBeVisible();
+  await revokeButton.click();
+
+  await expect(page.getByRole('heading', { name: '隐私政策提示' })).toBeVisible();
+  await expect(page.getByRole('button', { name: '同意并继续' })).toBeVisible();
+});


### PR DESCRIPTION
## 修改内容

- 将“同意并继续”和“重新选择”调整为与登录按钮一致的全宽主按钮
- 将“拒绝并退出”和“退出应用”调整为主按钮下方居中的灰色文字操作，同时保留足够点击区域
- 在完整隐私政策页为已同意用户增加“撤回同意”入口
- 撤回后立即清除同意状态、卸载服务器同步 Provider，并重新显示隐私确认门
- 增加隐私同意撤回单测和浏览器端到端烟测

## 验证

- pnpm test（151/151）
- pnpm typecheck
- pnpm lint（0 errors，25 个既有 warnings）
- Playwright responsive smoke（2/2）
