### PR TITLE
fix: unify Android back navigation and reader transitions

### DIFF
--- a/src-tauri/android/MainActivity.kt
+++ b/src-tauri/android/MainActivity.kt
@@ -33,7 +33,7 @@ class MainActivity : TauriActivity(), KeyDownInterceptor {
 
     companion object {
         private const val EXIT_CONFIRM_WINDOW_MS = 2_000L
-        private val APP_EXIT_ROUTES = setOf("/", "/welcome", "/shelf")
+        private val APP_EXIT_ROUTES = setOf("/", "/welcome", "/shelf", "/library", "/user")
     }
 
     // DOWN 已被本 Activity 消费（并转发到 webview）的按键集合。被拦截的按键

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,11 +1,11 @@
 'use client';
 
-import Link from 'next/link';
 import { useState, useRef } from 'react';
 import { ArrowLeft, BookOpen, Coffee, ExternalLink, HeartHandshake, Info, Sparkles, X } from 'lucide-react';
 import { DesktopLayout } from '@/components/layout/DesktopLayout';
 import { useDeveloperStore } from '@/lib/store/developer';
 import { APP_VERSION } from '@/lib/app-version';
+import { requestAnimatedBack } from '@/lib/native-back';
 
 interface Contributor {
   id: string;
@@ -120,13 +120,14 @@ export default function AboutPage() {
             <h1 className="text-2xl font-semibold text-foreground">关于应用</h1>
             <p className="mt-1 text-sm text-muted-foreground">了解应用定位与项目贡献者</p>
           </div>
-          <Link
-            href="/settings"
+          <button
+            type="button"
+            onClick={() => requestAnimatedBack('/settings')}
             className="inline-flex items-center gap-2 h-10 rounded-2xl border border-amber-950/10 bg-white/60 shadow-sm px-4 text-sm text-foreground transition hover:bg-muted"
           >
             <ArrowLeft className="w-4 h-4" />
             <span>返回设置</span>
-          </Link>
+          </button>
         </div>
 
         <div className="space-y-6">

--- a/src/app/access/page.tsx
+++ b/src/app/access/page.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import Link from 'next/link';
 import { useState, useEffect, Suspense } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { KeyRound } from 'lucide-react';
@@ -8,6 +7,7 @@ import { submitWelcomeCode } from '@/lib/api';
 import { isHttpUrl } from '@/lib/server-url';
 import { useServerStore } from '@/lib/store/server';
 import { CaptchaModal } from '@/components/auth/CaptchaModal';
+import { requestAnimatedBack } from '@/lib/native-back';
 import { debugLog } from '@/lib/debug-log';
 
 function AccessPageInner() {
@@ -125,9 +125,9 @@ function AccessPageInner() {
       <div className="relative w-full max-w-[410px] my-8 overflow-hidden rounded-[32px] app-glass p-10">
         <div className="absolute -right-16 -top-16 h-40 w-40 rounded-full bg-primary/10 blur-2xl" />
         <div className="relative">
-        <Link href="/welcome" className="absolute -top-2 -left-2 w-8 h-8 rounded-full bg-muted hover:bg-muted/80 flex items-center justify-center transition-colors">
+        <button type="button" onClick={() => requestAnimatedBack('/welcome')} aria-label="返回" className="absolute -top-2 -left-2 w-8 h-8 rounded-full bg-muted hover:bg-muted/80 flex items-center justify-center transition-colors">
           <svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4 text-foreground" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M15 18l-6-6 6-6"/></svg>
-        </Link>
+        </button>
         <div className="flex justify-center mb-8">
           <div className="w-16 h-16 rounded-2xl bg-primary shadow-lg shadow-primary/15 flex items-center justify-center">
             <KeyRound className="w-7 h-7 text-primary-foreground" />

--- a/src/app/detail/page.tsx
+++ b/src/app/detail/page.tsx
@@ -3,6 +3,7 @@
 import { Suspense, useState, useEffect, useRef } from 'react';
 import { useSearchParams, useRouter } from 'next/navigation';
 import { ArrowLeft, ChevronRight, Star, FileText, HardDrive, Calendar, BookOpen, Building2, Barcode, Tags, Users, LibraryBig, FileBadge2, Bookmark, Trash2 } from 'lucide-react';
+import { requestAnimatedBack } from '@/lib/native-back';
 import { DesktopLayout } from '@/components/layout/DesktopLayout';
 import { getErrorMessage, MokeApiError, readApiJson, request } from '@/lib/api';
 import { deleteOfflineBook, getOfflineBook } from '@/lib/offline-books';
@@ -415,7 +416,7 @@ function DetailContent() {
     <DesktopLayout>
       <div className="flex-1 overflow-y-auto px-4 py-5 sm:px-6 md:px-8 md:py-8">
         <div className="mb-6 rounded-[24px] app-card px-4 py-4 sm:mb-8 sm:rounded-[28px] sm:px-5">
-          <button onClick={() => router.back()} className="inline-flex items-center gap-1.5 text-sm mb-2 text-muted-foreground transition-colors hover:text-foreground group">
+          <button onClick={() => requestAnimatedBack()} className="inline-flex items-center gap-1.5 text-sm mb-2 text-muted-foreground transition-colors hover:text-foreground group">
             <ArrowLeft className="w-4 h-4 group-hover:-translate-x-0.5 transition-transform" />
             <span>返回</span>
           </button>

--- a/src/app/extensions/detail/page.tsx
+++ b/src/app/extensions/detail/page.tsx
@@ -12,6 +12,7 @@ import {
   Trash2,
 } from 'lucide-react';
 import { DesktopLayout } from '@/components/layout/DesktopLayout';
+import { requestAnimatedBack } from '@/lib/native-back';
 import { useExtensionStore, type ExtensionInfo } from '@/lib/store/extensions';
 
 function DetailContent() {
@@ -78,7 +79,7 @@ function DetailContent() {
             <Puzzle className="w-10 h-10 text-muted-foreground/40 mb-4" />
             <p className="text-sm text-muted-foreground">未找到拓展「{name}」</p>
             <button
-              onClick={() => router.push('/extensions')}
+              onClick={() => requestAnimatedBack('/extensions')}
               className="mt-3 text-sm text-primary hover:underline"
             >
               返回拓展列表
@@ -100,7 +101,7 @@ function DetailContent() {
             </div>
           )}
           <button
-            onClick={() => router.push('/extensions')}
+            onClick={() => requestAnimatedBack('/extensions')}
             className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors mb-6"
           >
             <ArrowLeft className="w-4 h-4" />

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -452,11 +452,19 @@
   }
 }
 
+/* Moke and the embedded Readest frontend are separate same-origin documents.
+   Opt in at the document level so every reader entry/exit path participates,
+   including native BACK and reader-owned close buttons. */
+@view-transition {
+  navigation: auto;
+}
+
 /* Android BACK is handled inside the single Tauri WebView, so it does not get
    the Activity transition that a native multi-screen app would receive. The
    View Transition snapshots put the already-rendered parent page underneath
    the current page, then animate only the current page out to the right. */
-html.moke-native-back-transition::view-transition-old(root) {
+html.moke-native-back-transition::view-transition-old(root),
+html[data-moke-reader-transition='exit']::view-transition-old(root) {
   animation-duration: 260ms;
   animation-timing-function: cubic-bezier(0.2, 0, 0, 1);
   animation-fill-mode: both;
@@ -466,7 +474,8 @@ html.moke-native-back-transition::view-transition-old(root) {
   box-shadow: -12px 0 32px rgba(37, 30, 20, 0.16);
 }
 
-html.moke-native-back-transition::view-transition-new(root) {
+html.moke-native-back-transition::view-transition-new(root),
+html[data-moke-reader-transition='exit']::view-transition-new(root) {
   z-index: 1;
   animation: none;
   mix-blend-mode: normal;
@@ -478,12 +487,14 @@ html.moke-native-back-transition::view-transition-new(root) {
 }
 
 @media (prefers-reduced-motion: reduce), (update: slow), (max-color: 1) {
-  html.moke-native-back-transition::view-transition-old(root) {
+  html.moke-native-back-transition::view-transition-old(root),
+  html[data-moke-reader-transition='exit']::view-transition-old(root) {
     animation-duration: 0.01ms !important;
   }
 }
 
-html[data-eink='true'].moke-native-back-transition::view-transition-old(root) {
+html[data-eink='true'].moke-native-back-transition::view-transition-old(root),
+html[data-eink='true'][data-moke-reader-transition='exit']::view-transition-old(root) {
   animation-duration: 0.01ms !important;
 }
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -452,6 +452,41 @@
   }
 }
 
+/* Android BACK is handled inside the single Tauri WebView, so it does not get
+   the Activity transition that a native multi-screen app would receive. The
+   View Transition snapshots put the already-rendered parent page underneath
+   the current page, then animate only the current page out to the right. */
+html.moke-native-back-transition::view-transition-old(root) {
+  animation-duration: 260ms;
+  animation-timing-function: cubic-bezier(0.2, 0, 0, 1);
+  animation-fill-mode: both;
+  mix-blend-mode: normal;
+  z-index: 2;
+  animation-name: moke-native-back-exit;
+  box-shadow: -12px 0 32px rgba(37, 30, 20, 0.16);
+}
+
+html.moke-native-back-transition::view-transition-new(root) {
+  z-index: 1;
+  animation: none;
+  mix-blend-mode: normal;
+}
+
+@keyframes moke-native-back-exit {
+  from { transform: translateX(0); }
+  to { transform: translateX(100%); }
+}
+
+@media (prefers-reduced-motion: reduce), (update: slow), (max-color: 1) {
+  html.moke-native-back-transition::view-transition-old(root) {
+    animation-duration: 0.01ms !important;
+  }
+}
+
+html[data-eink='true'].moke-native-back-transition::view-transition-old(root) {
+  animation-duration: 0.01ms !important;
+}
+
 /* Manual override: force ink mode on any device via the Settings toggle.
    Uses the same [data-eink='true'] signal as the readest reader so the Moke
    bridge (window.__MOKE_EINK) and the reader share one convention. */

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,43 @@ import '@/app/globals.css';
 import type { Viewport } from 'next';
 import { AppShell } from '@/components/providers/AppShell';
 
+function installMokeReaderExitTransition() {
+  window.addEventListener(
+    'pagereveal',
+    (event) => {
+      try {
+        const navigationApi = (window as Window & {
+          navigation?: { activation?: { from?: { url?: string } | null } };
+        }).navigation;
+        const fromUrl = navigationApi?.activation?.from?.url;
+        if (!fromUrl) return;
+        const fromPath = new URL(fromUrl).pathname.replace(/\/$/, '') || '/';
+        if (fromPath !== '/readest' && !fromPath.startsWith('/readest/')) return;
+
+        const root = document.documentElement;
+        root.dataset.mokeReaderTransition = 'exit';
+        const clearMarker = () => {
+          delete root.dataset.mokeReaderTransition;
+        };
+        const transition = (event as Event & {
+          viewTransition?: { finished: Promise<unknown> };
+        }).viewTransition;
+        if (transition) {
+          void transition.finished.finally(clearMarker).catch(() => undefined);
+        } else {
+          clearMarker();
+        }
+        window.setTimeout(clearMarker, 1_000);
+      } catch {
+        // Ignore malformed activation URLs and keep the destination usable.
+      }
+    },
+    { once: true },
+  );
+}
+
+const mokeReaderExitTransitionScript = `(${installMokeReaderExitTransition.toString()})();`;
+
 export const viewport: Viewport = {
   width: 'device-width',
   initialScale: 1,
@@ -16,6 +53,7 @@ export default function RootLayout({
   return (
     <html lang="zh-CN" suppressHydrationWarning>
       <head>
+        <script dangerouslySetInnerHTML={{ __html: mokeReaderExitTransitionScript }} />
         {/* Apply the persisted theme before hydration so the first paint is
             already dark when dark mode is on (no flash of white). Reads the
             zustand persist payload directly; falls back to the OS preference

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -7,6 +7,7 @@ import { BookOpen, Eye, EyeOff } from 'lucide-react';
 import { useServerStore } from '@/lib/store/server';
 import { fetchCurrentUser, request } from '@/lib/api';
 import { CaptchaModal } from '@/components/auth/CaptchaModal';
+import { requestAnimatedBack } from '@/lib/native-back';
 import { safeRemoveLocalStorageItem } from '@/lib/browser-storage';
 
 interface TalebookLoginResponse {
@@ -92,9 +93,9 @@ export default function LoginPage() {
       <div className="relative w-full max-w-[410px] my-8 overflow-hidden rounded-[32px] app-glass p-10">
         <div className="absolute -right-16 -top-16 h-40 w-40 rounded-full bg-primary/10 blur-2xl" />
         <div className="relative">
-        <Link href="/" className="absolute -top-2 -left-2 w-8 h-8 rounded-full bg-muted hover:bg-muted/80 flex items-center justify-center transition-colors">
+        <button type="button" onClick={() => requestAnimatedBack('/')} aria-label="返回" className="absolute -top-2 -left-2 w-8 h-8 rounded-full bg-muted hover:bg-muted/80 flex items-center justify-center transition-colors">
           <svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4 text-foreground" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M15 18l-6-6 6-6"/></svg>
-        </Link>
+        </button>
         <div className="flex justify-center mb-8">
           <div className="w-16 h-16 rounded-2xl bg-primary shadow-lg shadow-primary/15 flex items-center justify-center">
             <BookOpen className="w-7 h-7 text-primary-foreground" />

--- a/src/app/network-book/page.tsx
+++ b/src/app/network-book/page.tsx
@@ -3,6 +3,7 @@
 import { Suspense, useCallback, useEffect, useRef, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { AlertTriangle, ArrowLeft, BookOpen, CheckCircle2, Loader2, Save } from 'lucide-react';
+import { requestAnimatedBack } from '@/lib/native-back';
 import { DesktopLayout } from '@/components/layout/DesktopLayout';
 import { getErrorMessage, MokeApiError } from '@/lib/api';
 import { useServerStore } from '@/lib/store/server';
@@ -139,7 +140,7 @@ function NetworkBookContent() {
       <div className="flex-1 overflow-y-auto px-4 py-5 sm:px-6 md:px-8 md:py-8">
         <div className="mb-6 rounded-[24px] app-card px-4 py-4 sm:mb-8 sm:rounded-[28px] sm:px-5">
           <button
-            onClick={() => router.back()}
+            onClick={() => requestAnimatedBack()}
             className="group inline-flex items-center gap-1.5 text-sm text-muted-foreground transition-colors hover:text-foreground"
           >
             <ArrowLeft className="h-4 w-4 transition-transform group-hover:-translate-x-0.5" />

--- a/src/app/privacy/privacy-back-button.tsx
+++ b/src/app/privacy/privacy-back-button.tsx
@@ -7,6 +7,7 @@ import {
   hasAcceptedCurrentPrivacyPolicy,
   revokeCurrentPrivacyPolicy,
 } from '@/lib/privacy-consent';
+import { requestAnimatedBack } from '@/lib/native-back';
 
 export function PrivacyBackButton() {
   const router = useRouter();
@@ -25,7 +26,7 @@ export function PrivacyBackButton() {
     <div className="flex flex-wrap items-center justify-between gap-3">
       <button
         type="button"
-        onClick={() => router.back()}
+        onClick={() => requestAnimatedBack()}
         className="inline-flex h-11 items-center gap-2 rounded-2xl border border-amber-950/10 bg-white/60 px-4 text-sm text-foreground"
       >
         <ArrowLeft className="h-4 w-4" />

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -7,6 +7,7 @@ import { BookOpen } from 'lucide-react';
 import { useServerStore } from '@/lib/store/server';
 import { request } from '@/lib/api';
 import { CaptchaModal } from '@/components/auth/CaptchaModal';
+import { requestAnimatedBack } from '@/lib/native-back';
 
 export default function RegisterPage() {
   const router = useRouter();
@@ -65,9 +66,9 @@ export default function RegisterPage() {
       <div className="relative w-full max-w-[410px] my-8 overflow-hidden rounded-[32px] app-glass p-10">
         <div className="absolute -right-16 -top-16 h-40 w-40 rounded-full bg-primary/10 blur-2xl" />
         <div className="relative">
-        <Link href="/" className="absolute -top-2 -left-2 w-8 h-8 rounded-full bg-muted hover:bg-muted/80 flex items-center justify-center transition-colors">
+        <button type="button" onClick={() => requestAnimatedBack('/')} aria-label="返回" className="absolute -top-2 -left-2 w-8 h-8 rounded-full bg-muted hover:bg-muted/80 flex items-center justify-center transition-colors">
           <svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4 text-foreground" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M15 18l-6-6 6-6"/></svg>
-        </Link>
+        </button>
         <div className="flex justify-center mb-8">
           <div className="w-16 h-16 rounded-2xl bg-primary shadow-lg shadow-primary/15 flex items-center justify-center">
             <BookOpen className="w-7 h-7 text-primary-foreground" />

--- a/src/app/reset-password/page.tsx
+++ b/src/app/reset-password/page.tsx
@@ -1,12 +1,12 @@
 'use client';
 
-import Link from 'next/link';
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { BookOpen } from 'lucide-react';
 import { useServerStore } from '@/lib/store/server';
 import { request } from '@/lib/api';
 import { CaptchaModal } from '@/components/auth/CaptchaModal';
+import { requestAnimatedBack } from '@/lib/native-back';
 
 interface TalebookResetResponse {
   err: string;
@@ -80,9 +80,9 @@ export default function ResetPasswordPage() {
       <div className="relative w-full max-w-[410px] my-8 overflow-hidden rounded-[32px] app-glass p-10">
         <div className="absolute -right-16 -top-16 h-40 w-40 rounded-full bg-primary/10 blur-2xl" />
         <div className="relative">
-        <Link href="/" className="absolute -top-2 -left-2 w-8 h-8 rounded-full bg-muted hover:bg-muted/80 flex items-center justify-center transition-colors">
+        <button type="button" onClick={() => requestAnimatedBack('/')} aria-label="返回" className="absolute -top-2 -left-2 w-8 h-8 rounded-full bg-muted hover:bg-muted/80 flex items-center justify-center transition-colors">
           <svg xmlns="http://www.w3.org/2000/svg" className="w-4 h-4 text-foreground" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M15 18l-6-6 6-6"/></svg>
-        </Link>
+        </button>
         <div className="flex justify-center mb-8">
           <div className="w-16 h-16 rounded-2xl bg-primary shadow-lg shadow-primary/15 flex items-center justify-center">
             <BookOpen className="w-7 h-7 text-primary-foreground" />
@@ -142,12 +142,13 @@ export default function ResetPasswordPage() {
 
         <p className="text-sm text-center mt-6 text-muted-foreground">
           记起密码了？{' '}
-          <Link
-            href="/login"
+          <button
+            type="button"
+            onClick={() => requestAnimatedBack('/login')}
             className="font-medium text-primary hover:underline"
           >
             返回登录
-          </Link>
+          </button>
         </p>
 
         <CaptchaModal

--- a/src/app/settings/developer/page.tsx
+++ b/src/app/settings/developer/page.tsx
@@ -1,16 +1,15 @@
 'use client';
 
 import { useState } from 'react';
-import { useRouter } from 'next/navigation';
 import { ArrowLeft, Bug, FlaskConical, Lock, Trash2, AlertTriangle, Eye, RefreshCw, Download } from 'lucide-react';
 import { DesktopLayout } from '@/components/layout/DesktopLayout';
 import { useDeveloperStore } from '@/lib/store/developer';
 import { useUpdateStore } from '@/lib/store/update';
 import { useDebugLogStore, debugLog } from '@/lib/debug-log';
 import { APP_VERSION } from '@/lib/app-version';
+import { requestAnimatedBack } from '@/lib/native-back';
 
 export default function DeveloperSettingsPage() {
-  const router = useRouter();
   const unlocked = useDeveloperStore((s) => s.unlocked);
   const enabled = useDeveloperStore((s) => s.enabled);
   const setEnabled = useDeveloperStore((s) => s.setEnabled);
@@ -28,7 +27,7 @@ export default function DeveloperSettingsPage() {
           <Lock className="w-10 h-10 text-muted-foreground mb-4" />
           <p className="text-sm text-muted-foreground">开发者选项尚未解锁。</p>
           <button
-            onClick={() => router.push('/settings')}
+            onClick={() => requestAnimatedBack('/settings')}
             className="mt-4 text-sm text-primary hover:underline"
           >
             返回设置
@@ -61,7 +60,7 @@ export default function DeveloperSettingsPage() {
       <div className="flex-1 min-h-0 overflow-y-auto px-4 py-5 sm:px-6 md:px-8 md:py-8">
         <div className="mx-auto" style={{ maxWidth: '860px' }}>
         <button
-          onClick={() => router.push('/settings')}
+          onClick={() => requestAnimatedBack('/settings')}
           className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors mb-6"
         >
           <ArrowLeft className="w-4 h-4" />

--- a/src/app/user/history/page.tsx
+++ b/src/app/user/history/page.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { useEffect, useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { ArrowLeft, BookOpen, Download, History, Send, Upload } from 'lucide-react';
+import { requestAnimatedBack } from '@/lib/native-back';
 import { DesktopLayout } from '@/components/layout/DesktopLayout';
 import { request } from '@/lib/api';
 import { useServerStore } from '@/lib/store/server';
@@ -142,7 +143,7 @@ export default function UserHistoryPage() {
         <div className="mx-auto" style={{ maxWidth: '1200px' }}>
         <div className="flex items-center gap-3 mb-8">
           <button
-            onClick={() => router.back()}
+            onClick={() => requestAnimatedBack()}
             className="flex items-center justify-center w-10 h-10 rounded-2xl border border-amber-950/10 bg-white/60 shadow-sm text-muted-foreground transition hover:text-foreground hover:bg-muted"
             aria-label="返回"
             title="返回"

--- a/src/components/layout/TabBar.tsx
+++ b/src/components/layout/TabBar.tsx
@@ -23,6 +23,7 @@ export function TabBar() {
           return (
             <Link
               key={tab.href}
+              replace
               href={tab.href}
               className={cn(
                 'flex min-h-[44px] min-w-0 flex-col items-center justify-center gap-0.5 px-1 transition-colors duration-150',

--- a/src/components/providers/NativeBackNavigation.tsx
+++ b/src/components/providers/NativeBackNavigation.tsx
@@ -4,29 +4,95 @@ import { useEffect, useRef } from 'react';
 import { usePathname, useRouter } from 'next/navigation';
 import { resolveNativeBackTarget } from '@/lib/native-back';
 
+const BACK_TRANSITION_CLASS = 'moke-native-back-transition';
+const BACK_TRANSITION_TIMEOUT_MS = 1_000;
+
+type PendingNavigation = {
+  target: string;
+  resolve: () => void;
+  timeoutId: number;
+};
+
+function shouldReduceBackMotion(): boolean {
+  const root = document.documentElement;
+  return root.dataset.eink === 'true'
+    || window.matchMedia('(prefers-reduced-motion: reduce), (update: slow), (max-color: 1)').matches;
+}
+
 /** Receives Android BACK events forwarded by MainActivity on nested pages. */
 export function NativeBackNavigation() {
   const router = useRouter();
   const pathname = usePathname();
   const routeStackRef = useRef<string[]>([]);
+  const pendingNavigationRef = useRef<PendingNavigation | null>(null);
+  const transitionRunningRef = useRef(false);
 
   useEffect(() => {
     if (routeStackRef.current.at(-1) !== pathname) {
       routeStackRef.current.push(pathname);
     }
+
+    const pending = pendingNavigationRef.current;
+    if (pending && pending.target === pathname) {
+      window.clearTimeout(pending.timeoutId);
+      pendingNavigationRef.current = null;
+      pending.resolve();
+    }
   }, [pathname]);
 
   useEffect(() => {
     const handleNativeBack = () => {
+      if (transitionRunningRef.current) return;
+
       const { target, nextStack } = resolveNativeBackTarget(pathname, routeStackRef.current);
       routeStackRef.current = nextStack;
+
       // Use a known app route instead of WebView/browser history. The latter
       // can contain full-document entries and reload the static Tauri page.
-      router.replace(target);
+      const navigate = () => router.replace(target);
+      if (shouldReduceBackMotion() || !document.startViewTransition) {
+        navigate();
+        return;
+      }
+
+      transitionRunningRef.current = true;
+      document.documentElement.classList.add(BACK_TRANSITION_CLASS);
+
+      const transition = document.startViewTransition(() => new Promise<void>((resolve) => {
+        // Keep the transition callback pending until React has committed the
+        // destination route. This lets the browser capture the real previous
+        // and next pages instead of two snapshots of the current page.
+        const timeoutId = window.setTimeout(resolve, BACK_TRANSITION_TIMEOUT_MS);
+        pendingNavigationRef.current = { target, resolve, timeoutId };
+        navigate();
+      }));
+
+      void transition.finished
+        .catch(() => undefined)
+        .then(() => {
+          const pending = pendingNavigationRef.current;
+          if (pending) {
+            window.clearTimeout(pending.timeoutId);
+            pendingNavigationRef.current = null;
+            pending.resolve();
+          }
+          transitionRunningRef.current = false;
+          document.documentElement.classList.remove(BACK_TRANSITION_CLASS);
+        });
     };
     window.addEventListener('moke:native-back', handleNativeBack);
     return () => window.removeEventListener('moke:native-back', handleNativeBack);
   }, [pathname, router]);
+
+  useEffect(() => () => {
+    const pending = pendingNavigationRef.current;
+    if (pending) {
+      window.clearTimeout(pending.timeoutId);
+      pending.resolve();
+      pendingNavigationRef.current = null;
+    }
+    document.documentElement.classList.remove(BACK_TRANSITION_CLASS);
+  }, []);
 
   return null;
 }

--- a/src/components/providers/NativeBackNavigation.tsx
+++ b/src/components/providers/NativeBackNavigation.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef } from 'react';
 import { usePathname, useRouter } from 'next/navigation';
-import { resolveNativeBackTarget } from '@/lib/native-back';
+import { APP_BACK_EVENT, resolveNativeBackTarget } from '@/lib/native-back';
 
 const BACK_TRANSITION_CLASS = 'moke-native-back-transition';
 const BACK_TRANSITION_TIMEOUT_MS = 1_000;
@@ -41,10 +41,12 @@ export function NativeBackNavigation() {
   }, [pathname]);
 
   useEffect(() => {
-    const handleNativeBack = () => {
+    const handleNativeBack = (event: Event) => {
       if (transitionRunningRef.current) return;
 
-      const { target, nextStack } = resolveNativeBackTarget(pathname, routeStackRef.current);
+      const requestedTarget = (event as CustomEvent<{ target?: string }>).detail?.target;
+      const { target: stackTarget, nextStack } = resolveNativeBackTarget(pathname, routeStackRef.current);
+      const target = requestedTarget ?? stackTarget;
       routeStackRef.current = nextStack;
 
       // Use a known app route instead of WebView/browser history. The latter
@@ -80,8 +82,8 @@ export function NativeBackNavigation() {
           document.documentElement.classList.remove(BACK_TRANSITION_CLASS);
         });
     };
-    window.addEventListener('moke:native-back', handleNativeBack);
-    return () => window.removeEventListener('moke:native-back', handleNativeBack);
+    window.addEventListener(APP_BACK_EVENT, handleNativeBack);
+    return () => window.removeEventListener(APP_BACK_EVENT, handleNativeBack);
   }, [pathname, router]);
 
   useEffect(() => () => {

--- a/src/components/providers/NativeBackNavigation.tsx
+++ b/src/components/providers/NativeBackNavigation.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef } from 'react';
 import { usePathname, useRouter } from 'next/navigation';
-import { APP_BACK_EVENT, resolveNativeBackTarget } from '@/lib/native-back';
+import { APP_BACK_EVENT, resolveNativeBackTarget, trackNativeRoute } from '@/lib/native-back';
 
 const BACK_TRANSITION_CLASS = 'moke-native-back-transition';
 const BACK_TRANSITION_TIMEOUT_MS = 1_000;
@@ -28,9 +28,7 @@ export function NativeBackNavigation() {
   const transitionRunningRef = useRef(false);
 
   useEffect(() => {
-    if (routeStackRef.current.at(-1) !== pathname) {
-      routeStackRef.current.push(pathname);
-    }
+    routeStackRef.current = trackNativeRoute(pathname, routeStackRef.current);
 
     const pending = pendingNavigationRef.current;
     if (pending && pending.target === pathname) {

--- a/src/lib/native-back.ts
+++ b/src/lib/native-back.ts
@@ -17,6 +17,15 @@ const FALLBACK_ROUTES: Record<string, string> = {
   '/user/history': '/user',
 };
 
+export const APP_BACK_EVENT = 'moke:native-back';
+
+/** Routes page-level back controls through the same animated path as Android BACK. */
+export function requestAnimatedBack(target?: string): void {
+  window.dispatchEvent(new CustomEvent(APP_BACK_EVENT, {
+    detail: { target },
+  }));
+}
+
 export function nativeBackFallback(pathname: string): string {
   return FALLBACK_ROUTES[pathname] ?? '/shelf';
 }

--- a/src/lib/native-back.ts
+++ b/src/lib/native-back.ts
@@ -17,6 +17,8 @@ const FALLBACK_ROUTES: Record<string, string> = {
   '/user/history': '/user',
 };
 
+const APP_ROOT_ROUTES = new Set(['/shelf', '/library', '/user']);
+
 export const APP_BACK_EVENT = 'moke:native-back';
 
 /** Routes page-level back controls through the same animated path as Android BACK. */
@@ -28,6 +30,13 @@ export function requestAnimatedBack(target?: string): void {
 
 export function nativeBackFallback(pathname: string): string {
   return FALLBACK_ROUTES[pathname] ?? '/shelf';
+}
+
+/** Home tabs are peers, so switching tabs starts a fresh app-navigation stack. */
+export function trackNativeRoute(pathname: string, routeStack: readonly string[]): string[] {
+  if (APP_ROOT_ROUTES.has(pathname)) return [pathname];
+  if (routeStack.at(-1) === pathname) return [...routeStack];
+  return [...routeStack, pathname];
 }
 
 export function resolveNativeBackTarget(

--- a/tests/android-back.test.mjs
+++ b/tests/android-back.test.mjs
@@ -7,6 +7,14 @@ const activitySource = readFileSync(
   fileURLToPath(new URL('../src-tauri/android/MainActivity.kt', import.meta.url)),
   'utf8',
 );
+const backNavigationSource = readFileSync(
+  fileURLToPath(new URL('../src/components/providers/NativeBackNavigation.tsx', import.meta.url)),
+  'utf8',
+);
+const globalStyles = readFileSync(
+  fileURLToPath(new URL('../src/app/globals.css', import.meta.url)),
+  'utf8',
+);
 
 test('Android 应用根页返回键提供二次确认并退出任务', () => {
   assert.match(activitySource, /再按一次退出应用/);
@@ -20,4 +28,12 @@ test('Android 非根页返回键交给 Next 路由且不覆盖阅读器拦截', 
   assert.match(activitySource, /moke:native-back/);
   assert.match(activitySource, /!interceptBackKeyEnabled/);
   assert.match(activitySource, /isEmbeddedReaderRoute\(\)/);
+});
+
+test('Android 返回先渲染上一页，再只把当前页向右划出', () => {
+  assert.match(backNavigationSource, /document\.startViewTransition/);
+  assert.match(backNavigationSource, /pending\.target === pathname/);
+  assert.match(globalStyles, /::view-transition-old\(root\)[\s\S]*animation-name: moke-native-back-exit/);
+  assert.match(globalStyles, /::view-transition-new\(root\)[\s\S]*animation: none/);
+  assert.match(globalStyles, /to \{ transform: translateX\(100%\); \}/);
 });

--- a/tests/android-back.test.mjs
+++ b/tests/android-back.test.mjs
@@ -15,13 +15,27 @@ const globalStyles = readFileSync(
   fileURLToPath(new URL('../src/app/globals.css', import.meta.url)),
   'utf8',
 );
+const tabBarSource = readFileSync(
+  fileURLToPath(new URL('../src/components/layout/TabBar.tsx', import.meta.url)),
+  'utf8',
+);
+const rootLayoutSource = readFileSync(
+  fileURLToPath(new URL('../src/app/layout.tsx', import.meta.url)),
+  'utf8',
+);
 
 test('Android 应用根页返回键提供二次确认并退出任务', () => {
   assert.match(activitySource, /再按一次退出应用/);
   assert.match(activitySource, /finishAndRemoveTask\(\)/);
   assert.match(activitySource, /\/welcome/);
   assert.match(activitySource, /\/shelf/);
+  assert.match(activitySource, /\/library/);
+  assert.match(activitySource, /\/user/);
   assert.match(activitySource, /removeSuffix\("\.html"\)/);
+});
+
+test('底部三个主页标签不累积浏览历史', () => {
+  assert.match(tabBarSource, /<Link[\s\S]*?replace[\s\S]*?href=\{tab\.href\}/);
 });
 
 test('Android 非根页返回键交给 Next 路由且不覆盖阅读器拦截', () => {
@@ -36,4 +50,12 @@ test('Android 返回先渲染上一页，再只把当前页向右划出', () => 
   assert.match(globalStyles, /::view-transition-old\(root\)[\s\S]*animation-name: moke-native-back-exit/);
   assert.match(globalStyles, /::view-transition-new\(root\)[\s\S]*animation: none/);
   assert.match(globalStyles, /to \{ transform: translateX\(100%\); \}/);
+});
+
+test('任意 Readest 文档退出都会触发 Moke 返回动画', () => {
+  assert.match(rootLayoutSource, /pagereveal/);
+  assert.match(rootLayoutSource, /fromPath\.startsWith\('\/readest\/'\)/);
+  assert.match(rootLayoutSource, /mokeReaderTransition = 'exit'/);
+  assert.match(globalStyles, /@view-transition\s*\{\s*navigation: auto;/);
+  assert.match(globalStyles, /data-moke-reader-transition='exit'/);
 });

--- a/tests/native-back.test.mjs
+++ b/tests/native-back.test.mjs
@@ -2,7 +2,9 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 
 import {
+  APP_BACK_EVENT,
   nativeBackFallback,
+  requestAnimatedBack,
   resolveNativeBackTarget,
 } from '../src/lib/native-back.ts';
 
@@ -21,4 +23,26 @@ test('刷新后路由栈为空时返回确定的上级页面', () => {
     target: '/shelf',
     nextStack: [],
   });
+});
+
+test('页面返回按钮与 Android 系统返回触发同一个动画事件', () => {
+  const windowTarget = new EventTarget();
+  let received = 0;
+  let target;
+  windowTarget.addEventListener(APP_BACK_EVENT, (event) => {
+    received += 1;
+    target = event.detail.target;
+  });
+  Object.defineProperty(globalThis, 'window', {
+    value: windowTarget,
+    configurable: true,
+  });
+
+  try {
+    requestAnimatedBack('/settings');
+    assert.equal(received, 1);
+    assert.equal(target, '/settings');
+  } finally {
+    delete globalThis.window;
+  }
 });

--- a/tests/native-back.test.mjs
+++ b/tests/native-back.test.mjs
@@ -6,6 +6,7 @@ import {
   nativeBackFallback,
   requestAnimatedBack,
   resolveNativeBackTarget,
+  trackNativeRoute,
 } from '../src/lib/native-back.ts';
 
 test('原生返回优先使用应用内路由栈，不依赖浏览器历史', () => {
@@ -45,4 +46,11 @@ test('页面返回按钮与 Android 系统返回触发同一个动画事件', ()
   } finally {
     delete globalThis.window;
   }
+});
+
+test('书架、书库、我的作为同级主页切换时重置应用内返回栈', () => {
+  assert.deepEqual(trackNativeRoute('/shelf', []), ['/shelf']);
+  assert.deepEqual(trackNativeRoute('/library', ['/shelf']), ['/library']);
+  assert.deepEqual(trackNativeRoute('/user', ['/library']), ['/user']);
+  assert.deepEqual(trackNativeRoute('/user/history', ['/user']), ['/user', '/user/history']);
 });


### PR DESCRIPTION
## 变更

- Android 返回和页面返回按钮共用返回动画：上一页静止在底层，当前页向右划出
- Moke 与 Readest 启用跨文档 View Transition，按 `/readest` 导航统一识别，不给具体按钮硬编码动画
- 覆盖 Moke 阅读按钮、内嵌阅读器入口，以及 Readest 按钮退出和 Android 返回键退出
- 书架、书库、我的作为同级主页标签，切换时替换历史记录并重置应用内返回栈
- Android 在三个主页标签上都使用“再按一次退出应用”
- 墨水屏、慢刷新及减少动态效果模式下跳过动画
- Readest 子模块更新对应 https://github.com/hehetoshang/readest/pull/11

## 验证

- `pnpm test`（156 项通过）
- `pnpm typecheck`
- `pnpm build`
- Readest：目标测试 3 项通过
- Readest：相关文件 Biome lint 通过
