### PR TITLE
fix: 游客访问书籍详情不再跳转登录

### DIFF
--- a/src/app/detail/page.tsx
+++ b/src/app/detail/page.tsx
@@ -17,7 +17,12 @@ import { fetchReadingProgress } from '@/lib/reading-progress';
 import { buildEmbeddedReaderUrl, getMokeRuntimePlatform, isSingleWebviewRuntime, openEmbeddedReaderBook } from '@/lib/moke-reader';
 import { resolveServerAssetUrl } from '@/lib/utils';
 import { AuthImage } from '@/components/ui/AuthImage';
-import { bookDetailShelfState, bookSummaryText, readStateShelfState } from '@/lib/book-detail-core';
+import {
+  bookDetailShelfState,
+  bookSummaryText,
+  readStateShelfState,
+  shouldLoadReadingStateFallback,
+} from '@/lib/book-detail-core';
 import { openAndRecordBookRead, recordAndOpenBookRead, recordBookRead } from '@/lib/book-read';
 import {
   getOfflineDownloadSnapshot,
@@ -48,7 +53,7 @@ interface BookDetail {
     read_state?: number;
     online_read?: number;
     download?: number;
-    wants?: boolean;
+    wants?: boolean | number;
   };
 }
 
@@ -56,7 +61,7 @@ function DetailContent() {
   const searchParams = useSearchParams();
   const id = searchParams.get('id');
   const router = useRouter();
-  const { serverUrl } = useServerStore();
+  const { serverUrl, user } = useServerStore();
   const [book, setBook] = useState<BookDetail | null>(null);
   const [loading, setLoading] = useState(true);
   const [expanded, setExpanded] = useState(false);
@@ -156,10 +161,9 @@ function DetailContent() {
         setInShelf(detailShelfState ?? false);
         const format = (nextBook?.files?.[0]?.format || 'epub').toLowerCase();
         setSelectedFormat(format);
-        // Newer Talebook versions include personalized state in book details.
-        // Only use the authenticated readstate endpoint as a compatibility
-        // fallback; a guest response must not make the public detail require login.
-        if (detailShelfState === undefined) {
+        // 游客不访问需要登录的 readstate 接口。仅对已登录用户兼容旧版
+        // Talebook 未在详情响应中携带书架状态的情况。
+        if (shouldLoadReadingStateFallback(detailShelfState, Boolean(user))) {
           loadReadingState(nextBook?.id || String(id), seq);
         }
       } else {

--- a/src/app/detail/page.tsx
+++ b/src/app/detail/page.tsx
@@ -17,7 +17,7 @@ import { fetchReadingProgress } from '@/lib/reading-progress';
 import { buildEmbeddedReaderUrl, getMokeRuntimePlatform, isSingleWebviewRuntime, openEmbeddedReaderBook } from '@/lib/moke-reader';
 import { resolveServerAssetUrl } from '@/lib/utils';
 import { AuthImage } from '@/components/ui/AuthImage';
-import { bookSummaryText } from '@/lib/book-detail-core';
+import { bookDetailShelfState, bookSummaryText, readStateShelfState } from '@/lib/book-detail-core';
 import { openAndRecordBookRead, recordAndOpenBookRead, recordBookRead } from '@/lib/book-read';
 import {
   getOfflineDownloadSnapshot,
@@ -152,10 +152,16 @@ function DetailContent() {
       const nextBook = data.book || data.data;
       if (data.err === 'ok' && nextBook) {
         setBook(nextBook);
-        setInShelf(Boolean(nextBook?.state?.wants));
+        const detailShelfState = bookDetailShelfState(nextBook);
+        setInShelf(detailShelfState ?? false);
         const format = (nextBook?.files?.[0]?.format || 'epub').toLowerCase();
         setSelectedFormat(format);
-        loadReadingState(nextBook?.id || String(id), seq);
+        // Newer Talebook versions include personalized state in book details.
+        // Only use the authenticated readstate endpoint as a compatibility
+        // fallback; a guest response must not make the public detail require login.
+        if (detailShelfState === undefined) {
+          loadReadingState(nextBook?.id || String(id), seq);
+        }
       } else {
         throw new Error(data.msg || '书籍详情加载失败。');
       }
@@ -177,15 +183,14 @@ function DetailContent() {
       const res = await request(`${serverUrl}/api/book/${bookId}/readstate`, {
         credentials: 'include',
       });
-      const data = await res.json();
+      const data = await readApiJson<{ err?: string; msg?: string; wants?: boolean | number }>(
+        res,
+        '阅读状态解析失败。',
+        ['ok', 'user.need_login'],
+      );
       if (seq !== loadBookSeqRef.current) return;
-      if (data.err === 'user.need_login') {
-        router.push('/login');
-        return;
-      }
-      if (data.err === 'ok') {
-        setInShelf(Boolean(data.wants));
-      }
+      const shelfState = readStateShelfState(data);
+      if (shelfState !== undefined) setInShelf(shelfState);
     } catch (error) {
       console.warn('Failed to load reading state:', error);
     }

--- a/src/lib/book-detail-core.ts
+++ b/src/lib/book-detail-core.ts
@@ -32,6 +32,14 @@ export function bookDetailShelfState(book: {
   return wants == null ? undefined : Boolean(wants);
 }
 
+/** Guests must never call Talebook's authenticated readstate endpoint. */
+export function shouldLoadReadingStateFallback(
+  detailShelfState: boolean | undefined,
+  isLoggedIn: boolean,
+): boolean {
+  return isLoggedIn && detailShelfState === undefined;
+}
+
 /**
  * Read a shelf state from the authenticated readstate endpoint.
  *

--- a/src/lib/book-detail-core.ts
+++ b/src/lib/book-detail-core.ts
@@ -22,6 +22,31 @@ function decodeHtmlEntities(value: string): string {
 
 const BLOCK_TAGS = new Set(['blockquote', 'div', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'li', 'p']);
 
+type ShelfStateValue = boolean | number | null;
+
+/** Read the optional shelf state embedded in Talebook's book-detail payload. */
+export function bookDetailShelfState(book: {
+  state?: { wants?: ShelfStateValue };
+} | null | undefined): boolean | undefined {
+  const wants = book?.state?.wants;
+  return wants == null ? undefined : Boolean(wants);
+}
+
+/**
+ * Read a shelf state from the authenticated readstate endpoint.
+ *
+ * Guests receive `user.need_login` from this optional personalization API.
+ * That does not make the public book detail unavailable, so callers should
+ * keep the detail page open when this function returns undefined.
+ */
+export function readStateShelfState(response: {
+  err?: string;
+  wants?: ShelfStateValue;
+} | null | undefined): boolean | undefined {
+  if (response?.err !== 'ok' || response.wants == null) return undefined;
+  return Boolean(response.wants);
+}
+
 function htmlToPlainText(value: string): string {
   let output = '';
   let hiddenTag: 'script' | 'style' | null = null;

--- a/tests/book-detail-core.test.mjs
+++ b/tests/book-detail-core.test.mjs
@@ -1,7 +1,23 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { bookSummaryText } from '../src/lib/book-detail-core.ts';
+import {
+  bookDetailShelfState,
+  bookSummaryText,
+  readStateShelfState,
+} from '../src/lib/book-detail-core.ts';
+
+test('详情页优先使用书籍详情中已有的书架状态', () => {
+  assert.equal(bookDetailShelfState({ state: { wants: 1 } }), true);
+  assert.equal(bookDetailShelfState({ state: { wants: 0 } }), false);
+  assert.equal(bookDetailShelfState({}), undefined);
+});
+
+test('游客无法读取个性化状态时不要求详情页登录', () => {
+  assert.equal(readStateShelfState({ err: 'user.need_login' }), undefined);
+  assert.equal(readStateShelfState({ err: 'ok', wants: true }), true);
+  assert.equal(readStateShelfState({ err: 'ok', wants: false }), false);
+});
 
 test('书籍简介会把 Talebook HTML 转成可读纯文本', () => {
   assert.equal(

--- a/tests/book-detail-core.test.mjs
+++ b/tests/book-detail-core.test.mjs
@@ -5,6 +5,7 @@ import {
   bookDetailShelfState,
   bookSummaryText,
   readStateShelfState,
+  shouldLoadReadingStateFallback,
 } from '../src/lib/book-detail-core.ts';
 
 test('详情页优先使用书籍详情中已有的书架状态', () => {
@@ -17,6 +18,12 @@ test('游客无法读取个性化状态时不要求详情页登录', () => {
   assert.equal(readStateShelfState({ err: 'user.need_login' }), undefined);
   assert.equal(readStateShelfState({ err: 'ok', wants: true }), true);
   assert.equal(readStateShelfState({ err: 'ok', wants: false }), false);
+});
+
+test('游客详情页不请求需要登录的 readstate 接口', () => {
+  assert.equal(shouldLoadReadingStateFallback(undefined, false), false);
+  assert.equal(shouldLoadReadingStateFallback(undefined, true), true);
+  assert.equal(shouldLoadReadingStateFallback(false, true), false);
 });
 
 test('书籍简介会把 Talebook HTML 转成可读纯文本', () => {


### PR DESCRIPTION
## 背景

未登录用户从书库点击公开书籍时，Moke 在详情接口成功后仍会请求需要登录的阅读状态接口。Talebook 返回 user.need_login 后，客户端错误地跳转到了登录页。

## 改动

- 优先使用书籍详情响应中已有的书架状态
- 仅在详情未携带书架状态时兼容请求 readstate 接口
- 游客读取可选个性化状态返回 user.need_login 时保留公开详情页
- 补充游客态与书架状态解析回归测试

## 验证

- pnpm test：153 项通过
- pnpm typecheck：通过
- pnpm lint：通过，无错误；保留仓库已有 warnings
- git diff --check：通过

## 风险与兼容性

Talebook 的公开书籍详情权限与 readstate 登录鉴权均保持不变；仅调整 Moke 对可选个性化状态响应的处理。