### PR TITLE
fix: 简化低高度屏幕隐私确认弹窗

### DIFF
--- a/src/components/providers/PrivacyConsentGate.tsx
+++ b/src/components/providers/PrivacyConsentGate.tsx
@@ -115,28 +115,12 @@ export function PrivacyConsentGate({ children }: { children: React.ReactNode }) 
           </div>
         ) : (
           <>
-            <div className="max-h-[45vh] space-y-3 overflow-y-auto rounded-2xl border border-border bg-muted/30 p-4 text-sm leading-6 text-foreground/90">
-              <p>
-                Moke 用于连接你自行选择的 Talebook 服务器。只有在你同意后，应用才会开始连接服务器并处理书库数据。
-              </p>
-              <ul className="list-disc space-y-2 pl-5">
-                <li>服务器地址、账号资料、书库内容和阅读进度仅用于连接及阅读功能。</li>
-                <li>离线书籍、阅读数据和应用设置主要保存在你的设备本地。</li>
-                <li>更新检查可能访问 GitHub；仅在服务器要求时加载验证码服务。</li>
-                <li>剪贴板、文件和系统语音等能力只在你主动使用对应功能时调用。</li>
-                <li>Moke 不集成广告、用户行为分析或跨应用追踪服务。</li>
-              </ul>
-              <p>
-                你可以在系统设置中撤回权限，或通过清除应用数据、卸载应用删除本地数据。服务器端数据由你所连接的服务器运营者管理。
-              </p>
-            </div>
-
             <button
               type="button"
               onClick={() => router.push('/privacy')}
-              className="mt-4 text-sm font-medium text-primary underline-offset-4 hover:underline"
+              className="text-sm font-medium text-primary underline-offset-4 hover:underline"
             >
-              查看完整《Moke 隐私政策》
+              查看隐私政策
             </button>
 
             <p className="mt-4 text-xs leading-5 text-muted-foreground">

--- a/tests/privacy-consent.test.mjs
+++ b/tests/privacy-consent.test.mjs
@@ -51,3 +51,9 @@ test('隐私确认门在服务器同步组件之外，且提供同意与拒绝�
   assert.match(consentGateSource, /拒绝并退出/);
   assert.match(consentGateSource, /@tauri-apps\/plugin-process/);
 });
+
+test('隐私确认弹窗使用极简布局并保留政策入口', () => {
+  assert.match(consentGateSource, />\s*查看隐私政策\s*</);
+  assert.doesNotMatch(consentGateSource, /查看完整/);
+  assert.doesNotMatch(consentGateSource, /max-h-\[45vh\]/);
+});

--- a/tests/responsive-smoke.spec.mjs
+++ b/tests/responsive-smoke.spec.mjs
@@ -6,6 +6,15 @@ const states = [
   { name: 'desktop', width: 1280, height: 900, tabBarVisible: false, sidebarVisible: true },
 ];
 
+test('低高度屏幕上的隐私确认保持极简可操作', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 480 });
+  await page.goto('http://127.0.0.1:3000/settings/developer', { waitUntil: 'domcontentloaded' });
+
+  await expect(page.getByRole('button', { name: '查看隐私政策' })).toBeVisible();
+  await expect(page.getByRole('button', { name: '同意并继续' })).toBeVisible();
+  await expect(page.getByRole('button', { name: '拒绝并退出' })).toBeVisible();
+});
+
 test('responsive navigation remains usable across device sizes', async ({ page }, testInfo) => {
   await page.goto('http://127.0.0.1:3000/settings/developer', { waitUntil: 'domcontentloaded' });
 


### PR DESCRIPTION
## 改动

- 移除首次启动隐私确认弹窗中的政策摘要，避免低高度屏幕上内容区被压缩
- 保留隐私政策入口，将文案简化为“查看隐私政策”
- 增加极简布局单元测试和 390x480 低高度浏览器用例

## 验证

- `pnpm test` (158 passed)
- `pnpm typecheck`
- `pnpm lint` (0 errors; 25 existing warnings)
- `pnpm exec playwright test tests/responsive-smoke.spec.mjs --grep "低高度屏幕" --reporter=line` (1 passed)
