### PR TITLE
fix: 修复 Android 分屏顶部偏移

### DIFF
--- a/src-tauri/android/MainActivity.kt
+++ b/src-tauri/android/MainActivity.kt
@@ -18,6 +18,7 @@ import android.net.Uri
 import android.os.Bundle
 import android.os.SystemClock
 import android.view.KeyEvent
+import android.webkit.JavascriptInterface
 import android.webkit.WebView
 import android.widget.Toast
 import androidx.activity.enableEdgeToEdge
@@ -30,6 +31,11 @@ class MainActivity : TauriActivity(), KeyDownInterceptor {
     private var interceptPageTurnerKeysEnabled = false
     private var keyLearnModeEnabled = false
     private var lastExitBackPressedAt = 0L
+
+    private inner class WindowModeBridge {
+        @JavascriptInterface
+        fun isInMultiWindowMode(): Boolean = this@MainActivity.isInMultiWindowMode
+    }
 
     companion object {
         private const val EXIT_CONFIRM_WINDOW_MS = 2_000L
@@ -112,6 +118,21 @@ class MainActivity : TauriActivity(), KeyDownInterceptor {
 
     override fun onWebViewCreate(webView: WebView) {
         wv = webView
+        // Android multi-window changes resize the existing WebView without a
+        // navigation. AppShell queries this synchronous bridge on each resize
+        // so it can avoid applying a second status-bar inset in split screen.
+        webView.addJavascriptInterface(WindowModeBridge(), "MokeWindowMode")
+    }
+
+    @Suppress("DEPRECATION")
+    override fun onMultiWindowModeChanged(isInMultiWindowMode: Boolean) {
+        super.onMultiWindowModeChanged(isInMultiWindowMode)
+        wv?.post {
+            it.evaluateJavascript(
+                """window.dispatchEvent(new Event("moke:window-mode-change"));""",
+                null,
+            )
+        }
     }
 
     override fun interceptVolumeKeys(enabled: Boolean) {

--- a/src-tauri/android/MainActivity.kt
+++ b/src-tauri/android/MainActivity.kt
@@ -23,6 +23,7 @@ import android.webkit.WebView
 import android.widget.Toast
 import androidx.activity.enableEdgeToEdge
 import com.readest.native_bridge.KeyDownInterceptor
+import java.lang.ref.WeakReference
 
 class MainActivity : TauriActivity(), KeyDownInterceptor {
     private var wv: WebView? = null
@@ -32,9 +33,12 @@ class MainActivity : TauriActivity(), KeyDownInterceptor {
     private var keyLearnModeEnabled = false
     private var lastExitBackPressedAt = 0L
 
-    private inner class WindowModeBridge {
+    private class WindowModeBridge(activity: MainActivity) {
+        private val activityRef = WeakReference<MainActivity>(activity)
+
         @JavascriptInterface
-        fun isInMultiWindowMode(): Boolean = this@MainActivity.isInMultiWindowMode
+        fun isInMultiWindowMode(): Boolean =
+            activityRef.get()?.isInMultiWindowMode ?: false
     }
 
     companion object {
@@ -121,18 +125,29 @@ class MainActivity : TauriActivity(), KeyDownInterceptor {
         // Android multi-window changes resize the existing WebView without a
         // navigation. AppShell queries this synchronous bridge on each resize
         // so it can avoid applying a second status-bar inset in split screen.
-        webView.addJavascriptInterface(WindowModeBridge(), "MokeWindowMode")
+        webView.addJavascriptInterface(WindowModeBridge(this), "MokeWindowMode")
+    }
+
+    private fun notifyWindowModeChanged() {
+        val webView = wv ?: return
+        webView.post {
+            if (wv !== webView) return@post
+            try {
+                webView.evaluateJavascript(
+                    """window.dispatchEvent(new Event("moke:window-mode-change"));""",
+                    null,
+                )
+            } catch (_: IllegalStateException) {
+                // The Activity may be destroyed after post() but before this
+                // runnable reaches the WebView thread.
+            }
+        }
     }
 
     @Suppress("DEPRECATION")
     override fun onMultiWindowModeChanged(isInMultiWindowMode: Boolean) {
         super.onMultiWindowModeChanged(isInMultiWindowMode)
-        wv?.post {
-            it.evaluateJavascript(
-                """window.dispatchEvent(new Event("moke:window-mode-change"));""",
-                null,
-            )
-        }
+        notifyWindowModeChanged()
     }
 
     override fun interceptVolumeKeys(enabled: Boolean) {
@@ -220,5 +235,12 @@ class MainActivity : TauriActivity(), KeyDownInterceptor {
     override fun onCreate(savedInstanceState: Bundle?) {
         enableEdgeToEdge()
         super.onCreate(savedInstanceState)
+    }
+
+    override fun onDestroy() {
+        val webView = wv
+        wv = null
+        webView?.removeJavascriptInterface("MokeWindowMode")
+        super.onDestroy()
     }
 }

--- a/src/components/providers/AppShell.tsx
+++ b/src/components/providers/AppShell.tsx
@@ -82,6 +82,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
     let cancelled = false;
     let runtimePlatform: string | null = null;
     let retryTimer: number | undefined;
+    let refreshFrame: number | undefined;
     let detectionId = 0;
     const maxAttempts = 12;
 
@@ -116,7 +117,12 @@ export function AppShell({ children }: { children: React.ReactNode }) {
           return;
         }
 
-        const top = await getNativeTopSafeAreaInset(platform, window.devicePixelRatio);
+        const top = await getNativeTopSafeAreaInset(
+          platform,
+          window.devicePixelRatio,
+          undefined,
+          isMultiWindow,
+        );
         if (cancelled || currentDetectionId !== detectionId) return;
         if (top > 0) {
           el.style.setProperty('--moke-top-safe-area', `${top}px`);
@@ -145,23 +151,31 @@ export function AppShell({ children }: { children: React.ReactNode }) {
     const refreshSafeArea = () => {
       if (!cancelled) void detectSafeArea();
     };
+    const scheduleSafeAreaRefresh = () => {
+      if (cancelled || refreshFrame !== undefined) return;
+      refreshFrame = window.requestAnimationFrame(() => {
+        refreshFrame = undefined;
+        refreshSafeArea();
+      });
+    };
     const handleVisibilityChange = () => {
       if (document.visibilityState === 'visible') refreshSafeArea();
     };
 
     void detectSafeArea();
     window.addEventListener('pageshow', refreshSafeArea);
-    window.addEventListener('resize', refreshSafeArea);
-    window.addEventListener('moke:window-mode-change', refreshSafeArea);
+    window.addEventListener('resize', scheduleSafeAreaRefresh);
+    window.addEventListener('moke:window-mode-change', scheduleSafeAreaRefresh);
     window.addEventListener('orientationchange', refreshSafeArea);
     document.addEventListener('visibilitychange', handleVisibilityChange);
 
     return () => {
       cancelled = true;
       clearRetry();
+      if (refreshFrame !== undefined) window.cancelAnimationFrame(refreshFrame);
       window.removeEventListener('pageshow', refreshSafeArea);
-      window.removeEventListener('resize', refreshSafeArea);
-      window.removeEventListener('moke:window-mode-change', refreshSafeArea);
+      window.removeEventListener('resize', scheduleSafeAreaRefresh);
+      window.removeEventListener('moke:window-mode-change', scheduleSafeAreaRefresh);
       window.removeEventListener('orientationchange', refreshSafeArea);
       document.removeEventListener('visibilitychange', handleVisibilityChange);
       delete el.dataset.mokeRuntimePlatform;

--- a/src/components/providers/AppShell.tsx
+++ b/src/components/providers/AppShell.tsx
@@ -13,6 +13,14 @@ import { resolveTheme, useSettingsStore } from '@/lib/store/settings';
 import { NativeBackNavigation } from './NativeBackNavigation';
 import { PrivacyConsentGate } from './PrivacyConsentGate';
 
+declare global {
+  interface Window {
+    MokeWindowMode?: {
+      isInMultiWindowMode: () => boolean;
+    };
+  }
+}
+
 // 开发环境尽早 patch console，使 console.error/warn/log 也进入调试面板。
 // 生产环境默认不启用（见下方 useEffect 的开发者解锁门控），避免为所有用户
 // 全局 patch console 并缓存日志（内存/性能与敏感信息暴露考量）。
@@ -66,12 +74,15 @@ export function AppShell({ children }: { children: React.ReactNode }) {
   // out below its status bar. Mark only the runtimes that need the CSS top
   // inset. Native values avoid Android WebView cold-start bugs where the CSS
   // safe-area env remains 0; a bounded retry covers the native bridge/window
-  // insets not being ready during the first frames of app startup.
+  // insets not being ready during the first frames of app startup. Android
+  // multi-window already places the WebView below the system status bar, so it
+  // must not receive the full-screen inset again.
   useEffect(() => {
     const el = document.documentElement;
     let cancelled = false;
     let runtimePlatform: string | null = null;
     let retryTimer: number | undefined;
+    let detectionId = 0;
     const maxAttempts = 12;
 
     const clearRetry = () => {
@@ -82,12 +93,21 @@ export function AppShell({ children }: { children: React.ReactNode }) {
     };
 
     const detectSafeArea = async (attempt = 0): Promise<void> => {
+      const currentDetectionId = ++detectionId;
       clearRetry();
       try {
         const platform = runtimePlatform ?? await getMokeRuntimePlatform();
-        if (cancelled) return;
+        if (cancelled || currentDetectionId !== detectionId) return;
         runtimePlatform = platform;
-        const enabled = shouldApplyTopSafeArea(platform);
+        let isMultiWindow = false;
+        if (platform === 'android') {
+          try {
+            isMultiWindow = window.MokeWindowMode?.isInMultiWindowMode() === true;
+          } catch {
+            // Older Android builds do not expose the window-mode bridge.
+          }
+        }
+        const enabled = shouldApplyTopSafeArea(platform, isMultiWindow);
         el.dataset.mokeRuntimePlatform = platform;
         el.toggleAttribute('data-moke-top-safe-area', enabled);
 
@@ -97,7 +117,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
         }
 
         const top = await getNativeTopSafeAreaInset(platform, window.devicePixelRatio);
-        if (cancelled) return;
+        if (cancelled || currentDetectionId !== detectionId) return;
         if (top > 0) {
           el.style.setProperty('--moke-top-safe-area', `${top}px`);
           return;
@@ -111,7 +131,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
           }, 250);
         }
       } catch (error) {
-        if (cancelled) return;
+        if (cancelled || currentDetectionId !== detectionId) return;
         if (attempt + 1 < maxAttempts) {
           retryTimer = window.setTimeout(() => {
             void detectSafeArea(attempt + 1);
@@ -131,6 +151,8 @@ export function AppShell({ children }: { children: React.ReactNode }) {
 
     void detectSafeArea();
     window.addEventListener('pageshow', refreshSafeArea);
+    window.addEventListener('resize', refreshSafeArea);
+    window.addEventListener('moke:window-mode-change', refreshSafeArea);
     window.addEventListener('orientationchange', refreshSafeArea);
     document.addEventListener('visibilitychange', handleVisibilityChange);
 
@@ -138,6 +160,8 @@ export function AppShell({ children }: { children: React.ReactNode }) {
       cancelled = true;
       clearRetry();
       window.removeEventListener('pageshow', refreshSafeArea);
+      window.removeEventListener('resize', refreshSafeArea);
+      window.removeEventListener('moke:window-mode-change', refreshSafeArea);
       window.removeEventListener('orientationchange', refreshSafeArea);
       document.removeEventListener('visibilitychange', handleVisibilityChange);
       delete el.dataset.mokeRuntimePlatform;

--- a/src/lib/moke-reader.ts
+++ b/src/lib/moke-reader.ts
@@ -5,11 +5,14 @@ export const isSingleWebviewRuntime = (platform: string): boolean =>
 
 /**
  * Android/iOS render the main WebView edge-to-edge, so Moke's controls need
- * the top safe-area inset. OHOS already keeps the WebView below its status bar
- * and must not receive a second offset.
+ * the top safe-area inset. Android multi-window and OHOS already keep the
+ * WebView below the status bar and must not receive a second offset.
  */
-export const shouldApplyTopSafeArea = (platform: string): boolean =>
-  platform === 'android' || platform === 'ios';
+export const shouldApplyTopSafeArea = (
+  platform: string,
+  isMultiWindow = false,
+): boolean =>
+  (platform === 'android' && !isMultiWindow) || platform === 'ios';
 
 type RuntimeInvoke = <T>(command: string) => Promise<T>;
 

--- a/src/lib/moke-reader.ts
+++ b/src/lib/moke-reader.ts
@@ -36,8 +36,9 @@ export async function getNativeTopSafeAreaInset(
   platform: string,
   devicePixelRatio = 1,
   invokeOverride?: RuntimeInvoke,
+  isMultiWindow = false,
 ): Promise<number> {
-  if (!shouldApplyTopSafeArea(platform)) return 0;
+  if (!shouldApplyTopSafeArea(platform, isMultiWindow)) return 0;
 
   const invoke = invokeOverride ?? (await import('@tauri-apps/api/core')).invoke;
   if (platform === 'android') {

--- a/tests/android-back.test.mjs
+++ b/tests/android-back.test.mjs
@@ -7,6 +7,10 @@ const activitySource = readFileSync(
   fileURLToPath(new URL('../src-tauri/android/MainActivity.kt', import.meta.url)),
   'utf8',
 );
+const appShellSource = readFileSync(
+  fileURLToPath(new URL('../src/components/providers/AppShell.tsx', import.meta.url)),
+  'utf8',
+);
 
 test('Android 应用根页返回键提供二次确认并退出任务', () => {
   assert.match(activitySource, /再按一次退出应用/);
@@ -20,4 +24,16 @@ test('Android 非根页返回键交给 Next 路由且不覆盖阅读器拦截', 
   assert.match(activitySource, /moke:native-back/);
   assert.match(activitySource, /!interceptBackKeyEnabled/);
   assert.match(activitySource, /isEmbeddedReaderRoute\(\)/);
+});
+
+test('Android 分屏时通过原生窗口状态移除重复的顶部安全区', () => {
+  assert.match(activitySource, /@JavascriptInterface/);
+  assert.match(activitySource, /this@MainActivity\.isInMultiWindowMode/);
+  assert.match(activitySource, /addJavascriptInterface\(WindowModeBridge\(\), "MokeWindowMode"\)/);
+  assert.match(activitySource, /onMultiWindowModeChanged\(isInMultiWindowMode: Boolean\)/);
+  assert.match(activitySource, /moke:window-mode-change/);
+  assert.match(appShellSource, /MokeWindowMode\?\.isInMultiWindowMode\(\)/);
+  assert.match(appShellSource, /shouldApplyTopSafeArea\(platform, isMultiWindow\)/);
+  assert.match(appShellSource, /addEventListener\('resize', refreshSafeArea\)/);
+  assert.match(appShellSource, /addEventListener\('moke:window-mode-change', refreshSafeArea\)/);
 });

--- a/tests/android-back.test.mjs
+++ b/tests/android-back.test.mjs
@@ -28,12 +28,18 @@ test('Android 非根页返回键交给 Next 路由且不覆盖阅读器拦截', 
 
 test('Android 分屏时通过原生窗口状态移除重复的顶部安全区', () => {
   assert.match(activitySource, /@JavascriptInterface/);
-  assert.match(activitySource, /this@MainActivity\.isInMultiWindowMode/);
-  assert.match(activitySource, /addJavascriptInterface\(WindowModeBridge\(\), "MokeWindowMode"\)/);
+  assert.match(activitySource, /WeakReference<MainActivity>/);
+  assert.match(activitySource, /addJavascriptInterface\(WindowModeBridge\(this\), "MokeWindowMode"\)/);
+  assert.match(activitySource, /removeJavascriptInterface\("MokeWindowMode"\)/);
   assert.match(activitySource, /onMultiWindowModeChanged\(isInMultiWindowMode: Boolean\)/);
   assert.match(activitySource, /moke:window-mode-change/);
+  assert.match(activitySource, /catch \(_: IllegalStateException\)/);
   assert.match(appShellSource, /MokeWindowMode\?\.isInMultiWindowMode\(\)/);
   assert.match(appShellSource, /shouldApplyTopSafeArea\(platform, isMultiWindow\)/);
-  assert.match(appShellSource, /addEventListener\('resize', refreshSafeArea\)/);
-  assert.match(appShellSource, /addEventListener\('moke:window-mode-change', refreshSafeArea\)/);
+  assert.match(appShellSource, /requestAnimationFrame/);
+  assert.match(appShellSource, /addEventListener\('resize', scheduleSafeAreaRefresh\)/);
+  assert.match(
+    appShellSource,
+    /addEventListener\('moke:window-mode-change', scheduleSafeAreaRefresh\)/,
+  );
 });

--- a/tests/moke-reader.test.mjs
+++ b/tests/moke-reader.test.mjs
@@ -52,6 +52,7 @@ test('native top safe area uses status-bar pixels on Android and safe insets on 
   };
 
   assert.equal(await getNativeTopSafeAreaInset('android', 3, invoke), 24);
+  assert.equal(await getNativeTopSafeAreaInset('android', 3, invoke, true), 0);
   assert.equal(await getNativeTopSafeAreaInset('ios', 2, invoke), 47);
   assert.equal(await getNativeTopSafeAreaInset('ohos', 3, invoke), 0);
   assert.deepEqual(commands, [

--- a/tests/moke-reader.test.mjs
+++ b/tests/moke-reader.test.mjs
@@ -30,9 +30,11 @@ test('runtimeCategoryFromPlatform classifies each runtime', () => {
   assert.equal(runtimeCategoryFromPlatform('macos'), 'desktop');
 });
 
-test('top safe area applies to edge-to-edge mobile runtimes except OHOS', () => {
+test('top safe area applies to edge-to-edge mobile runtimes except Android multi-window', () => {
   assert.equal(shouldApplyTopSafeArea('android'), true);
+  assert.equal(shouldApplyTopSafeArea('android', true), false);
   assert.equal(shouldApplyTopSafeArea('ios'), true);
+  assert.equal(shouldApplyTopSafeArea('ios', true), true);
   assert.equal(shouldApplyTopSafeArea('ohos'), false);
   assert.equal(shouldApplyTopSafeArea('linux'), false);
   assert.equal(shouldApplyTopSafeArea('windows'), false);


### PR DESCRIPTION
## Summary

- expose the Android multi-window state to the WebView
- recalculate the top safe area when split-screen mode changes
- skip the duplicate status-bar inset in Android multi-window mode
- ignore stale asynchronous safe-area calculations during rapid window changes

## Testing

- `pnpm test` (152 tests passed)
- `pnpm typecheck`
- `pnpm lint` (0 errors; 25 pre-existing warnings)
- `pnpm build`

## Notes

- Android device split-screen visual verification is still recommended
