### PR TITLE
feat: integrate Talebook annotation sync

### DIFF
--- a/src/app/detail/page.tsx
+++ b/src/app/detail/page.tsx
@@ -26,7 +26,12 @@ import {
 } from '@/lib/offline-download-manager';
 import { makeOfflineBookKey } from '@/lib/offline-book-core';
 import { AnnotationPanel } from '@/components/annotations/AnnotationPanel';
-import { annotationReaderProgress, type BookAnnotation } from '@/lib/annotations';
+import {
+  annotationReaderProgress,
+  clearAnnotationLocateProgressSuppression,
+  suppressAnnotationLocateProgress,
+  type BookAnnotation,
+} from '@/lib/annotations';
 
 interface BookDetail {
   id: string;
@@ -58,7 +63,7 @@ function DetailContent() {
   const searchParams = useSearchParams();
   const id = searchParams.get('id');
   const router = useRouter();
-  const { serverUrl } = useServerStore();
+  const { serverUrl, capabilities } = useServerStore();
   const [book, setBook] = useState<BookDetail | null>(null);
   const [loading, setLoading] = useState(true);
   const [expanded, setExpanded] = useState(false);
@@ -334,7 +339,10 @@ function DetailContent() {
             eink: useSettingsStore.getState().eink,
             mokeBookId: String(book.id),
             restoreProgress,
-            serverUrl: useServerStore.getState().serverUrl,
+            // A single-WebView annotation locate session intentionally omits
+            // direct progress sync: otherwise the restored CFI would replace
+            // the user's ordinary continue-reading position.
+            serverUrl: targetAnnotation ? undefined : useServerStore.getState().serverUrl,
           });
 
           // Navigation replaces this WebView and destroys the current JS
@@ -349,6 +357,9 @@ function DetailContent() {
           return;
         }
 
+        if (targetAnnotation && restoreProgress?.location) {
+          suppressAnnotationLocateProgress(book.id, restoreProgress.location);
+        }
         await openAndRecordBookRead({
           open: async () => {
             const { invoke } = await import('@tauri-apps/api/core');
@@ -372,6 +383,7 @@ function DetailContent() {
         setMessage('无法打开书籍：未找到本地文件或当前环境不支持。');
       }
     } catch (e) {
+      if (targetAnnotation) clearAnnotationLocateProgressSuppression(book.id);
       console.error('Failed to open book:', e);
       setMessage(targetAnnotation ? '打开书籍或定位笔记失败，请重试。' : '打开书籍失败。');
     } finally {
@@ -617,14 +629,17 @@ function DetailContent() {
           </div>
         </div>
 
-        <AnnotationPanel
-          key={String(book.id)}
-          bookId={String(book.id)}
-          serverUrl={serverUrl}
-          downloaded={downloaded}
-          onLocate={handleOfflineRead}
-          onAuthRequired={handleAnnotationAuthRequired}
-        />
+        {capabilities.checkedAt != null && capabilities.annotationApi && (
+          <AnnotationPanel
+            key={String(book.id)}
+            bookId={String(book.id)}
+            serverUrl={serverUrl}
+            downloaded={downloaded}
+            openingReader={openingReader}
+            onLocate={handleOfflineRead}
+            onAuthRequired={handleAnnotationAuthRequired}
+          />
+        )}
       </div>
 
       {showDeleteConfirm && (

--- a/src/app/detail/page.tsx
+++ b/src/app/detail/page.tsx
@@ -358,7 +358,7 @@ function DetailContent() {
         }
 
         if (targetAnnotation && restoreProgress?.location) {
-          suppressAnnotationLocateProgress(book.id, restoreProgress.location);
+          suppressAnnotationLocateProgress(serverUrl, book.id, restoreProgress.location);
         }
         await openAndRecordBookRead({
           open: async () => {
@@ -383,7 +383,7 @@ function DetailContent() {
         setMessage('无法打开书籍：未找到本地文件或当前环境不支持。');
       }
     } catch (e) {
-      if (targetAnnotation) clearAnnotationLocateProgressSuppression(book.id);
+      if (targetAnnotation) clearAnnotationLocateProgressSuppression(serverUrl, book.id);
       console.error('Failed to open book:', e);
       setMessage(targetAnnotation ? '打开书籍或定位笔记失败，请重试。' : '打开书籍失败。');
     } finally {
@@ -629,11 +629,12 @@ function DetailContent() {
           </div>
         </div>
 
-        {capabilities.checkedAt != null && capabilities.annotationApi && (
+        {capabilities.checkedAt != null && (
           <AnnotationPanel
             key={String(book.id)}
             bookId={String(book.id)}
             serverUrl={serverUrl}
+            supported={capabilities.annotationApi}
             downloaded={downloaded}
             openingReader={openingReader}
             onLocate={handleOfflineRead}

--- a/src/app/detail/page.tsx
+++ b/src/app/detail/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Suspense, useState, useEffect, useRef } from 'react';
+import { Suspense, useState, useEffect, useRef, useCallback } from 'react';
 import { useSearchParams, useRouter } from 'next/navigation';
 import { ArrowLeft, ChevronRight, Star, FileText, HardDrive, Calendar, BookOpen, Building2, Barcode, Tags, Users, LibraryBig, FileBadge2, Bookmark, Trash2 } from 'lucide-react';
 import { DesktopLayout } from '@/components/layout/DesktopLayout';
@@ -25,6 +25,8 @@ import {
   subscribeOfflineDownload,
 } from '@/lib/offline-download-manager';
 import { makeOfflineBookKey } from '@/lib/offline-book-core';
+import { AnnotationPanel } from '@/components/annotations/AnnotationPanel';
+import { annotationReaderProgress, type BookAnnotation } from '@/lib/annotations';
 
 interface BookDetail {
   id: string;
@@ -87,6 +89,7 @@ function DetailContent() {
     book?.files?.map((file) => file.format.toUpperCase()).filter(Boolean) ?? [],
   ));
   const ratingValue = typeof book?.rating === 'number' ? book.rating : book?.rating?.value;
+  const handleAnnotationAuthRequired = useCallback(() => router.push('/login'), [router]);
 
   useEffect(() => {
     if (!id) return;
@@ -302,7 +305,7 @@ function DetailContent() {
     }
   };
 
-  const handleOfflineRead = async () => {
+  const handleOfflineRead = async (targetAnnotation?: BookAnnotation) => {
     if (!book || openingReaderRef.current) return;
 
     openingReaderRef.current = true;
@@ -320,7 +323,9 @@ function DetailContent() {
         // 通过统一的 open_reader 命令打开阅读器：阅读器作为打包资源随应用一起
         // 发布（合为一个应用），并在自己的独立窗口中打开书籍。后续更换阅读器
         // 只需替换打包资源，无需改动这里的调用方式。
-        const restoreProgress = await fetchReadingProgress(book.id);
+        const restoreProgress = targetAnnotation
+          ? annotationReaderProgress(targetAnnotation, book.id)
+          : await fetchReadingProgress(book.id);
         const currentPlatform = await getMokeRuntimePlatform();
 
         if (isSingleWebviewRuntime(currentPlatform)) {
@@ -368,7 +373,7 @@ function DetailContent() {
       }
     } catch (e) {
       console.error('Failed to open book:', e);
-      setMessage('打开书籍失败。');
+      setMessage(targetAnnotation ? '打开书籍或定位笔记失败，请重试。' : '打开书籍失败。');
     } finally {
       finishOpening();
     }
@@ -446,7 +451,7 @@ function DetailContent() {
             {isTauriApp ? (
               <>
                 <button
-                  onClick={downloaded ? handleOfflineRead : handleDownload}
+                  onClick={() => void (downloaded ? handleOfflineRead() : handleDownload())}
                   disabled={downloading || openingReader}
                   className={`relative mt-5 inline-flex h-11 w-full items-center justify-center overflow-hidden rounded-xl text-sm font-semibold shadow-md transition-all duration-200 active:scale-[0.98] hover:shadow-lg disabled:opacity-100 md:mt-6 md:w-[220px] ${downloading ? 'border border-primary/15 bg-primary/15 text-primary-foreground' : 'bg-primary text-primary-foreground hover:bg-primary/90'}`}
                 >
@@ -611,6 +616,14 @@ function DetailContent() {
             )}
           </div>
         </div>
+
+        <AnnotationPanel
+          bookId={String(book.id)}
+          serverUrl={serverUrl}
+          downloaded={downloaded}
+          onLocate={handleOfflineRead}
+          onAuthRequired={handleAnnotationAuthRequired}
+        />
       </div>
 
       {showDeleteConfirm && (

--- a/src/app/detail/page.tsx
+++ b/src/app/detail/page.tsx
@@ -618,6 +618,7 @@ function DetailContent() {
         </div>
 
         <AnnotationPanel
+          key={String(book.id)}
           bookId={String(book.id)}
           serverUrl={serverUrl}
           downloaded={downloaded}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -548,6 +548,25 @@
   color: #000000 !important;
 }
 
+/* Exact soft-fill and semantic-token variants used by annotation status UI.
+   Exact class-token matching avoids catching hover:bg-* variants and leaking a
+   persistent fill into their resting state. */
+[data-eink='true'] [class~='bg-primary/10'],
+[data-eink='true'] [class~='bg-primary/15'],
+[data-eink='true'] [class~='bg-amber-500/10'] {
+  background-color: #E5E5E5 !important;
+}
+[data-eink='true'] [class~='text-destructive'] {
+  color: #000000 !important;
+}
+[data-eink='true'] [class~='bg-destructive/10'] {
+  background-color: #FFFFFF !important;
+}
+[data-eink='true'] [class~='border-destructive/30'],
+[data-eink='true'] [class~='border-amber-500/30'] {
+  border-color: #000000 !important;
+}
+
 /* text-primary / text-primary/N: warm brown accent text (used for captions
    like "共 13 本藏书", "探索书库", the small label above the page title).
    The 80/60 opacity variants are too low-contrast on white-on-white. Force

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -559,6 +559,9 @@
 [data-eink='true'] [class~='text-destructive'] {
   color: #000000 !important;
 }
+[data-eink='true'] [class~='text-primary-foreground'] {
+  color: #000000 !important;
+}
 [data-eink='true'] [class~='bg-destructive/10'] {
   background-color: #FFFFFF !important;
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -559,7 +559,8 @@
 [data-eink='true'] [class~='text-destructive'] {
   color: #000000 !important;
 }
-[data-eink='true'] [class~='text-primary-foreground'] {
+[data-eink='true'] .bg-primary [class~='text-primary-foreground'],
+[data-eink='true'] [class~='bg-primary/15'] [class~='text-primary-foreground'] {
   color: #000000 !important;
 }
 [data-eink='true'] [class~='bg-destructive/10'] {

--- a/src/components/annotations/AnnotationPanel.tsx
+++ b/src/components/annotations/AnnotationPanel.tsx
@@ -6,6 +6,7 @@ import { getErrorMessage, MokeApiError, request } from '@/lib/api';
 import {
   annotationSourceNames,
   fetchBookAnnotations,
+  hasReadestAnnotationLocation,
   isAnnotationApiUnsupported,
   newMokeAnnotationClientId,
   TALEBOOK_ANNOTATION_CONTRACT,
@@ -13,11 +14,13 @@ import {
   type AnnotationType,
   type BookAnnotation,
 } from '@/lib/annotations';
+import { useServerStore } from '@/lib/store/server';
 
 interface AnnotationPanelProps {
   bookId: string;
   serverUrl: string;
   downloaded: boolean;
+  openingReader: boolean;
   onLocate: (annotation: BookAnnotation) => Promise<void>;
   onAuthRequired: () => void;
 }
@@ -44,6 +47,7 @@ export function AnnotationPanel({
   bookId,
   serverUrl,
   downloaded,
+  openingReader,
   onLocate,
   onAuthRequired,
 }: AnnotationPanelProps) {
@@ -77,6 +81,12 @@ export function AnnotationPanel({
         return;
       }
       if (isAnnotationApiUnsupported(error)) {
+        const { capabilities, setServerCapabilities } = useServerStore.getState();
+        setServerCapabilities({
+          ...capabilities,
+          annotationApi: false,
+          checkedAt: Date.now(),
+        });
         setLoadState('unsupported');
         return;
       }
@@ -127,8 +137,11 @@ export function AnnotationPanel({
       // snapshot could arrive last and erase the newly saved note from the UI.
       loadSequenceRef.current += 1;
       setAnnotations((current) => {
-        const remaining = current.filter((item) => item.id !== result.annotation.id);
-        return [...remaining, result.annotation];
+        const remaining = current.filter((item) => (
+          item.id !== result.annotation.id
+          && (!result.annotation.client_id || item.client_id !== result.annotation.client_id)
+        ));
+        return [result.annotation, ...remaining];
       });
       setChapter('');
       setContent('');
@@ -264,6 +277,7 @@ export function AnnotationPanel({
                 key={annotation.id}
                 annotation={annotation}
                 downloaded={downloaded}
+                openingReader={openingReader}
                 onLocate={onLocate}
               />
             ))}
@@ -277,10 +291,12 @@ export function AnnotationPanel({
 function AnnotationCard({
   annotation,
   downloaded,
+  openingReader,
   onLocate,
 }: {
   annotation: BookAnnotation;
   downloaded: boolean;
+  openingReader: boolean;
   onLocate: (annotation: BookAnnotation) => Promise<void>;
 }) {
   const meta = TYPE_META[annotation.annotation_type];
@@ -289,6 +305,8 @@ function AnnotationCard({
   const sourcePositions = Array.from(new Set(
     annotation.sources.map((source) => source.source_position).filter((value): value is string => Boolean(value)),
   ));
+  const canLocate = hasReadestAnnotationLocation(annotation);
+  const locateDisabled = !downloaded || openingReader;
 
   return (
     <article className="rounded-2xl border border-border/60 bg-background/65 p-4">
@@ -317,15 +335,15 @@ function AnnotationCard({
       {annotation.content && <p className="mt-2 whitespace-pre-wrap text-sm leading-relaxed text-foreground">{annotation.content}</p>}
 
       <div className="mt-3 flex flex-wrap items-center gap-x-3 gap-y-2 text-xs">
-        {annotation.cfi ? (
+        {canLocate ? (
           <button
             type="button"
-            disabled={!downloaded}
+            disabled={locateDisabled}
             onClick={() => void onLocate(annotation)}
             className="inline-flex items-center gap-1 font-semibold text-primary hover:underline disabled:cursor-not-allowed disabled:text-muted-foreground disabled:no-underline"
-            title={downloaded ? '在阅读器中定位' : '请先下载书籍'}
+            title={!downloaded ? '请先下载书籍' : openingReader ? '阅读器正在打开' : '在阅读器中定位'}
           >
-            <MapPin className="h-3.5 w-3.5" /> {downloaded ? '精确定位' : '下载后可定位'}
+            <MapPin className="h-3.5 w-3.5" /> {!downloaded ? '下载后可定位' : openingReader ? '打开中' : '精确定位'}
           </button>
         ) : (
           <span className="inline-flex items-center gap-1 text-amber-700 dark:text-amber-400">

--- a/src/components/annotations/AnnotationPanel.tsx
+++ b/src/components/annotations/AnnotationPanel.tsx
@@ -19,6 +19,7 @@ import { useServerStore } from '@/lib/store/server';
 interface AnnotationPanelProps {
   bookId: string;
   serverUrl: string;
+  supported: boolean;
   downloaded: boolean;
   openingReader: boolean;
   onLocate: (annotation: BookAnnotation) => Promise<void>;
@@ -46,13 +47,14 @@ const SOURCE_LABELS: Record<string, string> = {
 export function AnnotationPanel({
   bookId,
   serverUrl,
+  supported,
   downloaded,
   openingReader,
   onLocate,
   onAuthRequired,
 }: AnnotationPanelProps) {
   const [annotations, setAnnotations] = useState<BookAnnotation[]>([]);
-  const [loadState, setLoadState] = useState<LoadState>('loading');
+  const [loadState, setLoadState] = useState<LoadState>(supported ? 'loading' : 'unsupported');
   const [errorMessage, setErrorMessage] = useState('');
   const [sourceFilter, setSourceFilter] = useState('all');
   const [showComposer, setShowComposer] = useState(false);
@@ -66,6 +68,11 @@ export function AnnotationPanel({
 
   const load = useCallback(async () => {
     const sequence = ++loadSequenceRef.current;
+    if (!supported) {
+      setLoadState('unsupported');
+      setErrorMessage('');
+      return;
+    }
     setLoadState('loading');
     setErrorMessage('');
     try {
@@ -93,7 +100,7 @@ export function AnnotationPanel({
       setErrorMessage(getErrorMessage(error, '暂时无法读取笔记，请检查网络后重试。'));
       setLoadState('error');
     }
-  }, [bookId, onAuthRequired, serverUrl]);
+  }, [bookId, onAuthRequired, serverUrl, supported]);
 
   useEffect(() => {
     void load();

--- a/src/components/annotations/AnnotationPanel.tsx
+++ b/src/components/annotations/AnnotationPanel.tsx
@@ -22,7 +22,7 @@ interface AnnotationPanelProps {
   onAuthRequired: () => void;
 }
 
-type LoadState = 'loading' | 'ready' | 'error' | 'unsupported';
+type LoadState = 'loading' | 'ready' | 'error' | 'unsupported' | 'auth-required';
 
 const TYPE_META: Record<AnnotationType, { label: string; icon: typeof StickyNote }> = {
   highlight: { label: '高亮', icon: Highlighter },
@@ -72,6 +72,7 @@ export function AnnotationPanel({
     } catch (error) {
       if (sequence !== loadSequenceRef.current) return;
       if (error instanceof MokeApiError && error.code === 'user.need_login') {
+        setLoadState('auth-required');
         onAuthRequired();
         return;
       }
@@ -96,10 +97,16 @@ export function AnnotationPanel({
     return Array.from(new Set(names)).sort((left, right) => left.localeCompare(right));
   }, [annotations]);
 
+  useEffect(() => {
+    if (sourceFilter !== 'all' && !sources.includes(sourceFilter)) {
+      setSourceFilter('all');
+    }
+  }, [sourceFilter, sources]);
+
   const visibleAnnotations = useMemo(() => {
-    if (sourceFilter === 'all') return annotations;
+    if (sourceFilter === 'all' || !sources.includes(sourceFilter)) return annotations;
     return annotations.filter((annotation) => annotationSourceNames(annotation).includes(sourceFilter));
-  }, [annotations, sourceFilter]);
+  }, [annotations, sourceFilter, sources]);
 
   const saveNote = async () => {
     const trimmedContent = content.trim();
@@ -116,6 +123,9 @@ export function AnnotationPanel({
         content: trimmedContent,
         is_private: isPrivate,
       });
+      // Invalidate a GET that started before this POST. Otherwise its stale
+      // snapshot could arrive last and erase the newly saved note from the UI.
+      loadSequenceRef.current += 1;
       setAnnotations((current) => {
         const remaining = current.filter((item) => item.id !== result.annotation.id);
         return [...remaining, result.annotation];
@@ -127,6 +137,7 @@ export function AnnotationPanel({
       draftClientIdRef.current = '';
     } catch (error) {
       if (error instanceof MokeApiError && error.code === 'user.need_login') {
+        setLoadState('auth-required');
         onAuthRequired();
         return;
       }
@@ -211,6 +222,12 @@ export function AnnotationPanel({
       {loadState === 'unsupported' && (
         <div className="mt-4 rounded-2xl border border-amber-500/30 bg-amber-500/10 p-4 text-sm text-foreground">
           当前 Talebook 版本不支持 Moke 笔记联动，需要服务端契约 <code className="text-xs">{TALEBOOK_ANNOTATION_CONTRACT}</code>。
+        </div>
+      )}
+
+      {loadState === 'auth-required' && (
+        <div className="mt-4 rounded-2xl border border-border bg-background p-4 text-sm text-foreground" role="status">
+          登录状态已失效，正在前往登录页…
         </div>
       )}
 

--- a/src/components/annotations/AnnotationPanel.tsx
+++ b/src/components/annotations/AnnotationPanel.tsx
@@ -1,0 +1,349 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Bookmark, Highlighter, LoaderCircle, MapPin, MessageSquareText, Plus, RefreshCw, StickyNote, X } from 'lucide-react';
+import { getErrorMessage, MokeApiError, request } from '@/lib/api';
+import {
+  annotationSourceNames,
+  fetchBookAnnotations,
+  isAnnotationApiUnsupported,
+  newMokeAnnotationClientId,
+  TALEBOOK_ANNOTATION_CONTRACT,
+  upsertBookAnnotation,
+  type AnnotationType,
+  type BookAnnotation,
+} from '@/lib/annotations';
+
+interface AnnotationPanelProps {
+  bookId: string;
+  serverUrl: string;
+  downloaded: boolean;
+  onLocate: (annotation: BookAnnotation) => Promise<void>;
+  onAuthRequired: () => void;
+}
+
+type LoadState = 'loading' | 'ready' | 'error' | 'unsupported';
+
+const TYPE_META: Record<AnnotationType, { label: string; icon: typeof StickyNote }> = {
+  highlight: { label: '高亮', icon: Highlighter },
+  note: { label: '笔记', icon: StickyNote },
+  bookmark: { label: '书签', icon: Bookmark },
+  chapter_comment: { label: '章评', icon: MessageSquareText },
+};
+
+const SOURCE_LABELS: Record<string, string> = {
+  talebook: 'Talebook',
+  moke: 'Moke',
+  calibre: 'Calibre',
+  weread: '微信读书',
+  readwise: 'Readwise',
+  brs: 'BRS',
+};
+
+export function AnnotationPanel({
+  bookId,
+  serverUrl,
+  downloaded,
+  onLocate,
+  onAuthRequired,
+}: AnnotationPanelProps) {
+  const [annotations, setAnnotations] = useState<BookAnnotation[]>([]);
+  const [loadState, setLoadState] = useState<LoadState>('loading');
+  const [errorMessage, setErrorMessage] = useState('');
+  const [sourceFilter, setSourceFilter] = useState('all');
+  const [showComposer, setShowComposer] = useState(false);
+  const [chapter, setChapter] = useState('');
+  const [content, setContent] = useState('');
+  const [isPrivate, setIsPrivate] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState('');
+  const draftClientIdRef = useRef('');
+  const loadSequenceRef = useRef(0);
+
+  const load = useCallback(async () => {
+    const sequence = ++loadSequenceRef.current;
+    setLoadState('loading');
+    setErrorMessage('');
+    try {
+      const items = await fetchBookAnnotations(request, serverUrl, bookId);
+      if (sequence !== loadSequenceRef.current) return;
+      setAnnotations(items);
+      setLoadState('ready');
+    } catch (error) {
+      if (sequence !== loadSequenceRef.current) return;
+      if (error instanceof MokeApiError && error.code === 'user.need_login') {
+        onAuthRequired();
+        return;
+      }
+      if (isAnnotationApiUnsupported(error)) {
+        setLoadState('unsupported');
+        return;
+      }
+      setErrorMessage(getErrorMessage(error, '暂时无法读取笔记，请检查网络后重试。'));
+      setLoadState('error');
+    }
+  }, [bookId, onAuthRequired, serverUrl]);
+
+  useEffect(() => {
+    void load();
+    return () => {
+      loadSequenceRef.current += 1;
+    };
+  }, [load]);
+
+  const sources = useMemo(() => {
+    const names = annotations.flatMap(annotationSourceNames);
+    return Array.from(new Set(names)).sort((left, right) => left.localeCompare(right));
+  }, [annotations]);
+
+  const visibleAnnotations = useMemo(() => {
+    if (sourceFilter === 'all') return annotations;
+    return annotations.filter((annotation) => annotationSourceNames(annotation).includes(sourceFilter));
+  }, [annotations, sourceFilter]);
+
+  const saveNote = async () => {
+    const trimmedContent = content.trim();
+    if (!trimmedContent || saving) return;
+    if (!draftClientIdRef.current) draftClientIdRef.current = newMokeAnnotationClientId();
+
+    setSaving(true);
+    setSaveError('');
+    try {
+      const result = await upsertBookAnnotation(request, serverUrl, bookId, {
+        annotation_type: 'note',
+        client_id: draftClientIdRef.current,
+        chapter: chapter.trim(),
+        content: trimmedContent,
+        is_private: isPrivate,
+      });
+      setAnnotations((current) => {
+        const remaining = current.filter((item) => item.id !== result.annotation.id);
+        return [...remaining, result.annotation];
+      });
+      setChapter('');
+      setContent('');
+      setIsPrivate(true);
+      setShowComposer(false);
+      draftClientIdRef.current = '';
+    } catch (error) {
+      if (error instanceof MokeApiError && error.code === 'user.need_login') {
+        onAuthRequired();
+        return;
+      }
+      setSaveError(getErrorMessage(error, '笔记保存失败；草稿已保留，可直接重试。'));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <section className="mt-6 rounded-[28px] app-glass px-5 py-5 sm:rounded-[32px] sm:px-7 sm:py-6" aria-labelledby="annotations-title">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <h2 id="annotations-title" className="flex items-center gap-2 text-base font-semibold text-foreground">
+            <StickyNote className="h-4 w-4 text-primary" />
+            笔记与标注
+          </h2>
+          <p className="mt-1 text-xs text-muted-foreground">来源可追溯；删除同步暂未启用，不会静默移除任一端数据。</p>
+        </div>
+        {loadState === 'ready' && (
+          <button
+            type="button"
+            onClick={() => setShowComposer((value) => !value)}
+            className="inline-flex h-9 items-center gap-1.5 rounded-xl border border-primary/25 bg-primary/10 px-3 text-xs font-semibold text-primary transition hover:bg-primary/15"
+          >
+            {showComposer ? <X className="h-3.5 w-3.5" /> : <Plus className="h-3.5 w-3.5" />}
+            {showComposer ? '取消' : '新增笔记'}
+          </button>
+        )}
+      </div>
+
+      {showComposer && (
+        <div className="mt-4 rounded-2xl border border-border/60 bg-background/70 p-4">
+          <label className="block text-xs font-medium text-foreground">
+            章节（可选）
+            <input
+              value={chapter}
+              onChange={(event) => setChapter(event.target.value)}
+              maxLength={500}
+              className="mt-1.5 h-10 w-full rounded-xl border border-border bg-background px-3 text-sm outline-none focus:border-primary"
+              placeholder="例如：第一章"
+            />
+          </label>
+          <label className="mt-3 block text-xs font-medium text-foreground">
+            笔记
+            <textarea
+              value={content}
+              onChange={(event) => setContent(event.target.value)}
+              rows={3}
+              className="mt-1.5 w-full resize-y rounded-xl border border-border bg-background px-3 py-2 text-sm outline-none focus:border-primary"
+              placeholder="写下你的想法"
+            />
+          </label>
+          <label className="mt-3 flex items-center gap-2 text-xs text-foreground">
+            <input
+              type="checkbox"
+              checked={isPrivate}
+              onChange={(event) => setIsPrivate(event.target.checked)}
+              className="h-4 w-4 rounded border-border"
+            />
+            设为私有（私有笔记不会同步到外部来源）
+          </label>
+          {saveError && <p className="mt-3 text-xs text-destructive" role="alert">{saveError}</p>}
+          <button
+            type="button"
+            onClick={saveNote}
+            disabled={!content.trim() || saving}
+            className="mt-4 inline-flex h-9 items-center gap-2 rounded-xl bg-primary px-4 text-xs font-semibold text-primary-foreground transition hover:bg-primary/90 disabled:opacity-50"
+          >
+            {saving && <LoaderCircle className="h-3.5 w-3.5 animate-spin" />}
+            {saving ? '保存中' : saveError ? '重试保存' : '保存笔记'}
+          </button>
+        </div>
+      )}
+
+      {loadState === 'loading' && (
+        <div className="flex items-center justify-center gap-2 py-10 text-sm text-muted-foreground">
+          <LoaderCircle className="h-4 w-4 animate-spin" /> 正在同步笔记…
+        </div>
+      )}
+
+      {loadState === 'unsupported' && (
+        <div className="mt-4 rounded-2xl border border-amber-500/30 bg-amber-500/10 p-4 text-sm text-foreground">
+          当前 Talebook 版本不支持 Moke 笔记联动，需要服务端契约 <code className="text-xs">{TALEBOOK_ANNOTATION_CONTRACT}</code>。
+        </div>
+      )}
+
+      {loadState === 'error' && (
+        <div className="mt-4 rounded-2xl border border-destructive/30 bg-destructive/10 p-4">
+          <p className="text-sm text-foreground" role="alert">{errorMessage}</p>
+          <p className="mt-1 text-xs text-muted-foreground">本次失败不会修改远端或本地笔记。</p>
+          <button type="button" onClick={() => void load()} className="mt-3 inline-flex items-center gap-1.5 text-xs font-semibold text-primary hover:underline">
+            <RefreshCw className="h-3.5 w-3.5" /> 重试
+          </button>
+        </div>
+      )}
+
+      {loadState === 'ready' && annotations.length === 0 && !showComposer && (
+        <p className="py-10 text-center text-sm text-muted-foreground">这本书还没有笔记或标注。</p>
+      )}
+
+      {loadState === 'ready' && annotations.length > 0 && (
+        <>
+          {sources.length > 1 && (
+            <div className="mt-4 flex flex-wrap gap-2" aria-label="按来源筛选">
+              <FilterButton active={sourceFilter === 'all'} onClick={() => setSourceFilter('all')}>全部来源</FilterButton>
+              {sources.map((source) => (
+                <FilterButton key={source} active={sourceFilter === source} onClick={() => setSourceFilter(source)}>
+                  {sourceLabel(source)}
+                </FilterButton>
+              ))}
+            </div>
+          )}
+
+          <div className="mt-4 space-y-3">
+            {visibleAnnotations.map((annotation) => (
+              <AnnotationCard
+                key={annotation.id}
+                annotation={annotation}
+                downloaded={downloaded}
+                onLocate={onLocate}
+              />
+            ))}
+          </div>
+        </>
+      )}
+    </section>
+  );
+}
+
+function AnnotationCard({
+  annotation,
+  downloaded,
+  onLocate,
+}: {
+  annotation: BookAnnotation;
+  downloaded: boolean;
+  onLocate: (annotation: BookAnnotation) => Promise<void>;
+}) {
+  const meta = TYPE_META[annotation.annotation_type];
+  const Icon = meta.icon;
+  const failedSources = annotation.sources.filter((source) => source.source_sync_status === 'failed');
+  const sourcePositions = Array.from(new Set(
+    annotation.sources.map((source) => source.source_position).filter((value): value is string => Boolean(value)),
+  ));
+
+  return (
+    <article className="rounded-2xl border border-border/60 bg-background/65 p-4">
+      <div className="flex flex-wrap items-start justify-between gap-2">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="inline-flex items-center gap-1 rounded-lg bg-muted px-2 py-1 text-[11px] font-semibold text-foreground">
+            <Icon className="h-3 w-3" /> {meta.label}
+          </span>
+          {annotationSourceNames(annotation).map((source) => (
+            <span key={source} className="rounded-lg border border-border/60 px-2 py-1 text-[11px] text-muted-foreground">
+              来源：{sourceLabel(source)}
+            </span>
+          ))}
+          {annotation.is_private && <span className="text-[11px] text-muted-foreground">仅自己可见</span>}
+        </div>
+        <span className="text-[11px] text-muted-foreground">{formatDate(annotation.updated_at || annotation.created_at)}</span>
+      </div>
+
+      {annotation.chapter && <p className="mt-3 text-xs font-semibold text-foreground">{annotation.chapter}</p>}
+      {!annotation.cfi && sourcePositions.length > 0 && (
+        <p className="mt-1 text-[11px] text-muted-foreground">来源位置：{sourcePositions.join(' · ')}</p>
+      )}
+      {annotation.quote_text && (
+        <blockquote className="mt-2 border-l-2 border-primary/35 pl-3 text-sm leading-relaxed text-muted-foreground">{annotation.quote_text}</blockquote>
+      )}
+      {annotation.content && <p className="mt-2 whitespace-pre-wrap text-sm leading-relaxed text-foreground">{annotation.content}</p>}
+
+      <div className="mt-3 flex flex-wrap items-center gap-x-3 gap-y-2 text-xs">
+        {annotation.cfi ? (
+          <button
+            type="button"
+            disabled={!downloaded}
+            onClick={() => void onLocate(annotation)}
+            className="inline-flex items-center gap-1 font-semibold text-primary hover:underline disabled:cursor-not-allowed disabled:text-muted-foreground disabled:no-underline"
+            title={downloaded ? '在阅读器中定位' : '请先下载书籍'}
+          >
+            <MapPin className="h-3.5 w-3.5" /> {downloaded ? '精确定位' : '下载后可定位'}
+          </button>
+        ) : (
+          <span className="inline-flex items-center gap-1 text-amber-700 dark:text-amber-400">
+            <MapPin className="h-3.5 w-3.5" /> 无精确位置，已按章节展示
+          </span>
+        )}
+        {failedSources.length > 0 && (
+          <span className="text-destructive">
+            {failedSources.length} 个来源同步失败，可在 Talebook 插件执行记录中重试
+          </span>
+        )}
+      </div>
+    </article>
+  );
+}
+
+function FilterButton({ active, onClick, children }: { active: boolean; onClick: () => void; children: React.ReactNode }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`rounded-xl border px-3 py-1.5 text-xs font-medium transition ${active ? 'border-primary/35 bg-primary/10 text-primary' : 'border-border/60 text-muted-foreground hover:bg-muted'}`}
+    >
+      {children}
+    </button>
+  );
+}
+
+function sourceLabel(source: string): string {
+  return SOURCE_LABELS[source] || source;
+}
+
+function formatDate(value: string | null): string {
+  if (!value) return '';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return '';
+  return new Intl.DateTimeFormat('zh-CN', { dateStyle: 'medium' }).format(date);
+}

--- a/src/components/providers/ReaderProgressProvider.tsx
+++ b/src/components/providers/ReaderProgressProvider.tsx
@@ -25,7 +25,7 @@ export function ReaderProgressProvider({ children }: { children: React.ReactNode
       .then(({ listen }) => listen<Record<string, unknown>>('reader:page:changed', (event) => {
         const progress = normalizeReaderProgressEvent(event.payload);
         if (!progress) return;
-        if (shouldSuppressAnnotationReaderProgress(progress)) return;
+        if (shouldSuppressAnnotationReaderProgress(serverUrl, progress)) return;
 
         const bookId = progress.moke_book_id;
         pendingRef.current.set(bookId, progress);

--- a/src/components/providers/ReaderProgressProvider.tsx
+++ b/src/components/providers/ReaderProgressProvider.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef } from 'react';
 import { normalizeReaderProgressEvent, saveReadingProgress, type ReadingProgressPayload } from '@/lib/reading-progress';
+import { shouldSuppressAnnotationReaderProgress } from '@/lib/annotations';
 import { useServerStore } from '@/lib/store/server';
 
 const SAVE_DELAY_MS = 1200;
@@ -24,6 +25,7 @@ export function ReaderProgressProvider({ children }: { children: React.ReactNode
       .then(({ listen }) => listen<Record<string, unknown>>('reader:page:changed', (event) => {
         const progress = normalizeReaderProgressEvent(event.payload);
         if (!progress) return;
+        if (shouldSuppressAnnotationReaderProgress(progress)) return;
 
         const bookId = progress.moke_book_id;
         pendingRef.current.set(bookId, progress);

--- a/src/lib/annotations.ts
+++ b/src/lib/annotations.ts
@@ -1,0 +1,375 @@
+import { MokeApiError, readApiJson } from './api-core.ts';
+import type { ReadingProgressPayload } from './reading-progress';
+
+export const TALEBOOK_ANNOTATION_CONTRACT = 'talebook.annotations.v2' as const;
+
+export const ANNOTATION_TYPES = ['highlight', 'note', 'bookmark', 'chapter_comment'] as const;
+export type AnnotationType = (typeof ANNOTATION_TYPES)[number];
+
+export interface AnnotationSource {
+  id: number;
+  source_name: string;
+  source_connection_id: string;
+  source_annotation_id: string | null;
+  source_run_id: string | null;
+  source_position: string | null;
+  source_raw_hash: string | null;
+  source_updated_at: string | null;
+  source_sync_status: string;
+  source_synced_at: string | null;
+  source_sync_error: string | null;
+}
+
+export interface BookAnnotation {
+  id: number;
+  book_id: number;
+  client_id: string | null;
+  annotation_type: AnnotationType;
+  is_private: boolean;
+  cfi: string | null;
+  chapter: string;
+  quote_text: string;
+  content: string;
+  color: string;
+  author_name: string;
+  user_modified_at: string | null;
+  created_at: string | null;
+  updated_at: string | null;
+  sources: AnnotationSource[];
+}
+
+export interface AnnotationUpsertInput {
+  annotation_type: AnnotationType;
+  client_id?: string;
+  is_private?: boolean;
+  cfi?: string | null;
+  chapter?: string;
+  quote_text?: string;
+  content?: string;
+  color?: string;
+  author_name?: string;
+  source_name?: string;
+  source_connection_id?: string;
+  source_annotation_id?: string;
+  source_run_id?: string;
+  source_position?: string;
+  source_raw_hash?: string;
+  source_updated_at?: string;
+}
+
+export interface AnnotationUpsertResult {
+  annotation: BookAnnotation;
+  created: boolean;
+  stale_ignored: boolean;
+  conflict_protected: boolean;
+  sync_enqueued: boolean;
+}
+
+export interface AnnotationBatchResult {
+  succeeded: AnnotationUpsertResult[];
+  failed: Array<{
+    input: AnnotationUpsertInput;
+    error: unknown;
+    retryable: boolean;
+  }>;
+}
+
+type ApiEnvelope = { err?: string; msg?: string };
+type RequestLike = (url: string, init?: RequestInit) => Promise<Response>;
+
+export interface AnnotationRetryOptions {
+  maxRetries?: number;
+  retryDelayMs?: number;
+  sleep?: (delayMs: number) => Promise<void>;
+}
+
+const DEFAULT_RETRY_OPTIONS: Required<AnnotationRetryOptions> = {
+  maxRetries: 2,
+  retryDelayMs: 300,
+  sleep: (delayMs) => new Promise((resolve) => setTimeout(resolve, delayMs)),
+};
+
+const TRANSIENT_STATUS = new Set([408, 425, 429, 500, 502, 503, 504]);
+
+export function isAnnotationRetryable(error: unknown): boolean {
+  if (error instanceof DOMException && error.name === 'AbortError') return false;
+  if (error instanceof MokeApiError) {
+    if (error.code === 'user.need_login' || error.code === 'permission.denied') return false;
+    return error.status !== undefined && TRANSIENT_STATUS.has(error.status);
+  }
+  return error instanceof TypeError || error instanceof Error && /network|fetch|timeout|offline/i.test(error.message);
+}
+
+export function isAnnotationApiUnsupported(error: unknown): boolean {
+  return error instanceof MokeApiError && (
+    error.code === 'annotation.api.unsupported'
+    || error.status === 404
+    || ['page.not_found', 'handler.not_found', 'api.not_found'].includes(error.code)
+  );
+}
+
+export async function withAnnotationRetry<T>(
+  operation: () => Promise<T>,
+  options: AnnotationRetryOptions = {},
+): Promise<T> {
+  const retry = { ...DEFAULT_RETRY_OPTIONS, ...options };
+  let attempt = 0;
+
+  while (true) {
+    try {
+      return await operation();
+    } catch (error) {
+      if (attempt >= retry.maxRetries || !isAnnotationRetryable(error)) throw error;
+      await retry.sleep(retry.retryDelayMs * 2 ** attempt);
+      attempt += 1;
+    }
+  }
+}
+
+export async function fetchBookAnnotations(
+  requestLike: RequestLike,
+  serverUrl: string,
+  bookId: string | number,
+  options?: AnnotationRetryOptions,
+): Promise<BookAnnotation[]> {
+  return withAnnotationRetry(async () => {
+    const response = await requestLike(
+      `${serverUrl}/api/book/${encodeURIComponent(String(bookId))}/annotations`,
+      { credentials: 'include' },
+    );
+
+    let data: ApiEnvelope & { annotations?: unknown };
+    try {
+      data = await readApiJson(response, '笔记接口响应无效。');
+    } catch (error) {
+      throw asCompatibilityError(error);
+    }
+
+    if (!Array.isArray(data.annotations)) {
+      throw unsupportedContractError();
+    }
+    return data.annotations.map(normalizeAnnotation);
+  }, options);
+}
+
+export async function upsertBookAnnotation(
+  requestLike: RequestLike,
+  serverUrl: string,
+  bookId: string | number,
+  input: AnnotationUpsertInput,
+  options?: AnnotationRetryOptions,
+): Promise<AnnotationUpsertResult> {
+  validateUpsertInput(input);
+
+  return withAnnotationRetry(async () => {
+    const response = await requestLike(
+      `${serverUrl}/api/book/${encodeURIComponent(String(bookId))}/annotations`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify(input),
+      },
+    );
+
+    let data: ApiEnvelope & Partial<Omit<AnnotationUpsertResult, 'annotation'>> & { annotation?: unknown };
+    try {
+      data = await readApiJson(response, '笔记保存响应无效。');
+    } catch (error) {
+      throw asCompatibilityError(error);
+    }
+
+    if (!data.annotation) throw unsupportedContractError();
+    return {
+      annotation: normalizeAnnotation(data.annotation),
+      created: Boolean(data.created),
+      stale_ignored: Boolean(data.stale_ignored),
+      conflict_protected: Boolean(data.conflict_protected),
+      sync_enqueued: Boolean(data.sync_enqueued),
+    };
+  }, options);
+}
+
+export async function upsertBookAnnotations(
+  requestLike: RequestLike,
+  serverUrl: string,
+  bookId: string | number,
+  inputs: AnnotationUpsertInput[],
+  options?: AnnotationRetryOptions,
+): Promise<AnnotationBatchResult> {
+  const settled = await Promise.allSettled(
+    inputs.map((input) => upsertBookAnnotation(requestLike, serverUrl, bookId, input, options)),
+  );
+  const result: AnnotationBatchResult = { succeeded: [], failed: [] };
+
+  settled.forEach((item, index) => {
+    if (item.status === 'fulfilled') {
+      result.succeeded.push(item.value);
+    } else {
+      result.failed.push({
+        input: inputs[index],
+        error: item.reason,
+        retryable: isAnnotationRetryable(item.reason),
+      });
+    }
+  });
+  return result;
+}
+
+/**
+ * Produce a deterministic, contract-safe client id for a local annotation.
+ * Callers should use an immutable local record id as `localId`; repeated syncs
+ * of the same record then hit Talebook's `(owner, book, client_id)` upsert key.
+ */
+export function stableMokeAnnotationClientId(bookId: string | number, localId: string): string {
+  const value = `${bookId}\u0000${localId}`;
+  const hashes = [0x811c9dc5, 0x9e3779b9, 0x85ebca6b, 0xc2b2ae35]
+    .map((seed) => hash32(value, seed).toString(16).padStart(8, '0'));
+  return `moke-${hashes.join('-')}`;
+}
+
+/** Generate once for a new draft and retain it when retrying the same save. */
+export function newMokeAnnotationClientId(): string {
+  if (typeof globalThis.crypto?.randomUUID === 'function') {
+    return `moke-${globalThis.crypto.randomUUID()}`;
+  }
+  return `moke-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 18)}`;
+}
+
+export function annotationSourceNames(annotation: BookAnnotation): string[] {
+  const names = annotation.sources.map((source) => source.source_name).filter(Boolean);
+  return names.length > 0 ? Array.from(new Set(names)) : ['talebook'];
+}
+
+export function annotationReaderProgress(
+  annotation: BookAnnotation,
+  bookId: string | number,
+): ReadingProgressPayload | null {
+  if (!annotation.cfi) return null;
+  return {
+    schema: 'moke.readest.progress.v1',
+    reader: 'readest',
+    moke_book_id: String(bookId),
+    location: annotation.cfi,
+    chapter: annotation.chapter || undefined,
+    updated_at: new Date().toISOString(),
+  };
+}
+
+function hash32(value: string, seed: number): number {
+  let hash = seed >>> 0;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return hash >>> 0;
+}
+
+function validateUpsertInput(input: AnnotationUpsertInput): void {
+  const hasClientId = Boolean(input.client_id?.trim());
+  const hasSourceName = Boolean(input.source_name?.trim());
+  const hasSourceId = Boolean(input.source_annotation_id?.trim());
+  const hasAnySourceField = [
+    input.source_name,
+    input.source_connection_id,
+    input.source_annotation_id,
+    input.source_run_id,
+    input.source_position,
+    input.source_raw_hash,
+    input.source_updated_at,
+  ].some((value) => value !== undefined);
+  if (!ANNOTATION_TYPES.includes(input.annotation_type)) {
+    throw new MokeApiError('不支持的笔记类型。', 'annotation.type.invalid');
+  }
+  if (!hasClientId && !hasSourceId) {
+    throw new MokeApiError('笔记缺少稳定的幂等标识。', 'annotation.identity.missing');
+  }
+  if (hasSourceName !== hasSourceId || hasAnySourceField !== hasSourceName || input.source_name?.trim() === 'talebook') {
+    throw new MokeApiError('笔记来源标识不完整。', 'annotation.source.invalid');
+  }
+  if (input.client_id && input.client_id.length > 64) {
+    throw new MokeApiError('笔记客户端标识过长。', 'annotation.identity.invalid');
+  }
+}
+
+function normalizeAnnotation(value: unknown): BookAnnotation {
+  if (!isRecord(value)
+    || typeof value.id !== 'number'
+    || typeof value.book_id !== 'number'
+    || typeof value.annotation_type !== 'string'
+    || !ANNOTATION_TYPES.includes(value.annotation_type as AnnotationType)
+    || typeof value.is_private !== 'boolean'
+    || !Array.isArray(value.sources)) {
+    throw unsupportedContractError();
+  }
+
+  return {
+    id: value.id,
+    book_id: value.book_id,
+    client_id: nullableString(value.client_id),
+    annotation_type: value.annotation_type as AnnotationType,
+    is_private: value.is_private,
+    cfi: nullableString(value.cfi),
+    chapter: stringValue(value.chapter),
+    quote_text: stringValue(value.quote_text),
+    content: stringValue(value.content),
+    color: stringValue(value.color),
+    author_name: stringValue(value.author_name),
+    user_modified_at: nullableString(value.user_modified_at),
+    created_at: nullableString(value.created_at),
+    updated_at: nullableString(value.updated_at),
+    sources: value.sources.map(normalizeSource),
+  };
+}
+
+function normalizeSource(value: unknown): AnnotationSource {
+  if (!isRecord(value)
+    || typeof value.id !== 'number'
+    || typeof value.source_name !== 'string'
+    || typeof value.source_connection_id !== 'string'
+    || typeof value.source_sync_status !== 'string') {
+    throw unsupportedContractError();
+  }
+  return {
+    id: value.id,
+    source_name: value.source_name,
+    source_connection_id: value.source_connection_id,
+    source_annotation_id: nullableString(value.source_annotation_id),
+    source_run_id: nullableString(value.source_run_id),
+    source_position: nullableString(value.source_position),
+    source_raw_hash: nullableString(value.source_raw_hash),
+    source_updated_at: nullableString(value.source_updated_at),
+    source_sync_status: value.source_sync_status,
+    source_synced_at: nullableString(value.source_synced_at),
+    source_sync_error: nullableString(value.source_sync_error),
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function stringValue(value: unknown): string {
+  return typeof value === 'string' ? value : '';
+}
+
+function nullableString(value: unknown): string | null {
+  return typeof value === 'string' && value ? value : null;
+}
+
+function unsupportedContractError(): MokeApiError {
+  return new MokeApiError(
+    `当前 Talebook 服务器未提供兼容的笔记契约（需要 ${TALEBOOK_ANNOTATION_CONTRACT}）。`,
+    'annotation.api.unsupported',
+  );
+}
+
+function asCompatibilityError(error: unknown): unknown {
+  if (error instanceof MokeApiError && (
+    error.status === 404
+    || ['page.not_found', 'handler.not_found', 'api.not_found'].includes(error.code)
+  )) {
+    return unsupportedContractError();
+  }
+  return error;
+}

--- a/src/lib/annotations.ts
+++ b/src/lib/annotations.ts
@@ -83,6 +83,10 @@ export interface AnnotationRetryOptions {
   sleep?: (delayMs: number) => Promise<void>;
 }
 
+export interface AnnotationBatchOptions extends AnnotationRetryOptions {
+  concurrency?: number;
+}
+
 const DEFAULT_RETRY_OPTIONS: Required<AnnotationRetryOptions> = {
   maxRetries: 2,
   retryDelayMs: 300,
@@ -90,6 +94,8 @@ const DEFAULT_RETRY_OPTIONS: Required<AnnotationRetryOptions> = {
 };
 
 const TRANSIENT_STATUS = new Set([408, 425, 429, 500, 502, 503, 504]);
+const SAFE_WRITE_RETRY_STATUS = new Set([408, 425, 429]);
+const DEFAULT_BATCH_CONCURRENCY = 6;
 
 export function isAnnotationRetryable(error: unknown): boolean {
   if (error instanceof DOMException && error.name === 'AbortError') return false;
@@ -97,6 +103,16 @@ export function isAnnotationRetryable(error: unknown): boolean {
     if (error.code === 'user.need_login' || error.code === 'permission.denied') return false;
     return error.status !== undefined && TRANSIENT_STATUS.has(error.status);
   }
+  return error instanceof TypeError || error instanceof Error && /network|fetch|timeout|offline/i.test(error.message);
+}
+
+function isAnnotationWriteRetryable(error: unknown): boolean {
+  if (error instanceof DOMException && error.name === 'AbortError') return false;
+  if (error instanceof MokeApiError) {
+    return error.status !== undefined && SAFE_WRITE_RETRY_STATUS.has(error.status);
+  }
+  // A transport error can mean the idempotent upsert committed but its response
+  // was lost. Reusing the same client/source identity makes this retry safe.
   return error instanceof TypeError || error instanceof Error && /network|fetch|timeout|offline/i.test(error.message);
 }
 
@@ -111,6 +127,7 @@ export function isAnnotationApiUnsupported(error: unknown): boolean {
 export async function withAnnotationRetry<T>(
   operation: () => Promise<T>,
   options: AnnotationRetryOptions = {},
+  shouldRetry: (error: unknown) => boolean = isAnnotationRetryable,
 ): Promise<T> {
   const retry = { ...DEFAULT_RETRY_OPTIONS, ...options };
   let attempt = 0;
@@ -119,7 +136,7 @@ export async function withAnnotationRetry<T>(
     try {
       return await operation();
     } catch (error) {
-      if (attempt >= retry.maxRetries || !isAnnotationRetryable(error)) throw error;
+      if (attempt >= retry.maxRetries || !shouldRetry(error)) throw error;
       await retry.sleep(retry.retryDelayMs * 2 ** attempt);
       attempt += 1;
     }
@@ -148,7 +165,16 @@ export async function fetchBookAnnotations(
     if (!Array.isArray(data.annotations)) {
       throw unsupportedContractError();
     }
-    return data.annotations.map(normalizeAnnotation);
+    const annotations: BookAnnotation[] = [];
+    for (const value of data.annotations) {
+      try {
+        annotations.push(normalizeAnnotation(value));
+      } catch {
+        // One corrupt/older record must not turn a supported endpoint into an
+        // "unsupported contract" error or hide all other valid annotations.
+      }
+    }
+    return annotations;
   }, options);
 }
 
@@ -187,7 +213,7 @@ export async function upsertBookAnnotation(
       conflict_protected: Boolean(data.conflict_protected),
       sync_enqueued: Boolean(data.sync_enqueued),
     };
-  }, options);
+  }, options, isAnnotationWriteRetryable);
 }
 
 export async function upsertBookAnnotations(
@@ -195,11 +221,18 @@ export async function upsertBookAnnotations(
   serverUrl: string,
   bookId: string | number,
   inputs: AnnotationUpsertInput[],
-  options?: AnnotationRetryOptions,
+  options: AnnotationBatchOptions = {},
 ): Promise<AnnotationBatchResult> {
-  const settled = await Promise.allSettled(
-    inputs.map((input) => upsertBookAnnotation(requestLike, serverUrl, bookId, input, options)),
-  );
+  const { concurrency = DEFAULT_BATCH_CONCURRENCY, ...retryOptions } = options;
+  const limit = Math.max(1, Math.min(20, Math.floor(concurrency) || DEFAULT_BATCH_CONCURRENCY));
+  const settled: PromiseSettledResult<AnnotationUpsertResult>[] = [];
+
+  for (let index = 0; index < inputs.length; index += limit) {
+    const batch = inputs.slice(index, index + limit);
+    settled.push(...await Promise.allSettled(
+      batch.map((input) => upsertBookAnnotation(requestLike, serverUrl, bookId, input, retryOptions)),
+    ));
+  }
   const result: AnnotationBatchResult = { succeeded: [], failed: [] };
 
   settled.forEach((item, index) => {
@@ -209,7 +242,7 @@ export async function upsertBookAnnotations(
       result.failed.push({
         input: inputs[index],
         error: item.reason,
-        retryable: isAnnotationRetryable(item.reason),
+        retryable: isAnnotationWriteRetryable(item.reason),
       });
     }
   });

--- a/src/lib/annotations.ts
+++ b/src/lib/annotations.ts
@@ -96,9 +96,18 @@ const DEFAULT_RETRY_OPTIONS: Required<AnnotationRetryOptions> = {
 const TRANSIENT_STATUS = new Set([408, 425, 429, 500, 502, 503, 504]);
 const SAFE_WRITE_RETRY_STATUS = new Set([408, 425, 429]);
 const DEFAULT_BATCH_CONCURRENCY = 6;
+// A hard guardrail for future bulk import/sync callers so one batch cannot
+// overwhelm a single-process Talebook server even if configured incorrectly.
+const MAX_BATCH_CONCURRENCY = 20;
 const TRANSPORT_ERROR_PATTERN = /network|fetch|offline|timed?\s*out|connection (?:refused|reset|closed)|failed to connect|error sending request|dns|socket/i;
 const ANNOTATION_LOCATE_SUPPRESSION_TTL_MS = 2 * 60 * 1000;
-const annotationLocateSuppressions = new Map<string, { location: string; expiresAt: number }>();
+const ANNOTATION_LOCATE_GRACE_MS = 10 * 1000;
+const annotationLocateSuppressions = new Map<string, {
+  location: string;
+  graceUntil: number;
+  expiresAt: number;
+  cleanupTimer: ReturnType<typeof setTimeout>;
+}>();
 
 export function isAnnotationRetryable(error: unknown): boolean {
   if (error instanceof DOMException && error.name === 'AbortError') return false;
@@ -223,6 +232,11 @@ export async function upsertBookAnnotation(
   }, options, isAnnotationWriteRetryable);
 }
 
+/**
+ * Reserved bulk-sync primitive for future local annotation importers. The UI
+ * currently saves one note at a time, but sync jobs need partial-failure
+ * reporting and bounded concurrency without reimplementing the v2 contract.
+ */
 export async function upsertBookAnnotations(
   requestLike: RequestLike,
   serverUrl: string,
@@ -234,7 +248,7 @@ export async function upsertBookAnnotations(
   const requestedConcurrency = Number.isFinite(concurrency)
     ? Math.max(1, Math.floor(concurrency))
     : DEFAULT_BATCH_CONCURRENCY;
-  const limit = Math.min(20, requestedConcurrency);
+  const limit = Math.min(MAX_BATCH_CONCURRENCY, requestedConcurrency);
   const settled: PromiseSettledResult<AnnotationUpsertResult>[] = [];
 
   for (let index = 0; index < inputs.length; index += limit) {
@@ -260,7 +274,7 @@ export async function upsertBookAnnotations(
 }
 
 /**
- * Produce a deterministic, contract-safe client id for a local annotation.
+ * Produce a deterministic, contract-safe client id for future local sync jobs.
  * Callers should use an immutable local record id as `localId`; repeated syncs
  * of the same record then hit Talebook's `(owner, book, client_id)` upsert key.
  */
@@ -305,30 +319,57 @@ export function hasReadestAnnotationLocation(annotation: BookAnnotation): boolea
 }
 
 /**
- * Desktop Readest emits its restored location as a page-change event. Suppress
- * that exact location until the user actually moves elsewhere so opening an
- * annotation cannot overwrite the user's ordinary continue-reading position.
+ * Desktop Readest emits startup and restored locations as page-change events.
+ * Suppress a short startup window, scoped by server and book, then keep exact
+ * restore suppression until the user moves elsewhere. A timer bounds cleanup.
  */
-export function suppressAnnotationLocateProgress(bookId: string | number, location: string): void {
-  annotationLocateSuppressions.set(String(bookId), {
+export function suppressAnnotationLocateProgress(
+  serverUrl: string,
+  bookId: string | number,
+  location: string,
+): void {
+  const key = annotationProgressKey(serverUrl, bookId);
+  const existing = annotationLocateSuppressions.get(key);
+  if (existing) clearTimeout(existing.cleanupTimer);
+  const startedAt = Date.now();
+  const cleanupTimer = setTimeout(() => {
+    annotationLocateSuppressions.delete(key);
+  }, ANNOTATION_LOCATE_SUPPRESSION_TTL_MS);
+  if (typeof cleanupTimer === 'object' && 'unref' in cleanupTimer) cleanupTimer.unref();
+  annotationLocateSuppressions.set(key, {
     location,
-    expiresAt: Date.now() + ANNOTATION_LOCATE_SUPPRESSION_TTL_MS,
+    graceUntil: startedAt + ANNOTATION_LOCATE_GRACE_MS,
+    expiresAt: startedAt + ANNOTATION_LOCATE_SUPPRESSION_TTL_MS,
+    cleanupTimer,
   });
 }
 
-export function clearAnnotationLocateProgressSuppression(bookId: string | number): void {
-  annotationLocateSuppressions.delete(String(bookId));
+export function clearAnnotationLocateProgressSuppression(serverUrl: string, bookId: string | number): void {
+  const key = annotationProgressKey(serverUrl, bookId);
+  const suppression = annotationLocateSuppressions.get(key);
+  if (suppression) clearTimeout(suppression.cleanupTimer);
+  annotationLocateSuppressions.delete(key);
 }
 
-export function shouldSuppressAnnotationReaderProgress(progress: ReadingProgressPayload): boolean {
-  const key = String(progress.moke_book_id);
+export function shouldSuppressAnnotationReaderProgress(
+  serverUrl: string,
+  progress: ReadingProgressPayload,
+  now = Date.now(),
+): boolean {
+  const key = annotationProgressKey(serverUrl, progress.moke_book_id);
   const suppression = annotationLocateSuppressions.get(key);
   if (!suppression) return false;
-  if (Date.now() >= suppression.expiresAt) {
+  if (now >= suppression.expiresAt) {
+    clearTimeout(suppression.cleanupTimer);
     annotationLocateSuppressions.delete(key);
     return false;
   }
+  // Readest may first emit its default page and may normalize the supplied CFI
+  // before emitting the restored page. Suppress every startup event during a
+  // short grace period rather than relying on byte-for-byte CFI equality.
+  if (now < suppression.graceUntil) return true;
   if (progress.location === suppression.location) return true;
+  clearTimeout(suppression.cleanupTimer);
   annotationLocateSuppressions.delete(key);
   return false;
 }
@@ -426,18 +467,19 @@ function normalizeUpsertAnnotation(
 
 function normalizeAnnotation(value: unknown): BookAnnotation {
   if (!isRecord(value)
-    || typeof value.id !== 'number'
-    || typeof value.book_id !== 'number'
     || typeof value.annotation_type !== 'string'
     || !ANNOTATION_TYPES.includes(value.annotation_type as AnnotationType)
     || typeof value.is_private !== 'boolean'
     || !Array.isArray(value.sources)) {
     throw unsupportedContractError();
   }
+  const id = finiteNumber(value.id);
+  const bookId = finiteNumber(value.book_id);
+  if (id === null || bookId === null) throw unsupportedContractError();
 
   return {
-    id: value.id,
-    book_id: value.book_id,
+    id,
+    book_id: bookId,
     client_id: nullableString(value.client_id),
     annotation_type: value.annotation_type as AnnotationType,
     is_private: value.is_private,
@@ -520,6 +562,10 @@ function readestAnnotationCfi(value: string | null): string | null {
   if (!value) return null;
   const cfi = value.trim();
   return /^epubcfi\(.+\)$/.test(cfi) ? cfi : null;
+}
+
+function annotationProgressKey(serverUrl: string, bookId: string | number): string {
+  return `${serverUrl.replace(/\/+$/, '')}\u0000${String(bookId)}`;
 }
 
 function unsupportedContractError(): MokeApiError {

--- a/src/lib/annotations.ts
+++ b/src/lib/annotations.ts
@@ -48,13 +48,13 @@ export interface AnnotationUpsertInput {
   content?: string;
   color?: string;
   author_name?: string;
-  source_name?: string;
-  source_connection_id?: string;
-  source_annotation_id?: string;
-  source_run_id?: string;
-  source_position?: string;
-  source_raw_hash?: string;
-  source_updated_at?: string;
+  source_name?: string | null;
+  source_connection_id?: string | null;
+  source_annotation_id?: string | null;
+  source_run_id?: string | null;
+  source_position?: string | null;
+  source_raw_hash?: string | null;
+  source_updated_at?: string | null;
 }
 
 export interface AnnotationUpsertResult {
@@ -96,6 +96,9 @@ const DEFAULT_RETRY_OPTIONS: Required<AnnotationRetryOptions> = {
 const TRANSIENT_STATUS = new Set([408, 425, 429, 500, 502, 503, 504]);
 const SAFE_WRITE_RETRY_STATUS = new Set([408, 425, 429]);
 const DEFAULT_BATCH_CONCURRENCY = 6;
+const TRANSPORT_ERROR_PATTERN = /network|fetch|offline|timed?\s*out|connection (?:refused|reset|closed)|failed to connect|error sending request|dns|socket/i;
+const ANNOTATION_LOCATE_SUPPRESSION_TTL_MS = 2 * 60 * 1000;
+const annotationLocateSuppressions = new Map<string, { location: string; expiresAt: number }>();
 
 export function isAnnotationRetryable(error: unknown): boolean {
   if (error instanceof DOMException && error.name === 'AbortError') return false;
@@ -103,7 +106,7 @@ export function isAnnotationRetryable(error: unknown): boolean {
     if (error.code === 'user.need_login' || error.code === 'permission.denied') return false;
     return error.status !== undefined && TRANSIENT_STATUS.has(error.status);
   }
-  return error instanceof TypeError || error instanceof Error && /network|fetch|timeout|offline/i.test(error.message);
+  return isTransportError(error);
 }
 
 function isAnnotationWriteRetryable(error: unknown): boolean {
@@ -111,15 +114,16 @@ function isAnnotationWriteRetryable(error: unknown): boolean {
   if (error instanceof MokeApiError) {
     return error.status !== undefined && SAFE_WRITE_RETRY_STATUS.has(error.status);
   }
-  // A transport error can mean the idempotent upsert committed but its response
-  // was lost. Reusing the same client/source identity makes this retry safe.
-  return error instanceof TypeError || error instanceof Error && /network|fetch|timeout|offline/i.test(error.message);
+  // Retry only when no HTTP response was received (or the server explicitly
+  // asks the client to retry via 408/425/429). An arbitrary 5xx can represent a
+  // deterministic application failure, so it is surfaced instead of looped.
+  // Reusing the same client/source identity keeps transport recovery idempotent.
+  return isTransportError(error);
 }
 
 export function isAnnotationApiUnsupported(error: unknown): boolean {
   return error instanceof MokeApiError && (
     error.code === 'annotation.api.unsupported'
-    || error.status === 404
     || ['page.not_found', 'handler.not_found', 'api.not_found'].includes(error.code)
   );
 }
@@ -174,6 +178,9 @@ export async function fetchBookAnnotations(
         // "unsupported contract" error or hide all other valid annotations.
       }
     }
+    if (data.annotations.length > 0 && annotations.length === 0) {
+      throw unsupportedContractError();
+    }
     return annotations;
   }, options);
 }
@@ -207,7 +214,7 @@ export async function upsertBookAnnotation(
 
     if (!data.annotation) throw unsupportedContractError();
     return {
-      annotation: normalizeAnnotation(data.annotation),
+      annotation: normalizeUpsertAnnotation(data.annotation, input, bookId),
       created: Boolean(data.created),
       stale_ignored: Boolean(data.stale_ignored),
       conflict_protected: Boolean(data.conflict_protected),
@@ -224,7 +231,10 @@ export async function upsertBookAnnotations(
   options: AnnotationBatchOptions = {},
 ): Promise<AnnotationBatchResult> {
   const { concurrency = DEFAULT_BATCH_CONCURRENCY, ...retryOptions } = options;
-  const limit = Math.max(1, Math.min(20, Math.floor(concurrency) || DEFAULT_BATCH_CONCURRENCY));
+  const requestedConcurrency = Number.isFinite(concurrency)
+    ? Math.max(1, Math.floor(concurrency))
+    : DEFAULT_BATCH_CONCURRENCY;
+  const limit = Math.min(20, requestedConcurrency);
   const settled: PromiseSettledResult<AnnotationUpsertResult>[] = [];
 
   for (let index = 0; index < inputs.length; index += limit) {
@@ -278,15 +288,49 @@ export function annotationReaderProgress(
   annotation: BookAnnotation,
   bookId: string | number,
 ): ReadingProgressPayload | null {
-  if (!annotation.cfi) return null;
+  const cfi = readestAnnotationCfi(annotation.cfi);
+  if (!cfi) return null;
   return {
     schema: 'moke.readest.progress.v1',
     reader: 'readest',
     moke_book_id: String(bookId),
-    location: annotation.cfi,
+    location: cfi,
     chapter: annotation.chapter || undefined,
     updated_at: new Date().toISOString(),
   };
+}
+
+export function hasReadestAnnotationLocation(annotation: BookAnnotation): boolean {
+  return readestAnnotationCfi(annotation.cfi) !== null;
+}
+
+/**
+ * Desktop Readest emits its restored location as a page-change event. Suppress
+ * that exact location until the user actually moves elsewhere so opening an
+ * annotation cannot overwrite the user's ordinary continue-reading position.
+ */
+export function suppressAnnotationLocateProgress(bookId: string | number, location: string): void {
+  annotationLocateSuppressions.set(String(bookId), {
+    location,
+    expiresAt: Date.now() + ANNOTATION_LOCATE_SUPPRESSION_TTL_MS,
+  });
+}
+
+export function clearAnnotationLocateProgressSuppression(bookId: string | number): void {
+  annotationLocateSuppressions.delete(String(bookId));
+}
+
+export function shouldSuppressAnnotationReaderProgress(progress: ReadingProgressPayload): boolean {
+  const key = String(progress.moke_book_id);
+  const suppression = annotationLocateSuppressions.get(key);
+  if (!suppression) return false;
+  if (Date.now() >= suppression.expiresAt) {
+    annotationLocateSuppressions.delete(key);
+    return false;
+  }
+  if (progress.location === suppression.location) return true;
+  annotationLocateSuppressions.delete(key);
+  return false;
 }
 
 function hash32(value: string, seed: number): number {
@@ -299,9 +343,9 @@ function hash32(value: string, seed: number): number {
 }
 
 function validateUpsertInput(input: AnnotationUpsertInput): void {
-  const hasClientId = Boolean(input.client_id?.trim());
-  const hasSourceName = Boolean(input.source_name?.trim());
-  const hasSourceId = Boolean(input.source_annotation_id?.trim());
+  const hasClientId = hasMeaningfulString(input.client_id);
+  const hasSourceName = hasMeaningfulString(input.source_name);
+  const hasSourceId = hasMeaningfulString(input.source_annotation_id);
   const hasAnySourceField = [
     input.source_name,
     input.source_connection_id,
@@ -310,19 +354,74 @@ function validateUpsertInput(input: AnnotationUpsertInput): void {
     input.source_position,
     input.source_raw_hash,
     input.source_updated_at,
-  ].some((value) => value !== undefined);
+  ].some(hasMeaningfulString);
   if (!ANNOTATION_TYPES.includes(input.annotation_type)) {
     throw new MokeApiError('不支持的笔记类型。', 'annotation.type.invalid');
   }
   if (!hasClientId && !hasSourceId) {
     throw new MokeApiError('笔记缺少稳定的幂等标识。', 'annotation.identity.missing');
   }
-  if (hasSourceName !== hasSourceId || hasAnySourceField !== hasSourceName || input.source_name?.trim() === 'talebook') {
+  if (hasSourceName !== hasSourceId || hasAnySourceField !== hasSourceName) {
     throw new MokeApiError('笔记来源标识不完整。', 'annotation.source.invalid');
   }
   if (input.client_id && input.client_id.length > 64) {
     throw new MokeApiError('笔记客户端标识过长。', 'annotation.identity.invalid');
   }
+}
+
+function normalizeUpsertAnnotation(
+  value: unknown,
+  input: AnnotationUpsertInput,
+  requestedBookId: string | number,
+): BookAnnotation {
+  try {
+    return normalizeAnnotation(value);
+  } catch {
+    // A successful idempotent POST may return a compact representation even
+    // when the GET endpoint uses the full v2 shape. Preserve the committed
+    // result by filling optional display fields from the submitted payload.
+  }
+
+  if (!isRecord(value)) throw unsupportedContractError();
+  const id = finiteNumber(value.id);
+  const bookId = finiteNumber(value.book_id) ?? finiteNumber(requestedBookId);
+  const annotationType = typeof value.annotation_type === 'string'
+    && ANNOTATION_TYPES.includes(value.annotation_type as AnnotationType)
+    ? value.annotation_type as AnnotationType
+    : input.annotation_type;
+  if (id === null || bookId === null || !ANNOTATION_TYPES.includes(annotationType)) {
+    throw unsupportedContractError();
+  }
+
+  const sources: AnnotationSource[] = [];
+  if (Array.isArray(value.sources)) {
+    for (const source of value.sources) {
+      try {
+        sources.push(normalizeSource(source));
+      } catch {
+        // A malformed optional source must not turn a committed POST into a
+        // visible save failure. The next GET can recover the canonical shape.
+      }
+    }
+  }
+
+  return {
+    id,
+    book_id: bookId,
+    client_id: nullableString(value.client_id) ?? nullableString(input.client_id),
+    annotation_type: annotationType,
+    is_private: typeof value.is_private === 'boolean' ? value.is_private : input.is_private ?? true,
+    cfi: fallbackNullableString(value.cfi, input.cfi),
+    chapter: fallbackString(value.chapter, input.chapter),
+    quote_text: fallbackString(value.quote_text, input.quote_text),
+    content: fallbackString(value.content, input.content),
+    color: fallbackString(value.color, input.color),
+    author_name: fallbackString(value.author_name, input.author_name),
+    user_modified_at: nullableString(value.user_modified_at),
+    created_at: nullableString(value.created_at),
+    updated_at: nullableString(value.updated_at),
+    sources,
+  };
 }
 
 function normalizeAnnotation(value: unknown): BookAnnotation {
@@ -390,6 +489,39 @@ function nullableString(value: unknown): string | null {
   return typeof value === 'string' && value ? value : null;
 }
 
+function fallbackString(value: unknown, fallback: unknown): string {
+  return typeof value === 'string' ? value : stringValue(fallback);
+}
+
+function fallbackNullableString(value: unknown, fallback: unknown): string | null {
+  if (value === null) return null;
+  return nullableString(value) ?? nullableString(fallback);
+}
+
+function finiteNumber(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return null;
+}
+
+function hasMeaningfulString(value: unknown): boolean {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function isTransportError(error: unknown): boolean {
+  return error instanceof TypeError
+    || error instanceof Error && TRANSPORT_ERROR_PATTERN.test(error.message);
+}
+
+function readestAnnotationCfi(value: string | null): string | null {
+  if (!value) return null;
+  const cfi = value.trim();
+  return /^epubcfi\(.+\)$/.test(cfi) ? cfi : null;
+}
+
 function unsupportedContractError(): MokeApiError {
   return new MokeApiError(
     `当前 Talebook 服务器未提供兼容的笔记契约（需要 ${TALEBOOK_ANNOTATION_CONTRACT}）。`,
@@ -399,8 +531,7 @@ function unsupportedContractError(): MokeApiError {
 
 function asCompatibilityError(error: unknown): unknown {
   if (error instanceof MokeApiError && (
-    error.status === 404
-    || ['page.not_found', 'handler.not_found', 'api.not_found'].includes(error.code)
+    ['page.not_found', 'handler.not_found', 'api.not_found'].includes(error.code)
   )) {
     return unsupportedContractError();
   }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -276,16 +276,18 @@ export async function discoverServerCapabilities(serverUrl: string): Promise<Ser
   const info = await readJsonResponse<UserInfoResponse>(infoResponse).catch(() => ({} as UserInfoResponse));
   const sampleBookId = await findSampleBookId(serverUrl);
 
-  const [shelfApi, readingStatsApi, networkSourcesApi, readingStateApi, readingProgressApi] = await Promise.all([
+  const [shelfApi, readingStatsApi, networkSourcesApi, readingStateApi, readingProgressApi, annotationApi] = await Promise.all([
     probeJsonEndpoint(serverUrl, '/api/shelf'),
     probeJsonEndpoint(serverUrl, '/api/reading/stats'),
     probeJsonEndpoint(serverUrl, '/api/network/sources'),
     sampleBookId ? probeJsonEndpoint(serverUrl, `/api/book/${sampleBookId}/readstate`) : Promise.resolve(true),
     sampleBookId ? probeJsonEndpoint(serverUrl, `/api/book/${sampleBookId}/progress`) : Promise.resolve(true),
+    sampleBookId ? probeJsonEndpoint(serverUrl, `/api/book/${sampleBookId}/annotations`) : Promise.resolve(true),
   ]);
 
   return {
     shelfApi,
+    annotationApi,
     readingStateApi,
     readingProgressApi,
     readingStatsApi,

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -276,12 +276,13 @@ export async function discoverServerCapabilities(serverUrl: string): Promise<Ser
   const info = await readJsonResponse<UserInfoResponse>(infoResponse).catch(() => ({} as UserInfoResponse));
   const sampleBookId = await findSampleBookId(serverUrl);
 
-  const [shelfApi, readingStatsApi, networkSourcesApi, readingStateApi, readingProgressApi] = await Promise.all([
+  const [shelfApi, readingStatsApi, networkSourcesApi, readingStateApi, readingProgressApi, annotationApi] = await Promise.all([
     probeJsonEndpoint(serverUrl, '/api/shelf'),
     probeJsonEndpoint(serverUrl, '/api/reading/stats'),
     probeJsonEndpoint(serverUrl, '/api/network/sources'),
     sampleBookId ? probeJsonEndpoint(serverUrl, `/api/book/${sampleBookId}/readstate`) : Promise.resolve(true),
     sampleBookId ? probeJsonEndpoint(serverUrl, `/api/book/${sampleBookId}/progress`) : Promise.resolve(true),
+    sampleBookId ? probeJsonEndpoint(serverUrl, `/api/book/${sampleBookId}/annotations`) : Promise.resolve(false),
   ]);
 
   return {
@@ -290,6 +291,7 @@ export async function discoverServerCapabilities(serverUrl: string): Promise<Ser
     readingProgressApi,
     readingStatsApi,
     networkSourcesApi,
+    annotationApi,
     checkedAt: Date.now(),
     version: info.sys?.version || '',
   };

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -276,13 +276,12 @@ export async function discoverServerCapabilities(serverUrl: string): Promise<Ser
   const info = await readJsonResponse<UserInfoResponse>(infoResponse).catch(() => ({} as UserInfoResponse));
   const sampleBookId = await findSampleBookId(serverUrl);
 
-  const [shelfApi, readingStatsApi, networkSourcesApi, readingStateApi, readingProgressApi, annotationApi] = await Promise.all([
+  const [shelfApi, readingStatsApi, networkSourcesApi, readingStateApi, readingProgressApi] = await Promise.all([
     probeJsonEndpoint(serverUrl, '/api/shelf'),
     probeJsonEndpoint(serverUrl, '/api/reading/stats'),
     probeJsonEndpoint(serverUrl, '/api/network/sources'),
     sampleBookId ? probeJsonEndpoint(serverUrl, `/api/book/${sampleBookId}/readstate`) : Promise.resolve(true),
     sampleBookId ? probeJsonEndpoint(serverUrl, `/api/book/${sampleBookId}/progress`) : Promise.resolve(true),
-    sampleBookId ? probeJsonEndpoint(serverUrl, `/api/book/${sampleBookId}/annotations`) : Promise.resolve(false),
   ]);
 
   return {
@@ -291,7 +290,6 @@ export async function discoverServerCapabilities(serverUrl: string): Promise<Ser
     readingProgressApi,
     readingStatsApi,
     networkSourcesApi,
-    annotationApi,
     checkedAt: Date.now(),
     version: info.sys?.version || '',
   };

--- a/src/lib/store/server.ts
+++ b/src/lib/store/server.ts
@@ -29,6 +29,7 @@ export interface ReaderInfo {
 
 export interface ServerCapabilities {
   shelfApi: boolean;
+  annotationApi: boolean;
   readingStateApi: boolean;
   readingProgressApi: boolean;
   readingStatsApi: boolean;
@@ -39,6 +40,7 @@ export interface ServerCapabilities {
 
 export const DEFAULT_SERVER_CAPABILITIES: ServerCapabilities = {
   shelfApi: false,
+  annotationApi: false,
   readingStateApi: false,
   readingProgressApi: false,
   readingStatsApi: false,
@@ -130,11 +132,23 @@ export const useServerStore = create<ServerState>()(
       storage: createJSONStorage(() => safeLocalStorage),
       // 持久化数据里的 hasHydrated 可能被卡住时的旧状态污染（false），
       // merge 时强制为 true；其余字段仍按持久化值恢复。
-      merge: (persistedState, currentState) => ({
-        ...currentState,
-        ...(persistedState as object),
-        hasHydrated: true,
-      }),
+      merge: (persistedState, currentState) => {
+        const persisted = (persistedState ?? {}) as Partial<ServerState>;
+        const persistedCapabilities = persisted.capabilities as Partial<ServerCapabilities> | undefined;
+        const hasAnnotationCapability = typeof persistedCapabilities?.annotationApi === 'boolean';
+        return {
+          ...currentState,
+          ...persisted,
+          capabilities: {
+            ...currentState.capabilities,
+            ...persistedCapabilities,
+            // Older persisted stores predate annotationApi. Force one fresh
+            // discovery instead of treating a missing field as unsupported.
+            checkedAt: hasAnnotationCapability ? persistedCapabilities?.checkedAt ?? null : null,
+          },
+          hasHydrated: true,
+        };
+      },
       onRehydrateStorage: () => (state) => {
         state?.setHasHydrated(true);
       },

--- a/src/lib/store/server.ts
+++ b/src/lib/store/server.ts
@@ -33,6 +33,7 @@ export interface ServerCapabilities {
   readingProgressApi: boolean;
   readingStatsApi: boolean;
   networkSourcesApi: boolean;
+  annotationApi: boolean;
   checkedAt: number | null;
   version: string;
 }
@@ -43,6 +44,7 @@ export const DEFAULT_SERVER_CAPABILITIES: ServerCapabilities = {
   readingProgressApi: false,
   readingStatsApi: false,
   networkSourcesApi: false,
+  annotationApi: false,
   checkedAt: null,
   version: '',
 };

--- a/src/lib/store/server.ts
+++ b/src/lib/store/server.ts
@@ -33,7 +33,6 @@ export interface ServerCapabilities {
   readingProgressApi: boolean;
   readingStatsApi: boolean;
   networkSourcesApi: boolean;
-  annotationApi: boolean;
   checkedAt: number | null;
   version: string;
 }
@@ -44,7 +43,6 @@ export const DEFAULT_SERVER_CAPABILITIES: ServerCapabilities = {
   readingProgressApi: false,
   readingStatsApi: false,
   networkSourcesApi: false,
-  annotationApi: false,
   checkedAt: null,
   version: '',
 };

--- a/tests/annotations.test.mjs
+++ b/tests/annotations.test.mjs
@@ -1,0 +1,207 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  annotationReaderProgress,
+  annotationSourceNames,
+  fetchBookAnnotations,
+  isAnnotationApiUnsupported,
+  stableMokeAnnotationClientId,
+  TALEBOOK_ANNOTATION_CONTRACT,
+  upsertBookAnnotation,
+  upsertBookAnnotations,
+} from '../src/lib/annotations.ts';
+
+function annotation(overrides = {}) {
+  return {
+    id: 7,
+    book_id: 42,
+    client_id: 'moke-local-1',
+    annotation_type: 'note',
+    is_private: true,
+    cfi: null,
+    chapter: '第二章',
+    quote_text: '引用文字',
+    content: '笔记正文',
+    color: '',
+    author_name: '',
+    user_modified_at: null,
+    created_at: '2026-08-16T08:00:00',
+    updated_at: '2026-08-16T09:00:00',
+    sources: [],
+    ...overrides,
+  };
+}
+
+function jsonResponse(body, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+test('Moke client_id 对同一本书和本地记录保持稳定且满足长度约束', () => {
+  const first = stableMokeAnnotationClientId(42, 'local-record-9');
+  assert.equal(first, stableMokeAnnotationClientId('42', 'local-record-9'));
+  assert.notEqual(first, stableMokeAnnotationClientId(42, 'local-record-10'));
+  assert.ok(first.length <= 64);
+});
+
+test('读取 contract v2 笔记并保留来源与无 CFI 的章节降级数据', async () => {
+  const source = {
+    id: 10,
+    source_name: 'weread',
+    source_connection_id: 'conn-1',
+    source_annotation_id: 'remote-1',
+    source_run_id: 'run-2',
+    source_position: 'chapter:2',
+    source_raw_hash: 'hash',
+    source_updated_at: '2026-08-16T08:00:00',
+    source_sync_status: 'synced',
+    source_synced_at: '2026-08-16T08:01:00',
+    source_sync_error: null,
+  };
+  const items = await fetchBookAnnotations(
+    async (url, init) => {
+      assert.equal(url, 'http://talebook/api/book/42/annotations');
+      assert.equal(init.credentials, 'include');
+      return jsonResponse({ err: 'ok', annotations: [annotation({ sources: [source] })] });
+    },
+    'http://talebook',
+    42,
+  );
+
+  assert.equal(items[0].cfi, null);
+  assert.equal(items[0].chapter, '第二章');
+  assert.deepEqual(annotationSourceNames(items[0]), ['weread']);
+  assert.equal(annotationReaderProgress(items[0], 42), null);
+});
+
+test('CFI 标注转换为 Readest 精确定位进度', () => {
+  const progress = annotationReaderProgress(annotation({ cfi: 'epubcfi(/6/4!/4/2/8)' }), 42);
+  assert.equal(progress.schema, 'moke.readest.progress.v1');
+  assert.equal(progress.location, 'epubcfi(/6/4!/4/2/8)');
+  assert.equal(progress.chapter, '第二章');
+});
+
+test('429/5xx/网络错误有限重试，登录失效不会重试', async () => {
+  let attempts = 0;
+  const items = await fetchBookAnnotations(
+    async () => {
+      attempts += 1;
+      if (attempts < 3) return jsonResponse({ err: 'busy', msg: '稍后重试' }, 503);
+      return jsonResponse({ err: 'ok', annotations: [annotation()] });
+    },
+    'http://talebook',
+    42,
+    { retryDelayMs: 0, sleep: async () => {} },
+  );
+  assert.equal(attempts, 3);
+  assert.equal(items.length, 1);
+
+  attempts = 0;
+  await assert.rejects(
+    () => fetchBookAnnotations(
+      async () => {
+        attempts += 1;
+        return jsonResponse({ err: 'user.need_login', msg: '请登录' });
+      },
+      'http://talebook',
+      42,
+      { retryDelayMs: 0, sleep: async () => {} },
+    ),
+    (error) => error.code === 'user.need_login',
+  );
+  assert.equal(attempts, 1);
+});
+
+test('重复 upsert 复用 client_id，且来源字段使用 v2 source_ 前缀', async () => {
+  const ids = new Map();
+  let nextId = 1;
+  const bodies = [];
+  const requestLike = async (_url, init) => {
+    const body = JSON.parse(init.body);
+    bodies.push(body);
+    const identity = body.client_id || `${body.source_name}:${body.source_connection_id}:${body.source_annotation_id}`;
+    if (!ids.has(identity)) ids.set(identity, nextId++);
+    return jsonResponse({
+      err: 'ok',
+      created: bodies.length === 1,
+      stale_ignored: false,
+      conflict_protected: false,
+      sync_enqueued: false,
+      annotation: annotation({ id: ids.get(identity), client_id: body.client_id || null }),
+    });
+  };
+
+  const input = { annotation_type: 'highlight', client_id: 'moke-stable-1', quote_text: '相同高亮' };
+  const first = await upsertBookAnnotation(requestLike, 'http://talebook', 42, input);
+  const second = await upsertBookAnnotation(requestLike, 'http://talebook', 42, input);
+  assert.equal(first.annotation.id, second.annotation.id);
+  assert.equal(ids.size, 1);
+
+  await upsertBookAnnotation(requestLike, 'http://talebook', 42, {
+    annotation_type: 'bookmark',
+    source_name: 'moke',
+    source_connection_id: 'desktop-1',
+    source_annotation_id: 'bookmark-9',
+    source_position: 'chapter:3',
+  });
+  assert.equal(bodies[2].source_name, 'moke');
+  assert.equal(bodies[2].source_annotation_id, 'bookmark-9');
+  assert.equal('source' in bodies[2], false);
+  assert.equal('external_id' in bodies[2], false);
+});
+
+test('批量 upsert 报告部分成功并保留失败项供恢复', async () => {
+  const result = await upsertBookAnnotations(
+    async (_url, init) => {
+      const body = JSON.parse(init.body);
+      if (body.client_id === 'denied') {
+        return jsonResponse({ err: 'permission.denied', msg: '没有权限' }, 403);
+      }
+      return jsonResponse({
+        err: 'ok',
+        created: true,
+        stale_ignored: false,
+        conflict_protected: false,
+        sync_enqueued: false,
+        annotation: annotation({ client_id: body.client_id }),
+      });
+    },
+    'http://talebook',
+    42,
+    [
+      { annotation_type: 'note', client_id: 'ok-1', content: '成功' },
+      { annotation_type: 'note', client_id: 'denied', content: '失败' },
+    ],
+    { maxRetries: 0 },
+  );
+  assert.equal(result.succeeded.length, 1);
+  assert.equal(result.failed.length, 1);
+  assert.equal(result.failed[0].input.client_id, 'denied');
+  assert.equal(result.failed[0].retryable, false);
+});
+
+test('旧服务器或畸形响应明确标记为 contract 不兼容', async () => {
+  await assert.rejects(
+    () => fetchBookAnnotations(
+      async () => jsonResponse({ err: 'page.not_found' }, 404),
+      'http://talebook',
+      42,
+      { maxRetries: 0 },
+    ),
+    (error) => isAnnotationApiUnsupported(error)
+      && error.message.includes(TALEBOOK_ANNOTATION_CONTRACT),
+  );
+
+  await assert.rejects(
+    () => fetchBookAnnotations(
+      async () => jsonResponse({ err: 'ok', annotations: [{ id: 1 }] }),
+      'http://talebook',
+      42,
+      { maxRetries: 0 },
+    ),
+    isAnnotationApiUnsupported,
+  );
+});

--- a/tests/annotations.test.mjs
+++ b/tests/annotations.test.mjs
@@ -153,6 +153,46 @@ test('重复 upsert 复用 client_id，且来源字段使用 v2 source_ 前缀',
   assert.equal('external_id' in bodies[2], false);
 });
 
+test('写入不重试服务端 5xx，但响应丢失时可按相同幂等键重试', async () => {
+  let attempts = 0;
+  await assert.rejects(
+    () => upsertBookAnnotation(
+      async () => {
+        attempts += 1;
+        return jsonResponse({ err: 'server.error', msg: '配置错误' }, 500);
+      },
+      'http://talebook',
+      42,
+      { annotation_type: 'note', client_id: 'no-5xx-retry' },
+      { retryDelayMs: 0, sleep: async () => {} },
+    ),
+    (error) => error.status === 500,
+  );
+  assert.equal(attempts, 1);
+
+  attempts = 0;
+  const result = await upsertBookAnnotation(
+    async () => {
+      attempts += 1;
+      if (attempts === 1) throw new TypeError('Failed to fetch');
+      return jsonResponse({
+        err: 'ok',
+        created: false,
+        stale_ignored: false,
+        conflict_protected: false,
+        sync_enqueued: false,
+        annotation: annotation({ client_id: 'safe-network-retry' }),
+      });
+    },
+    'http://talebook',
+    42,
+    { annotation_type: 'note', client_id: 'safe-network-retry' },
+    { retryDelayMs: 0, sleep: async () => {} },
+  );
+  assert.equal(attempts, 2);
+  assert.equal(result.annotation.client_id, 'safe-network-retry');
+});
+
 test('批量 upsert 报告部分成功并保留失败项供恢复', async () => {
   const result = await upsertBookAnnotations(
     async (_url, init) => {
@@ -183,7 +223,39 @@ test('批量 upsert 报告部分成功并保留失败项供恢复', async () => 
   assert.equal(result.failed[0].retryable, false);
 });
 
-test('旧服务器或畸形响应明确标记为 contract 不兼容', async () => {
+test('批量 upsert 按配置限制并发请求数', async () => {
+  let active = 0;
+  let maxActive = 0;
+  const inputs = Array.from({ length: 17 }, (_, index) => ({
+    annotation_type: 'note',
+    client_id: `batch-${index}`,
+  }));
+  const result = await upsertBookAnnotations(
+    async (_url, init) => {
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      await new Promise((resolve) => setTimeout(resolve, 2));
+      active -= 1;
+      const body = JSON.parse(init.body);
+      return jsonResponse({
+        err: 'ok',
+        created: true,
+        stale_ignored: false,
+        conflict_protected: false,
+        sync_enqueued: false,
+        annotation: annotation({ id: Number(body.client_id.replace('batch-', '')) + 1, client_id: body.client_id }),
+      });
+    },
+    'http://talebook',
+    42,
+    inputs,
+    { maxRetries: 0, concurrency: 4 },
+  );
+  assert.equal(result.succeeded.length, inputs.length);
+  assert.ok(maxActive <= 4, `并发峰值 ${maxActive} 应 <= 4`);
+});
+
+test('旧服务器或非数组响应明确标记为 contract 不兼容', async () => {
   await assert.rejects(
     () => fetchBookAnnotations(
       async () => jsonResponse({ err: 'page.not_found' }, 404),
@@ -197,11 +269,29 @@ test('旧服务器或畸形响应明确标记为 contract 不兼容', async () =
 
   await assert.rejects(
     () => fetchBookAnnotations(
-      async () => jsonResponse({ err: 'ok', annotations: [{ id: 1 }] }),
+      async () => jsonResponse({ err: 'ok', annotations: { id: 1 } }),
       'http://talebook',
       42,
       { maxRetries: 0 },
     ),
     isAnnotationApiUnsupported,
   );
+});
+
+test('单条畸形记录不会隐藏同一响应中的合法笔记', async () => {
+  const items = await fetchBookAnnotations(
+    async () => jsonResponse({
+      err: 'ok',
+      annotations: [
+        annotation({ id: 1 }),
+        { id: 'broken', content: '不完整记录' },
+        annotation({ id: 2, sources: [{ source_name: 'missing-required-fields' }] }),
+        annotation({ id: 3, content: '仍可展示' }),
+      ],
+    }),
+    'http://talebook',
+    42,
+    { maxRetries: 0 },
+  );
+  assert.deepEqual(items.map((item) => item.id), [1, 3]);
 });

--- a/tests/annotations.test.mjs
+++ b/tests/annotations.test.mjs
@@ -81,6 +81,19 @@ test('读取 contract v2 笔记并保留来源与无 CFI 的章节降级数据',
   assert.equal(annotationReaderProgress(items[0], 42), null);
 });
 
+test('GET 与 POST 一致兼容数字字符串形式的 annotation/book id', async () => {
+  const items = await fetchBookAnnotations(
+    async () => jsonResponse({
+      err: 'ok',
+      annotations: [annotation({ id: '7', book_id: '42' })],
+    }),
+    'http://talebook',
+    42,
+  );
+  assert.equal(items[0].id, 7);
+  assert.equal(items[0].book_id, 42);
+});
+
 test('CFI 标注转换为 Readest 精确定位进度', () => {
   const item = annotation({ cfi: '  epubcfi(/6/4!/4/2/8)  ' });
   const progress = annotationReaderProgress(item, 42);
@@ -96,7 +109,8 @@ test('CFI 标注转换为 Readest 精确定位进度', () => {
 
 test('标注定位恢复位置不会覆盖普通阅读进度，用户翻页后恢复同步', () => {
   const target = 'epubcfi(/6/4!/4/2/8)';
-  suppressAnnotationLocateProgress(42, target);
+  const serverUrl = 'http://talebook-a';
+  suppressAnnotationLocateProgress(serverUrl, 42, target);
   const restored = {
     schema: 'moke.readest.progress.v1',
     reader: 'readest',
@@ -104,11 +118,31 @@ test('标注定位恢复位置不会覆盖普通阅读进度，用户翻页后�
     location: target,
     updated_at: new Date().toISOString(),
   };
-  assert.equal(shouldSuppressAnnotationReaderProgress(restored), true);
-  assert.equal(shouldSuppressAnnotationReaderProgress(restored), true);
-  assert.equal(shouldSuppressAnnotationReaderProgress({ ...restored, location: 'epubcfi(/6/6)' }), false);
-  assert.equal(shouldSuppressAnnotationReaderProgress(restored), false);
-  clearAnnotationLocateProgressSuppression(42);
+  assert.equal(shouldSuppressAnnotationReaderProgress(serverUrl, restored), true);
+  assert.equal(
+    shouldSuppressAnnotationReaderProgress(serverUrl, { ...restored, location: 'reader-normalized-default' }),
+    true,
+  );
+  assert.equal(
+    shouldSuppressAnnotationReaderProgress(serverUrl, { ...restored, location: 'epubcfi(/6/6)' }, Date.now() + 11_000),
+    false,
+  );
+  assert.equal(shouldSuppressAnnotationReaderProgress(serverUrl, restored), false);
+  clearAnnotationLocateProgressSuppression(serverUrl, 42);
+});
+
+test('标注定位进度抑制按 serverUrl 隔离', () => {
+  const progress = {
+    schema: 'moke.readest.progress.v1',
+    reader: 'readest',
+    moke_book_id: '42',
+    location: 'epubcfi(/6/4)',
+    updated_at: new Date().toISOString(),
+  };
+  suppressAnnotationLocateProgress('http://talebook-a/', 42, progress.location);
+  assert.equal(shouldSuppressAnnotationReaderProgress('http://talebook-b', progress), false);
+  assert.equal(shouldSuppressAnnotationReaderProgress('http://talebook-a', progress), true);
+  clearAnnotationLocateProgressSuppression('http://talebook-a', 42);
 });
 
 test('429/5xx/网络错误有限重试，登录失效不会重试', async () => {
@@ -376,6 +410,28 @@ test('批量 upsert 按配置限制并发请求数', async () => {
     { maxRetries: 0, concurrency: 0 },
   );
   assert.equal(maxActive, 1);
+
+  active = 0;
+  maxActive = 0;
+  const oversizedBatch = Array.from({ length: 25 }, (_, index) => ({
+    annotation_type: 'note',
+    client_id: `oversized-${index}`,
+  }));
+  await upsertBookAnnotations(
+    async (_url, init) => {
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      await new Promise((resolve) => setTimeout(resolve, 2));
+      active -= 1;
+      const body = JSON.parse(init.body);
+      return jsonResponse({ err: 'ok', annotation: annotation({ client_id: body.client_id }) });
+    },
+    'http://talebook',
+    42,
+    oversizedBatch,
+    { maxRetries: 0, concurrency: 100 },
+  );
+  assert.ok(maxActive <= 20, `保护上限要求并发峰值 ${maxActive} <= 20`);
 });
 
 test('旧服务器或非数组响应明确标记为 contract 不兼容', async () => {

--- a/tests/annotations.test.mjs
+++ b/tests/annotations.test.mjs
@@ -4,9 +4,13 @@ import assert from 'node:assert/strict';
 import {
   annotationReaderProgress,
   annotationSourceNames,
+  clearAnnotationLocateProgressSuppression,
   fetchBookAnnotations,
+  hasReadestAnnotationLocation,
   isAnnotationApiUnsupported,
+  shouldSuppressAnnotationReaderProgress,
   stableMokeAnnotationClientId,
+  suppressAnnotationLocateProgress,
   TALEBOOK_ANNOTATION_CONTRACT,
   upsertBookAnnotation,
   upsertBookAnnotations,
@@ -78,10 +82,33 @@ test('读取 contract v2 笔记并保留来源与无 CFI 的章节降级数据',
 });
 
 test('CFI 标注转换为 Readest 精确定位进度', () => {
-  const progress = annotationReaderProgress(annotation({ cfi: 'epubcfi(/6/4!/4/2/8)' }), 42);
+  const item = annotation({ cfi: '  epubcfi(/6/4!/4/2/8)  ' });
+  const progress = annotationReaderProgress(item, 42);
+  assert.equal(hasReadestAnnotationLocation(item), true);
   assert.equal(progress.schema, 'moke.readest.progress.v1');
   assert.equal(progress.location, 'epubcfi(/6/4!/4/2/8)');
   assert.equal(progress.chapter, '第二章');
+
+  const external = annotation({ cfi: 'calibre-position:chapter-2' });
+  assert.equal(hasReadestAnnotationLocation(external), false);
+  assert.equal(annotationReaderProgress(external, 42), null);
+});
+
+test('标注定位恢复位置不会覆盖普通阅读进度，用户翻页后恢复同步', () => {
+  const target = 'epubcfi(/6/4!/4/2/8)';
+  suppressAnnotationLocateProgress(42, target);
+  const restored = {
+    schema: 'moke.readest.progress.v1',
+    reader: 'readest',
+    moke_book_id: '42',
+    location: target,
+    updated_at: new Date().toISOString(),
+  };
+  assert.equal(shouldSuppressAnnotationReaderProgress(restored), true);
+  assert.equal(shouldSuppressAnnotationReaderProgress(restored), true);
+  assert.equal(shouldSuppressAnnotationReaderProgress({ ...restored, location: 'epubcfi(/6/6)' }), false);
+  assert.equal(shouldSuppressAnnotationReaderProgress(restored), false);
+  clearAnnotationLocateProgressSuppression(42);
 });
 
 test('429/5xx/网络错误有限重试，登录失效不会重试', async () => {
@@ -113,6 +140,20 @@ test('429/5xx/网络错误有限重试，登录失效不会重试', async () => 
     (error) => error.code === 'user.need_login',
   );
   assert.equal(attempts, 1);
+
+  attempts = 0;
+  await fetchBookAnnotations(
+    async () => {
+      attempts += 1;
+      if (attempts === 1) throw new Error('error sending request for url: connection refused');
+      if (attempts === 2) throw new Error('operation timed out');
+      return jsonResponse({ err: 'ok', annotations: [] });
+    },
+    'http://talebook',
+    42,
+    { retryDelayMs: 0, sleep: async () => {} },
+  );
+  assert.equal(attempts, 3);
 });
 
 test('重复 upsert 复用 client_id，且来源字段使用 v2 source_ 前缀', async () => {
@@ -191,6 +232,70 @@ test('写入不重试服务端 5xx，但响应丢失时可按相同幂等键重�
   );
   assert.equal(attempts, 2);
   assert.equal(result.annotation.client_id, 'safe-network-retry');
+
+  attempts = 0;
+  await upsertBookAnnotation(
+    async () => {
+      attempts += 1;
+      if (attempts === 1) throw new Error('error sending request for url: operation timed out');
+      return jsonResponse({
+        err: 'ok',
+        annotation: annotation({ client_id: 'tauri-network-retry' }),
+      });
+    },
+    'http://talebook',
+    42,
+    { annotation_type: 'note', client_id: 'tauri-network-retry' },
+    { retryDelayMs: 0, sleep: async () => {} },
+  );
+  assert.equal(attempts, 2);
+});
+
+test('POST 精简响应按提交内容补全，不把已成功写入误报为契约失败', async () => {
+  const result = await upsertBookAnnotation(
+    async () => jsonResponse({
+      err: 'ok',
+      created: true,
+      annotation: { id: '19', annotation_type: 'note', content: '服务端正文' },
+    }),
+    'http://talebook',
+    42,
+    {
+      annotation_type: 'note',
+      client_id: 'compact-response',
+      chapter: '第三章',
+      content: '提交正文',
+      is_private: false,
+    },
+  );
+  assert.equal(result.annotation.id, 19);
+  assert.equal(result.annotation.book_id, 42);
+  assert.equal(result.annotation.client_id, 'compact-response');
+  assert.equal(result.annotation.chapter, '第三章');
+  assert.equal(result.annotation.content, '服务端正文');
+  assert.equal(result.annotation.is_private, false);
+  assert.deepEqual(result.annotation.sources, []);
+});
+
+test('空来源字段不触发伪部分来源错误，talebook 来源身份可合法回写', async () => {
+  const bodies = [];
+  const requestLike = async (_url, init) => {
+    const body = JSON.parse(init.body);
+    bodies.push(body);
+    return jsonResponse({ err: 'ok', annotation: annotation({ client_id: body.client_id ?? null }) });
+  };
+  await upsertBookAnnotation(requestLike, 'http://talebook', 42, {
+    annotation_type: 'note',
+    client_id: 'nullable-source-fields',
+    source_name: null,
+    source_connection_id: '   ',
+  });
+  await upsertBookAnnotation(requestLike, 'http://talebook', 42, {
+    annotation_type: 'highlight',
+    source_name: 'talebook',
+    source_annotation_id: 'native-9',
+  });
+  assert.equal(bodies.length, 2);
 });
 
 test('批量 upsert 报告部分成功并保留失败项供恢复', async () => {
@@ -253,6 +358,24 @@ test('批量 upsert 按配置限制并发请求数', async () => {
   );
   assert.equal(result.succeeded.length, inputs.length);
   assert.ok(maxActive <= 4, `并发峰值 ${maxActive} 应 <= 4`);
+
+  active = 0;
+  maxActive = 0;
+  await upsertBookAnnotations(
+    async (_url, init) => {
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      await new Promise((resolve) => setTimeout(resolve, 2));
+      active -= 1;
+      const body = JSON.parse(init.body);
+      return jsonResponse({ err: 'ok', annotation: annotation({ client_id: body.client_id }) });
+    },
+    'http://talebook',
+    42,
+    inputs.slice(0, 3),
+    { maxRetries: 0, concurrency: 0 },
+  );
+  assert.equal(maxActive, 1);
 });
 
 test('旧服务器或非数组响应明确标记为 contract 不兼容', async () => {
@@ -294,4 +417,26 @@ test('单条畸形记录不会隐藏同一响应中的合法笔记', async () =>
     { maxRetries: 0 },
   );
   assert.deepEqual(items.map((item) => item.id), [1, 3]);
+});
+
+test('非空响应全部畸形时报告契约不兼容，书籍 404 不误报接口缺失', async () => {
+  await assert.rejects(
+    () => fetchBookAnnotations(
+      async () => jsonResponse({ err: 'ok', annotations: [{ id: 'broken' }, { content: 'bad' }] }),
+      'http://talebook',
+      42,
+      { maxRetries: 0 },
+    ),
+    isAnnotationApiUnsupported,
+  );
+
+  await assert.rejects(
+    () => fetchBookAnnotations(
+      async () => jsonResponse({ err: 'book.not_found', msg: '书籍不存在' }, 404),
+      'http://talebook',
+      42,
+      { maxRetries: 0 },
+    ),
+    (error) => error.code === 'book.not_found' && !isAnnotationApiUnsupported(error),
+  );
 });


### PR DESCRIPTION
## Summary

- connect Moke to the Talebook annotations v2 contract for highlights, notes, bookmarks, chapter comments, source status, and idempotent writes
- open downloaded books at validated Readest CFI locations while preserving the user's normal continue-reading progress
- update the embedded Readest submodule to the latest `master` commit (`19656884d29d`)

## Validation

- merged current `main` into `feat/plugins` and resolved the detail-page store conflict while preserving annotation capabilities and guest access behavior
- `pnpm test` — 182 passed
- `pnpm typecheck` — passed
- `pnpm lint` — no errors (25 existing warnings)
- PR #50 CI passed: frontend quality, Rust tests, desktop build smoke test, and mobile/tablet/desktop page smoke test

## Related

- #50
- https://github.com/hehetoshang/readest/pull/10
- https://github.com/hehetoshang/readest/pull/11
