### PR TITLE
fix(mobile): Moke 主界面保持系统状态栏可见

### DIFF
--- a/src-tauri/android/MainActivity.kt
+++ b/src-tauri/android/MainActivity.kt
@@ -22,6 +22,8 @@ import android.webkit.JavascriptInterface
 import android.webkit.WebView
 import android.widget.Toast
 import androidx.activity.enableEdgeToEdge
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
 import com.readest.native_bridge.KeyDownInterceptor
 import java.lang.ref.WeakReference
 
@@ -39,6 +41,11 @@ class MainActivity : TauriActivity(), KeyDownInterceptor {
         @JavascriptInterface
         fun isInMultiWindowMode(): Boolean =
             activityRef.get()?.isInMultiWindowMode ?: false
+
+        @JavascriptInterface
+        fun showStatusBar(darkMode: Boolean) {
+            activityRef.get()?.showMokeStatusBar(darkMode)
+        }
     }
 
     companion object {
@@ -144,6 +151,21 @@ class MainActivity : TauriActivity(), KeyDownInterceptor {
         }
     }
 
+    /**
+     * Readest and Moke share this Activity on Android. The reader may enter an
+     * immersive mode that hides the system bars, so every Moke document asks
+     * the Activity to restore the top status bar. Keep the navigation bar
+     * untouched: its visibility remains owned by the current system/reader
+     * policy.
+     */
+    private fun showMokeStatusBar(darkMode: Boolean) {
+        runOnUiThread {
+            val controller = WindowCompat.getInsetsController(window, window.decorView)
+            controller.show(WindowInsetsCompat.Type.statusBars())
+            controller.isAppearanceLightStatusBars = !darkMode
+        }
+    }
+
     @Suppress("DEPRECATION")
     override fun onMultiWindowModeChanged(isInMultiWindowMode: Boolean) {
         super.onMultiWindowModeChanged(isInMultiWindowMode)
@@ -235,6 +257,7 @@ class MainActivity : TauriActivity(), KeyDownInterceptor {
     override fun onCreate(savedInstanceState: Bundle?) {
         enableEdgeToEdge()
         super.onCreate(savedInstanceState)
+        showMokeStatusBar(darkMode = false)
     }
 
     override fun onDestroy() {

--- a/src/components/providers/AppShell.tsx
+++ b/src/components/providers/AppShell.tsx
@@ -6,6 +6,7 @@ import { installConsoleCapture, uninstallConsoleCapture } from '@/lib/debug-log'
 import {
   getMokeRuntimePlatform,
   getNativeTopSafeAreaInset,
+  showMokeSystemStatusBar,
   shouldApplyTopSafeArea,
 } from '@/lib/moke-reader';
 import { useDeveloperStore } from '@/lib/store/developer';
@@ -17,6 +18,7 @@ declare global {
   interface Window {
     MokeWindowMode?: {
       isInMultiWindowMode: () => boolean;
+      showStatusBar?: (darkMode: boolean) => void;
     };
   }
 }
@@ -47,19 +49,45 @@ export function AppShell({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     const darkMq = window.matchMedia('(prefers-color-scheme: dark)');
     const autoEinkMq = window.matchMedia('(update: slow), (max-color: 1)');
+    let cancelled = false;
+    let platformPromise: Promise<string> | undefined;
+
+    const restoreStatusBar = (dark: boolean) => {
+      platformPromise ??= getMokeRuntimePlatform();
+      void platformPromise
+        .then(async (platform) => {
+          if (cancelled) return;
+          await showMokeSystemStatusBar(platform, dark, window.MokeWindowMode);
+        })
+        .catch((error) => {
+          if (!cancelled) console.warn('Unable to restore the Moke status bar:', error);
+        });
+    };
+
     const apply = () => {
       const resolved = resolveTheme(theme, darkMq.matches);
       const dark = !eink && !autoEinkMq.matches && resolved === 'dark';
       const el = document.documentElement;
       el.classList.toggle('dark', dark);
       el.style.colorScheme = dark ? 'dark' : 'light';
+      restoreStatusBar(dark);
+    };
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'visible') apply();
     };
     apply();
     darkMq.addEventListener('change', apply);
     autoEinkMq.addEventListener('change', apply);
+    window.addEventListener('pageshow', apply);
+    window.addEventListener('orientationchange', apply);
+    document.addEventListener('visibilitychange', handleVisibilityChange);
     return () => {
+      cancelled = true;
       darkMq.removeEventListener('change', apply);
       autoEinkMq.removeEventListener('change', apply);
+      window.removeEventListener('pageshow', apply);
+      window.removeEventListener('orientationchange', apply);
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
     };
   }, [theme, eink]);
 

--- a/src/lib/moke-reader.ts
+++ b/src/lib/moke-reader.ts
@@ -14,7 +14,46 @@ export const shouldApplyTopSafeArea = (
 ): boolean =>
   (platform === 'android' && !isMultiWindow) || platform === 'ios';
 
-type RuntimeInvoke = <T>(command: string) => Promise<T>;
+type RuntimeInvoke = <T>(command: string, args?: Record<string, unknown>) => Promise<T>;
+
+interface AndroidSystemUIBridge {
+  showStatusBar?: (darkMode: boolean) => void;
+}
+
+interface SystemUIVisibilityResponse {
+  success: boolean;
+  error?: string;
+}
+
+/**
+ * Restore the system status bar while the Moke shell is active. Android uses
+ * a Moke-owned bridge so restoring the top bar does not also change the
+ * navigation bar; iOS uses the existing native-bridge command. Readest has a
+ * separate frontend and keeps ownership of its own immersive/fullscreen UI.
+ */
+export async function showMokeSystemStatusBar(
+  platform: string,
+  darkMode: boolean,
+  androidBridge?: AndroidSystemUIBridge,
+  invokeOverride?: RuntimeInvoke,
+): Promise<boolean> {
+  if (platform === 'android') {
+    if (!androidBridge?.showStatusBar) return false;
+    androidBridge.showStatusBar(darkMode);
+    return true;
+  }
+  if (platform !== 'ios') return false;
+
+  const invoke = invokeOverride ?? (await import('@tauri-apps/api/core')).invoke;
+  const response = await invoke<SystemUIVisibilityResponse>(
+    'plugin:native-bridge|set_system_ui_visibility',
+    { payload: { visible: true, darkMode } },
+  );
+  if (!response.success) {
+    throw new Error(response.error || 'Unable to show the iOS status bar');
+  }
+  return true;
+}
 
 interface StatusBarHeightResponse {
   height: number;

--- a/tests/android-back.test.mjs
+++ b/tests/android-back.test.mjs
@@ -66,6 +66,14 @@ test('Android 分屏时通过原生窗口状态移除重复的顶部安全区', 
   );
 });
 
+test('Android Moke 主界面显式恢复顶部状态栏且不接管导航栏', () => {
+  assert.match(activitySource, /fun showStatusBar\(darkMode: Boolean\)/);
+  assert.match(activitySource, /show\(WindowInsetsCompat\.Type\.statusBars\(\)\)/);
+  assert.match(activitySource, /isAppearanceLightStatusBars = !darkMode/);
+  assert.doesNotMatch(activitySource, /showMokeStatusBar[\s\S]*?navigationBars\(\)/);
+  assert.match(appShellSource, /showMokeSystemStatusBar\(platform, dark, window\.MokeWindowMode\)/);
+});
+
 test('Android 返回先渲染上一页，再只把当前页向右划出', () => {
   assert.match(backNavigationSource, /document\.startViewTransition/);
   assert.match(backNavigationSource, /pending\.target === pathname/);

--- a/tests/moke-reader.test.mjs
+++ b/tests/moke-reader.test.mjs
@@ -9,6 +9,7 @@ import {
   isSingleWebviewRuntime,
   resolveRuntimeCategory,
   runtimeCategoryFromPlatform,
+  showMokeSystemStatusBar,
   shouldApplyTopSafeArea,
   shouldIncludeServerUrl,
 } from '../src/lib/moke-reader.ts';
@@ -73,6 +74,43 @@ test('native top safe area rejects errors and normalizes invalid values', async 
   assert.equal(
     await getNativeTopSafeAreaInset('ios', 2, async () => ({ top: Number.NaN })),
     0,
+  );
+});
+
+test('Moke restores the mobile status bar without changing Android navigation UI', async () => {
+  const androidCalls = [];
+  const androidBridge = {
+    showStatusBar: (darkMode) => androidCalls.push(darkMode),
+  };
+  const invokeCalls = [];
+  const invoke = async (command, args) => {
+    invokeCalls.push([command, args]);
+    return { success: true };
+  };
+
+  assert.equal(await showMokeSystemStatusBar('android', true, androidBridge, invoke), true);
+  assert.deepEqual(androidCalls, [true]);
+  assert.deepEqual(invokeCalls, []);
+
+  assert.equal(await showMokeSystemStatusBar('ios', false, undefined, invoke), true);
+  assert.deepEqual(invokeCalls, [[
+    'plugin:native-bridge|set_system_ui_visibility',
+    { payload: { visible: true, darkMode: false } },
+  ]]);
+
+  assert.equal(await showMokeSystemStatusBar('ohos', false, androidBridge, invoke), false);
+  assert.equal(await showMokeSystemStatusBar('windows', false, androidBridge, invoke), false);
+  assert.deepEqual(androidCalls, [true]);
+  assert.equal(invokeCalls.length, 1);
+});
+
+test('Moke surfaces iOS status-bar restoration failures', async () => {
+  await assert.rejects(
+    showMokeSystemStatusBar('ios', false, undefined, async () => ({
+      success: false,
+      error: 'status bar unavailable',
+    })),
+    /status bar unavailable/,
   );
 });
 


### PR DESCRIPTION
## 变更

- Android 由 Moke 自有桥恢复顶部状态栏，不改变底部导航栏状态
- iOS 在 Moke AppShell 激活时恢复状态栏
- 在启动、回到前台、页面恢复及旋转时重新同步，并匹配浅色/深色图标
- Readest 的全屏与系统栏行为保持不变

## 验证

- pnpm test（186 项通过）
- pnpm typecheck
- pnpm lint（0 errors，25 个既有 warnings）
- pnpm build