### PR TITLE
feat: 调整各平台系统应用名称

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -234,6 +234,10 @@ jobs:
         if: matrix.platform == 'android'
         run: pnpm tauri android init
 
+      - name: Add localized Android app names
+        if: matrix.platform == 'android'
+        run: node scripts/prepare-mobile-app-names.mjs android
+
       # tauri android init scaffolds gen/android with Tauri's DEFAULT launcher icons.
       # Regenerate them from src-tauri/icons/icon.png: since gen/android already
       # exists, `tauri icon` writes straight into gen/android/app/src/main/res/
@@ -343,6 +347,10 @@ jobs:
         env:
           APPLE_DEVELOPMENT_TEAM: "6X9BLAS47C"
         run: pnpm tauri ios init
+
+      - name: Add localized iOS app names
+        if: matrix.platform == 'ios'
+        run: node scripts/prepare-mobile-app-names.mjs ios
 
       # Tauri forces Automatic signing + -allowProvisioningUpdates, which needs a
       # logged-in Xcode Apple ID (unavailable on CI) -> "No Accounts". Switch the

--- a/scripts/merge-updater-json.cjs
+++ b/scripts/merge-updater-json.cjs
@@ -46,7 +46,7 @@ const base = `https://github.com/talebook/moke/releases/download/v${version}`;
 function platformFromName(name) {
   const n = name.toLowerCase();
   if (n.includes('setup.exe.sig')) return 'windows-x86_64';
-  if (n.includes('en-us.msi.sig')) return 'windows-x86_64-msi'; // dedup below
+  if (n.endsWith('.msi.sig')) return 'windows-x86_64-msi'; // dedup below
   if (n.includes('aarch64.dmg.sig')) return 'darwin-aarch64';
   if (n.includes('x64.dmg.sig')) return 'darwin-x86_64';
   if (n.includes('amd64.appimage.sig')) return 'linux-x86_64';

--- a/scripts/merge-updater-json.cjs
+++ b/scripts/merge-updater-json.cjs
@@ -46,7 +46,7 @@ const base = `https://github.com/talebook/moke/releases/download/v${version}`;
 function platformFromName(name) {
   const n = name.toLowerCase();
   if (n.includes('setup.exe.sig')) return 'windows-x86_64';
-  if (n.endsWith('.msi.sig')) return 'windows-x86_64-msi'; // dedup below
+  if (n.includes('en-us.msi.sig')) return 'windows-x86_64-msi'; // dedup below
   if (n.includes('aarch64.dmg.sig')) return 'darwin-aarch64';
   if (n.includes('x64.dmg.sig')) return 'darwin-x86_64';
   if (n.includes('amd64.appimage.sig')) return 'linux-x86_64';

--- a/scripts/prepare-mobile-app-names.mjs
+++ b/scripts/prepare-mobile-app-names.mjs
@@ -1,0 +1,67 @@
+import { copyFileSync, mkdirSync, readdirSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const projectRoot = fileURLToPath(new URL('..', import.meta.url));
+
+export function prepareAndroidAppNames(root = projectRoot) {
+  const source = path.join(root, 'src-tauri', 'mobile', 'android', 'values-en', 'strings.xml');
+  const destinationDir = path.join(
+    root,
+    'src-tauri',
+    'gen',
+    'android',
+    'app',
+    'src',
+    'main',
+    'res',
+    'values-en',
+  );
+  mkdirSync(destinationDir, { recursive: true });
+  copyFileSync(source, path.join(destinationDir, 'strings.xml'));
+}
+
+export function prepareIosAppNames(root = projectRoot, run = spawnSync) {
+  const appleRoot = path.join(root, 'src-tauri', 'gen', 'apple');
+  const appDirectory = readdirSync(appleRoot, { withFileTypes: true })
+    .find((entry) => entry.isDirectory() && entry.name.endsWith('_iOS'))?.name;
+
+  if (!appDirectory) {
+    throw new Error(`Generated iOS app directory was not found under ${appleRoot}`);
+  }
+
+  const source = path.join(root, 'src-tauri', 'mobile', 'ios', 'en.lproj', 'InfoPlist.strings');
+  const destinationDir = path.join(appleRoot, appDirectory, 'en.lproj');
+  mkdirSync(destinationDir, { recursive: true });
+  copyFileSync(source, path.join(destinationDir, 'InfoPlist.strings'));
+
+  // The generated Xcode project only knows about files that existed when
+  // `tauri ios init` ran. Regenerate it now so InfoPlist.strings is bundled.
+  const result = run(
+    'xcodegen',
+    ['generate', '--spec', path.join(appleRoot, 'project.yml')],
+    { cwd: appleRoot, encoding: 'utf8', stdio: 'inherit' },
+  );
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(`xcodegen exited with status ${result.status}`);
+  }
+}
+
+const invokedDirectly = process.argv[1]
+  && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (invokedDirectly) {
+  const platform = process.argv[2];
+  if (platform === 'android') {
+    prepareAndroidAppNames();
+    console.log('[app-names] Added Android English app name: Moke');
+  } else if (platform === 'ios') {
+    prepareIosAppNames();
+    console.log('[app-names] Added iOS English app name: Moke');
+  } else {
+    console.error('Usage: node scripts/prepare-mobile-app-names.mjs <android|ios>');
+    process.exitCode = 1;
+  }
+}

--- a/src-tauri/Info.ios.plist
+++ b/src-tauri/Info.ios.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleDisplayName</key>
+  <string>墨客</string>
+</dict>
+</plist>

--- a/src-tauri/mobile/android/values-en/strings.xml
+++ b/src-tauri/mobile/android/values-en/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">Moke</string>
+    <string name="main_activity_title">Moke</string>
+</resources>

--- a/src-tauri/mobile/ios/en.lproj/InfoPlist.strings
+++ b/src-tauri/mobile/ios/en.lproj/InfoPlist.strings
@@ -1,0 +1,2 @@
+"CFBundleDisplayName" = "Moke";
+"CFBundleName" = "Moke";

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -51,8 +51,7 @@
     ],
     "windows": {
       "wix": {
-        "upgradeCode": "d1dfe239-c6ec-5195-980b-2d6cd723458a",
-        "language": "zh-CN"
+        "upgradeCode": "d1dfe239-c6ec-5195-980b-2d6cd723458a"
       },
       "nsis": {
         "installMode": "currentUser"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
-  "productName": "Moke",
+  "productName": "墨客",
   "version": "../package.json",
   "identifier": "org.houheya.moke",
   "build": {
@@ -12,7 +12,7 @@
   "app": {
     "windows": [
       {
-        "title": "Moke",
+        "title": "墨客",
         "width": 1280,
         "height": 800,
         "minWidth": 800,
@@ -50,7 +50,9 @@
       "icons/icon.ico"
     ],
     "windows": {
-      "wix": null,
+      "wix": {
+        "upgradeCode": "d1dfe239-c6ec-5195-980b-2d6cd723458a"
+      },
       "nsis": {
         "installMode": "currentUser"
       }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -51,7 +51,8 @@
     ],
     "windows": {
       "wix": {
-        "upgradeCode": "d1dfe239-c6ec-5195-980b-2d6cd723458a"
+        "upgradeCode": "d1dfe239-c6ec-5195-980b-2d6cd723458a",
+        "language": "zh-CN"
       },
       "nsis": {
         "installMode": "currentUser"

--- a/src-tauri/tauri.macos.conf.json
+++ b/src-tauri/tauri.macos.conf.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "productName": "Moke",
+  "app": {
+    "windows": [
+      {
+        "title": "Moke",
+        "width": 1280,
+        "height": 800,
+        "minWidth": 800,
+        "minHeight": 600,
+        "resizable": true,
+        "fullscreen": false
+      }
+    ]
+  }
+}

--- a/src-tauri/tauri.mobile.conf.json
+++ b/src-tauri/tauri.mobile.conf.json
@@ -2,7 +2,7 @@
   "app": {
     "windows": [
       {
-        "title": "Moke - Mobile Preview",
+        "title": "墨客 - Mobile Preview",
         "width": 390,
         "height": 844,
         "minWidth": 320,

--- a/src-tauri/tauri.ohos.conf.json
+++ b/src-tauri/tauri.ohos.conf.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
+  "productName": "Moke",
   "identifier": "org.houheya.moke",
   "build": {
     "frontendDist": "../out",

--- a/src-tauri/tauri.tablet.conf.json
+++ b/src-tauri/tauri.tablet.conf.json
@@ -2,7 +2,7 @@
   "app": {
     "windows": [
       {
-        "title": "Moke - Tablet Preview",
+        "title": "墨客 - Tablet Preview",
         "width": 768,
         "height": 1024,
         "minWidth": 360,

--- a/src-tauri/tauri.windows.conf.json
+++ b/src-tauri/tauri.windows.conf.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "productName": "Moke",
+  "app": {
+    "windows": [
+      {
+        "title": "Moke",
+        "width": 1280,
+        "height": 800,
+        "minWidth": 800,
+        "minHeight": 600,
+        "resizable": true,
+        "fullscreen": false
+      }
+    ]
+  }
+}

--- a/tests/app-name-localization.test.mjs
+++ b/tests/app-name-localization.test.mjs
@@ -11,15 +11,18 @@ import {
 
 const root = path.resolve(import.meta.dirname, '..');
 
-test('默认名称为墨客，Windows 与 OHOS 保持 Moke', () => {
+test('默认名称为墨客，Windows、macOS 与 OHOS 保持 Moke', () => {
   const config = JSON.parse(readFileSync(path.join(root, 'src-tauri', 'tauri.conf.json'), 'utf8'));
   const windowsConfig = JSON.parse(readFileSync(path.join(root, 'src-tauri', 'tauri.windows.conf.json'), 'utf8'));
+  const macosConfig = JSON.parse(readFileSync(path.join(root, 'src-tauri', 'tauri.macos.conf.json'), 'utf8'));
   const ohosConfig = JSON.parse(readFileSync(path.join(root, 'src-tauri', 'tauri.ohos.conf.json'), 'utf8'));
 
   assert.equal(config.productName, '墨客');
   assert.equal(config.app.windows[0].title, '墨客');
   assert.equal(windowsConfig.productName, 'Moke');
   assert.equal(windowsConfig.app.windows[0].title, 'Moke');
+  assert.equal(macosConfig.productName, 'Moke');
+  assert.equal(macosConfig.app.windows[0].title, 'Moke');
   assert.equal(ohosConfig.productName, 'Moke');
   assert.equal(config.bundle.windows.wix.upgradeCode, 'd1dfe239-c6ec-5195-980b-2d6cd723458a');
   assert.equal(config.bundle.windows.wix.language, undefined);

--- a/tests/app-name-localization.test.mjs
+++ b/tests/app-name-localization.test.mjs
@@ -19,6 +19,7 @@ test('桌面默认名称为墨客，OHOS 保持 Moke', () => {
   assert.equal(config.app.windows[0].title, '墨客');
   assert.equal(ohosConfig.productName, 'Moke');
   assert.equal(config.bundle.windows.wix.upgradeCode, 'd1dfe239-c6ec-5195-980b-2d6cd723458a');
+  assert.equal(config.bundle.windows.wix.language, 'zh-CN');
 });
 
 test('移动端默认名称为墨客，英文系统名称为 Moke', () => {

--- a/tests/app-name-localization.test.mjs
+++ b/tests/app-name-localization.test.mjs
@@ -11,15 +11,18 @@ import {
 
 const root = path.resolve(import.meta.dirname, '..');
 
-test('桌面默认名称为墨客，OHOS 保持 Moke', () => {
+test('默认名称为墨客，Windows 与 OHOS 保持 Moke', () => {
   const config = JSON.parse(readFileSync(path.join(root, 'src-tauri', 'tauri.conf.json'), 'utf8'));
+  const windowsConfig = JSON.parse(readFileSync(path.join(root, 'src-tauri', 'tauri.windows.conf.json'), 'utf8'));
   const ohosConfig = JSON.parse(readFileSync(path.join(root, 'src-tauri', 'tauri.ohos.conf.json'), 'utf8'));
 
   assert.equal(config.productName, '墨客');
   assert.equal(config.app.windows[0].title, '墨客');
+  assert.equal(windowsConfig.productName, 'Moke');
+  assert.equal(windowsConfig.app.windows[0].title, 'Moke');
   assert.equal(ohosConfig.productName, 'Moke');
   assert.equal(config.bundle.windows.wix.upgradeCode, 'd1dfe239-c6ec-5195-980b-2d6cd723458a');
-  assert.equal(config.bundle.windows.wix.language, 'zh-CN');
+  assert.equal(config.bundle.windows.wix.language, undefined);
 });
 
 test('移动端默认名称为墨客，英文系统名称为 Moke', () => {

--- a/tests/app-name-localization.test.mjs
+++ b/tests/app-name-localization.test.mjs
@@ -1,0 +1,78 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import {
+  prepareAndroidAppNames,
+  prepareIosAppNames,
+} from '../scripts/prepare-mobile-app-names.mjs';
+
+const root = path.resolve(import.meta.dirname, '..');
+
+test('桌面默认名称为墨客，OHOS 保持 Moke', () => {
+  const config = JSON.parse(readFileSync(path.join(root, 'src-tauri', 'tauri.conf.json'), 'utf8'));
+  const ohosConfig = JSON.parse(readFileSync(path.join(root, 'src-tauri', 'tauri.ohos.conf.json'), 'utf8'));
+
+  assert.equal(config.productName, '墨客');
+  assert.equal(config.app.windows[0].title, '墨客');
+  assert.equal(ohosConfig.productName, 'Moke');
+  assert.equal(config.bundle.windows.wix.upgradeCode, 'd1dfe239-c6ec-5195-980b-2d6cd723458a');
+});
+
+test('移动端默认名称为墨客，英文系统名称为 Moke', () => {
+  const iosDefault = readFileSync(path.join(root, 'src-tauri', 'Info.ios.plist'), 'utf8');
+  const iosEnglish = readFileSync(
+    path.join(root, 'src-tauri', 'mobile', 'ios', 'en.lproj', 'InfoPlist.strings'),
+    'utf8',
+  );
+  const androidEnglish = readFileSync(
+    path.join(root, 'src-tauri', 'mobile', 'android', 'values-en', 'strings.xml'),
+    'utf8',
+  );
+
+  assert.match(iosDefault, /<string>墨客<\/string>/);
+  assert.match(iosEnglish, /"CFBundleDisplayName" = "Moke";/);
+  assert.match(androidEnglish, /<string name="app_name">Moke<\/string>/);
+  assert.match(androidEnglish, /<string name="main_activity_title">Moke<\/string>/);
+});
+
+test('Android 英文名称资源会复制到生成项目', () => {
+  const temporaryRoot = mkdtempSync(path.join(os.tmpdir(), 'moke-app-name-'));
+  const sourceDir = path.join(temporaryRoot, 'src-tauri', 'mobile', 'android', 'values-en');
+  mkdirSync(sourceDir, { recursive: true });
+  writeFileSync(path.join(sourceDir, 'strings.xml'), '<resources><string name="app_name">Moke</string></resources>');
+
+  prepareAndroidAppNames(temporaryRoot);
+
+  const generated = readFileSync(
+    path.join(temporaryRoot, 'src-tauri', 'gen', 'android', 'app', 'src', 'main', 'res', 'values-en', 'strings.xml'),
+    'utf8',
+  );
+  assert.match(generated, />Moke</);
+});
+
+test('iOS 英文名称资源会复制并重新生成 Xcode 项目', () => {
+  const temporaryRoot = mkdtempSync(path.join(os.tmpdir(), 'moke-app-name-'));
+  const sourceDir = path.join(temporaryRoot, 'src-tauri', 'mobile', 'ios', 'en.lproj');
+  const appleRoot = path.join(temporaryRoot, 'src-tauri', 'gen', 'apple');
+  mkdirSync(sourceDir, { recursive: true });
+  mkdirSync(path.join(appleRoot, 'moke_iOS'), { recursive: true });
+  writeFileSync(path.join(sourceDir, 'InfoPlist.strings'), '"CFBundleDisplayName" = "Moke";\n');
+  writeFileSync(path.join(appleRoot, 'project.yml'), 'name: moke\n');
+
+  let command;
+  prepareIosAppNames(temporaryRoot, (...args) => {
+    command = args;
+    return { status: 0 };
+  });
+
+  const generated = readFileSync(
+    path.join(appleRoot, 'moke_iOS', 'en.lproj', 'InfoPlist.strings'),
+    'utf8',
+  );
+  assert.match(generated, /Moke/);
+  assert.equal(command[0], 'xcodegen');
+  assert.deepEqual(command[1], ['generate', '--spec', path.join(appleRoot, 'project.yml')]);
+});


### PR DESCRIPTION
## 变更
- 所有平台的默认产品名、应用包名和安装包名统一为 `Moke`，Windows 执行文件继续为 `moke.exe`
- macOS、Linux、Android 与 iOS 在简体或繁体中文系统下显示“墨客”；英文及其他语言回退为默认名称 `Moke`
- Linux 的 `.deb`、RPM 与 AppImage 使用带本地化名称的 `.desktop` 模板
- GitHub Actions 在上传前检查安装包、签名和应用包产物；文件名包含“墨客”时自动替换为小写 `moke`
- Windows 与 OHOS 保持 `Moke`，保留原 Windows WiX 升级标识，不改应用内文案

## 验证
- `pnpm test`（188 项通过）
- `pnpm lint`（0 errors，25 个既有 warnings）
- 应用名称本地化与移动端资源复制测试通过
- 配置、脚本语法与 `git diff --check` 通过