### PR TITLE
feat: persist and sync debug logs with Readest

### DIFF
--- a/src/app/detail/page.tsx
+++ b/src/app/detail/page.tsx
@@ -13,6 +13,7 @@ import {
   endOfflineDownload,
 } from '@/lib/offline-download';
 import { useServerStore } from '@/lib/store/server';
+import { useDeveloperStore } from '@/lib/store/developer';
 import { useSettingsStore } from '@/lib/store/settings';
 import { fetchReadingProgress } from '@/lib/reading-progress';
 import { buildEmbeddedReaderUrl, getMokeRuntimePlatform, isSingleWebviewRuntime, openEmbeddedReaderBook } from '@/lib/moke-reader';
@@ -353,6 +354,7 @@ function DetailContent() {
           const href = buildEmbeddedReaderUrl({
             filePath: record.filePath,
             eink: useSettingsStore.getState().eink,
+            debugPanel: useDeveloperStore.getState().showDebugPanel,
             mokeBookId: String(book.id),
             restoreProgress,
             // A single-WebView annotation locate session intentionally omits
@@ -384,6 +386,7 @@ function DetailContent() {
             await invoke('open_reader', {
               filePath: record.filePath,
               eink: useSettingsStore.getState().eink,
+              debugPanel: useDeveloperStore.getState().showDebugPanel,
               mokeBookId: String(book.id),
               restoreProgress,
             });

--- a/src/app/settings/developer/page.tsx
+++ b/src/app/settings/developer/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import { ArrowLeft, Bug, FlaskConical, Lock, Trash2, AlertTriangle, Eye, RefreshCw, Download } from 'lucide-react';
+import { ArrowLeft, FlaskConical, Lock, Trash2, AlertTriangle, Eye, RefreshCw, Download } from 'lucide-react';
 import { DesktopLayout } from '@/components/layout/DesktopLayout';
 import { useDeveloperStore } from '@/lib/store/developer';
 import { useUpdateStore } from '@/lib/store/update';
@@ -88,9 +88,19 @@ export default function DeveloperSettingsPage() {
 
           <DevSection title="调试面板" description="控制屏幕上的调试日志面板入口">
             <ToggleRow
-              icon={Bug}
+              icon={DebugIcon}
               label="显示调试面板按钮"
-              description={`在所有页面右下角显示 🐞 浮动按钮，可查看实时日志（当前 ${logCount} 条）`}
+              description={
+                <span className="inline-flex flex-wrap items-center gap-1">
+                  <span>在所有页面右下角显示</span>
+                  <img
+                    src="/debug.avif"
+                    alt="自定义调试图标"
+                    className="h-4 w-4 object-contain"
+                  />
+                  <span>浮动按钮，可查看实时日志（当前 {logCount} 条）</span>
+                </span>
+              }
               checked={showDebugPanel}
               onChange={setShowDebugPanel}
             />
@@ -145,7 +155,30 @@ function DevSection({ title, description, children }: { title: string; descripti
   );
 }
 
-function ToggleRow({ icon: Icon, label, description, checked, onChange }: { icon: typeof Bug; label: string; description: string; checked: boolean; onChange: (v: boolean) => void }) {
+function DebugIcon({ className }: { className?: string }) {
+  return (
+    <img
+      src="/debug.avif"
+      alt=""
+      aria-hidden="true"
+      className={`object-contain ${className ?? ''}`}
+    />
+  );
+}
+
+function ToggleRow({
+  icon: Icon,
+  label,
+  description,
+  checked,
+  onChange,
+}: {
+  icon: React.ComponentType<{ className?: string }>;
+  label: string;
+  description: React.ReactNode;
+  checked: boolean;
+  onChange: (v: boolean) => void;
+}) {
   return (
     <div className="flex items-center justify-between gap-4 px-4 py-3 rounded-xl transition-colors hover:bg-muted/60">
       <div className="flex items-start gap-3.5 min-w-0">
@@ -263,7 +296,7 @@ function DevRow({ label, value }: { label: string; value: string }) {
   );
 }
 
-function ActionRow({ icon: Icon, label, description, tone = 'default', onClick }: { icon: typeof Bug; label: string; description: string; tone?: 'default' | 'danger'; onClick: () => void }) {
+function ActionRow({ icon: Icon, label, description, tone = 'default', onClick }: { icon: React.ComponentType<{ className?: string }>; label: string; description: string; tone?: 'default' | 'danger'; onClick: () => void }) {
   return (
     <button
       onClick={onClick}

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -81,6 +81,7 @@ export default function SettingsPage() {
     try {
       await openEmbeddedReaderHome({
         eink: useSettingsStore.getState().eink,
+        debugPanel: useDeveloperStore.getState().showDebugPanel,
         serverUrl,
         navigate: (href) => router.push(href),
       });

--- a/src/app/welcome/page.tsx
+++ b/src/app/welcome/page.tsx
@@ -117,6 +117,7 @@ export default function WelcomePage() {
     try {
       await openEmbeddedReaderHome({
         eink: useSettingsStore.getState().eink,
+        debugPanel: useDeveloperStore.getState().showDebugPanel,
         serverUrl: useServerStore.getState().serverUrl,
         navigate: (href) => router.push(href),
       });

--- a/src/components/providers/AppShell.tsx
+++ b/src/components/providers/AppShell.tsx
@@ -2,7 +2,12 @@
 
 import { useEffect } from 'react';
 import { DebugLogPanel } from '@/components/ui/DebugLogPanel';
-import { installConsoleCapture, uninstallConsoleCapture } from '@/lib/debug-log';
+import {
+  broadcastDebugPanelVisibility,
+  installConsoleCapture,
+  installDebugLogBridge,
+  uninstallConsoleCapture,
+} from '@/lib/debug-log';
 import {
   getMokeRuntimePlatform,
   getNativeTopSafeAreaInset,
@@ -32,6 +37,30 @@ export function AppShell({ children }: { children: React.ReactNode }) {
   const eink = useSettingsStore((s) => s.eink);
   const theme = useSettingsStore((s) => s.theme);
   const developerUnlocked = useDeveloperStore((s) => s.unlocked);
+  const showDebugPanel = useDeveloperStore((s) => s.showDebugPanel);
+
+  // Persist logs across document reloads and bridge them to every embedded
+  // Readest window. The visibility handshake lets an already-open reader
+  // follow the host toggle without being reopened.
+  useEffect(() => {
+    let disposed = false;
+    let cleanup: (() => void) | undefined;
+    void installDebugLogBridge({
+      source: 'moke',
+      getPanelVisible: () => useDeveloperStore.getState().showDebugPanel,
+    }).then((uninstall) => {
+      if (disposed) uninstall();
+      else cleanup = uninstall;
+    });
+    return () => {
+      disposed = true;
+      cleanup?.();
+    };
+  }, []);
+
+  useEffect(() => {
+    broadcastDebugPanelVisibility(showDebugPanel);
+  }, [showDebugPanel]);
 
   // Manual override: set the [data-eink='true'] attribute (same signal readest
   // uses) so Moke + the embedded reader share one convention. Auto e-ink

--- a/src/components/ui/DebugLogPanel.tsx
+++ b/src/components/ui/DebugLogPanel.tsx
@@ -50,7 +50,7 @@ const defaultFilter: LevelFilterState = {
 
 export function DebugLogPanel() {
   const [open, setOpen] = useState(false);
-  const [expandedId, setExpandedId] = useState<number | null>(null);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState<DebugLogType>('console');
   const [filters, setFilters] = useState<Record<DebugLogType, LevelFilterState>>({
     console: { ...defaultFilter },
@@ -300,6 +300,17 @@ export function DebugLogPanel() {
                       }}
                     >
                       {levelLabel[log.level]}
+                    </span>
+                    <span
+                      style={{
+                        color: log.source === 'readest' ? levelColor.info : theme.muted,
+                        flexShrink: 0,
+                        fontSize: 10,
+                        fontWeight: 700,
+                        textTransform: 'uppercase',
+                      }}
+                    >
+                      {log.source}
                     </span>
                     <span style={{ color: theme.muted, flexShrink: 0, fontSize: 11 }}>
                       [{log.tag}]

--- a/src/lib/debug-log.ts
+++ b/src/lib/debug-log.ts
@@ -2,13 +2,18 @@ import { create } from 'zustand';
 
 export type DebugLogLevel = 'info' | 'success' | 'warn' | 'error';
 export type DebugLogType = 'console' | 'network';
+export type DebugLogSource = 'moke' | 'readest';
 
 export interface DebugLogEntry {
-  id: number;
+  /** Cross-window stable id. Do not replace with an array index. */
+  id: string;
   time: string;
+  createdAt: number;
   level: DebugLogLevel;
   /** 日志类别：console 捕获 / 网络请求 */
   type: DebugLogType;
+  /** 日志来自 Moke 宿主还是 Readest 阅读器。 */
+  source: DebugLogSource;
   tag: string;
   message: string;
   detail?: string;
@@ -22,11 +27,46 @@ interface DebugLogState {
   setEnabled: (enabled: boolean) => void;
 }
 
-let counter = 0;
-/** 每个类别（console / network）各自保留的日志条数上限 */
-const MAX_LOGS_PER_TYPE = 1000;
+interface DebugLogBridgeOptions {
+  source: DebugLogSource;
+  getPanelVisible?: () => boolean;
+  onPanelVisible?: (visible: boolean) => void;
+}
 
-/** 按 tag 推断日志类别：request/image 属于网络请求日志，其余归入 console */
+type DebugLogSyncMessage =
+  | { kind: 'append'; sender: string; entry: DebugLogEntry }
+  | { kind: 'clear'; sender: string; clearedAt: number }
+  | { kind: 'request'; sender: string }
+  | { kind: 'snapshot'; sender: string; target: string; logs: DebugLogEntry[] }
+  | { kind: 'visibility-request'; sender: string }
+  | { kind: 'visibility'; sender: string; visible: boolean };
+
+const STORAGE_KEY = 'moke-debug-logs-v1';
+const CLEAR_STORAGE_KEY = 'moke-debug-logs-cleared-at-v1';
+const DEBUG_LOG_SYNC_EVENT = 'moke:debug-log-sync:v1';
+/** 每个类别（console / network）各自保留的内存日志条数上限。 */
+const MAX_LOGS_PER_TYPE = 1000;
+/** 持久化数量略低于内存上限，避免 localStorage 配额被超长日志耗尽。 */
+const MAX_PERSISTED_LOGS_PER_TYPE = 500;
+const MAX_PERSISTED_DETAIL_LENGTH = 20_000;
+const instanceId = createInstanceId();
+let counter = 0;
+let hydrated = false;
+let bridgeSender: ((message: DebugLogSyncMessage) => void) | null = null;
+let lastClearedAt = 0;
+
+function createInstanceId(): string {
+  try {
+    if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+      return crypto.randomUUID();
+    }
+  } catch {
+    // Fall through to a non-cryptographic id; this is only for de-duplication.
+  }
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+}
+
+/** 按 tag 推断日志类别：request/image 属于网络请求日志，其余归入 console。 */
 function inferLogType(tag: string): DebugLogType {
   return tag === 'request' || tag === 'image' ? 'network' : 'console';
 }
@@ -41,40 +81,255 @@ function stringifyDetail(detail: unknown): string | undefined {
   }
 }
 
+function isDebugLogEntry(value: unknown): value is DebugLogEntry {
+  if (!value || typeof value !== 'object') return false;
+  const entry = value as Partial<DebugLogEntry>;
+  return (
+    typeof entry.id === 'string' &&
+    typeof entry.time === 'string' &&
+    typeof entry.createdAt === 'number' &&
+    ['info', 'success', 'warn', 'error'].includes(String(entry.level)) &&
+    ['console', 'network'].includes(String(entry.type)) &&
+    ['moke', 'readest'].includes(String(entry.source)) &&
+    typeof entry.tag === 'string' &&
+    typeof entry.message === 'string'
+  );
+}
+
+function limitLogs(logs: DebugLogEntry[], perTypeLimit: number): DebugLogEntry[] {
+  const newestFirst = [...logs].sort((a, b) => b.createdAt - a.createdAt);
+  const counts: Record<DebugLogType, number> = { console: 0, network: 0 };
+  const kept = newestFirst.filter((entry) => {
+    if (counts[entry.type] >= perTypeLimit) return false;
+    counts[entry.type] += 1;
+    return true;
+  });
+  return kept.sort((a, b) => a.createdAt - b.createdAt);
+}
+
+function mergeLogs(current: DebugLogEntry[], incoming: DebugLogEntry[]): DebugLogEntry[] {
+  const byId = new Map(
+    current.filter((entry) => entry.createdAt > lastClearedAt).map((entry) => [entry.id, entry]),
+  );
+  for (const entry of incoming) {
+    if (isDebugLogEntry(entry) && entry.createdAt > lastClearedAt) byId.set(entry.id, entry);
+  }
+  return limitLogs([...byId.values()], MAX_LOGS_PER_TYPE);
+}
+
+function readPersistedClearTime(): number {
+  if (typeof window === 'undefined') return 0;
+  try {
+    const value = Number(window.localStorage.getItem(CLEAR_STORAGE_KEY) || 0);
+    return Number.isFinite(value) && value > 0 ? value : 0;
+  } catch {
+    return 0;
+  }
+}
+
+function readPersistedLogs(): DebugLogEntry[] {
+  if (typeof window === 'undefined') return [];
+  try {
+    const parsed: unknown = JSON.parse(window.localStorage.getItem(STORAGE_KEY) || '[]');
+    return Array.isArray(parsed) ? limitLogs(parsed.filter(isDebugLogEntry), MAX_PERSISTED_LOGS_PER_TYPE) : [];
+  } catch {
+    return [];
+  }
+}
+
+function persistLogs(logs: DebugLogEntry[], mergeExisting = true): void {
+  if (typeof window === 'undefined') return;
+  try {
+    const combined = mergeExisting ? mergeLogs(readPersistedLogs(), logs) : logs;
+    const persisted = limitLogs(combined, MAX_PERSISTED_LOGS_PER_TYPE).map((entry) => ({
+      ...entry,
+      detail: entry.detail?.slice(0, MAX_PERSISTED_DETAIL_LENGTH),
+    }));
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(persisted));
+  } catch {
+    // Storage is best-effort (private mode / quota / custom-scheme restrictions).
+  }
+}
+
+function addSyncedLogs(logs: DebugLogEntry[]): void {
+  if (logs.length === 0) return;
+  useDebugLogStore.setState((state) => {
+    const merged = mergeLogs(state.logs, logs);
+    persistLogs(merged);
+    return { logs: merged };
+  });
+}
+
+function clearSyncedLogs(clearedAt = Date.now()): void {
+  lastClearedAt = Math.max(lastClearedAt, clearedAt);
+  useDebugLogStore.setState({ logs: [] });
+  try {
+    window.localStorage.setItem(CLEAR_STORAGE_KEY, String(lastClearedAt));
+  } catch {
+    // Best effort, matching the log history persistence path.
+  }
+  persistLogs([], false);
+}
+
+function createEntry(
+  level: DebugLogLevel,
+  tag: string,
+  message: string,
+  detail?: unknown,
+  type?: DebugLogType,
+): DebugLogEntry {
+  const createdAt = Math.max(Date.now(), lastClearedAt + 1);
+  return {
+    id: `moke:${instanceId}:${++counter}`,
+    time:
+      new Date(createdAt).toLocaleTimeString('zh-CN', { hour12: false }) +
+      '.' +
+      String(createdAt % 1000).padStart(3, '0'),
+    createdAt,
+    level,
+    type: type ?? inferLogType(tag),
+    source: 'moke',
+    tag,
+    message,
+    detail: stringifyDetail(detail),
+  };
+}
+
 export const useDebugLogStore = create<DebugLogState>((set) => ({
   logs: [],
   enabled: true,
   addLog: (level, tag, message, detail, type) => {
-    const entry: DebugLogEntry = {
-      id: ++counter,
-      time: new Date().toLocaleTimeString('zh-CN', { hour12: false }) + '.' + String(Date.now() % 1000).padStart(3, '0'),
-      level,
-      type: type ?? inferLogType(tag),
-      tag,
-      message,
-      detail: stringifyDetail(detail),
-    };
+    const entry = createEntry(level, tag, message, detail, type);
     set((state) => {
-      const next = [...state.logs, entry];
-      // 按类别分别保留最近 MAX_LOGS_PER_TYPE 条，避免某类日志挤掉另一类
-      for (const t of ['console', 'network'] as DebugLogType[]) {
-        let excess = next.filter((l) => l.type === t).length - MAX_LOGS_PER_TYPE;
-        let i = 0;
-        while (excess > 0 && i < next.length) {
-          if (next[i].type === t) {
-            next.splice(i, 1);
-            excess--;
-          } else {
-            i++;
-          }
-        }
-      }
-      return { logs: next };
+      const logs = mergeLogs(state.logs, [entry]);
+      persistLogs(logs);
+      return { logs };
     });
+    bridgeSender?.({ kind: 'append', sender: instanceId, entry });
   },
-  clear: () => set({ logs: [] }),
+  clear: () => {
+    const clearedAt = Date.now();
+    lastClearedAt = Math.max(lastClearedAt, clearedAt);
+    set({ logs: [] });
+    try {
+      if (typeof window === 'undefined') throw new Error('no window');
+      window.localStorage.setItem(CLEAR_STORAGE_KEY, String(lastClearedAt));
+    } catch {
+      // Best effort, matching the log history persistence path.
+    }
+    persistLogs([], false);
+    bridgeSender?.({ kind: 'clear', sender: instanceId, clearedAt });
+  },
   setEnabled: (enabled) => set({ enabled }),
 }));
+
+export function hydrateDebugLogs(): void {
+  if (hydrated || typeof window === 'undefined') return;
+  hydrated = true;
+  lastClearedAt = readPersistedClearTime();
+  addSyncedLogs(readPersistedLogs());
+}
+
+/**
+ * 在 Moke / Readest 的多个 WebView 之间同步日志、清空动作和面板显示状态。
+ * 本地持久化负责整页导航/重载，Tauri 全局事件负责桌面多窗口互通。
+ */
+export async function installDebugLogBridge(options: DebugLogBridgeOptions): Promise<() => void> {
+  if (typeof window === 'undefined') return () => {};
+  hydrateDebugLogs();
+
+  const handleStorage = (event: StorageEvent) => {
+    if (event.key === CLEAR_STORAGE_KEY) {
+      clearSyncedLogs(Number(event.newValue || 0));
+      return;
+    }
+    if (event.key !== STORAGE_KEY) return;
+    if (!event.newValue) {
+      clearSyncedLogs();
+      return;
+    }
+    try {
+      const parsed: unknown = JSON.parse(event.newValue);
+      if (Array.isArray(parsed)) {
+        if (parsed.length === 0) clearSyncedLogs(readPersistedClearTime());
+        else addSyncedLogs(parsed.filter(isDebugLogEntry));
+      }
+    } catch {
+      // Ignore another window's incomplete or incompatible payload.
+    }
+  };
+  window.addEventListener('storage', handleStorage);
+
+  if (process.env.NEXT_PUBLIC_APP_PLATFORM !== 'tauri') {
+    return () => window.removeEventListener('storage', handleStorage);
+  }
+
+  try {
+    const [{ emit, listen }, { getCurrentWindow }] = await Promise.all([
+      import('@tauri-apps/api/event'),
+      import('@tauri-apps/api/window'),
+    ]);
+    const sender = `${options.source}:${getCurrentWindow().label}:${instanceId}`;
+    const send = (message: DebugLogSyncMessage) => {
+      void emit(DEBUG_LOG_SYNC_EVENT, { ...message, sender }).catch(() => undefined);
+    };
+    bridgeSender = send;
+
+    const unlisten = await listen<DebugLogSyncMessage>(DEBUG_LOG_SYNC_EVENT, ({ payload }) => {
+      if (!payload || payload.sender === sender) return;
+      switch (payload.kind) {
+        case 'append':
+          addSyncedLogs([payload.entry]);
+          break;
+        case 'clear':
+          clearSyncedLogs(payload.clearedAt);
+          break;
+        case 'request':
+          send({
+            kind: 'snapshot',
+            sender,
+            target: payload.sender,
+            logs: useDebugLogStore.getState().logs,
+          });
+          break;
+        case 'snapshot':
+          if (payload.target === sender) addSyncedLogs(payload.logs);
+          break;
+        case 'visibility-request': {
+          const visible = options.getPanelVisible?.();
+          if (typeof visible === 'boolean') send({ kind: 'visibility', sender, visible });
+          break;
+        }
+        case 'visibility':
+          options.onPanelVisible?.(payload.visible);
+          break;
+      }
+    });
+
+    send({ kind: 'request', sender });
+    send({ kind: 'visibility-request', sender });
+    const initialVisible = options.getPanelVisible?.();
+    if (typeof initialVisible === 'boolean') {
+      send({ kind: 'visibility', sender, visible: initialVisible });
+    }
+
+    return () => {
+      unlisten();
+      window.removeEventListener('storage', handleStorage);
+      if (bridgeSender === send) bridgeSender = null;
+    };
+  } catch {
+    return () => window.removeEventListener('storage', handleStorage);
+  }
+}
+
+export function broadcastDebugPanelVisibility(visible: boolean): void {
+  bridgeSender?.({ kind: 'visibility', sender: instanceId, visible });
+}
+
+export function requestDebugPanelVisibility(): void {
+  bridgeSender?.({ kind: 'visibility-request', sender: instanceId });
+}
 
 /**
  * 原生 console 引用。debugLog 与 console 捕获器都经由它们输出，
@@ -88,21 +343,20 @@ const originalConsole = {
   error: console.error.bind(console),
 };
 
-/** 在任意非 React 上下文（如 api.ts）中记录日志 */
+/** 在任意非 React 上下文（如 api.ts）中记录日志。 */
 export function debugLog(level: DebugLogLevel, tag: string, message: string, detail?: unknown, type?: DebugLogType) {
   try {
     useDebugLogStore.getState().addLog(level, tag, message, detail, type);
   } catch {
     // store 尚未初始化时静默忽略
   }
-  // 同时输出到控制台（走原始引用，避免被下方 console 捕获器再次记录）
   const line = `[${tag}] ${message}`;
   if (level === 'error') originalConsole.error(line, detail ?? '');
   else if (level === 'warn') originalConsole.warn(line, detail ?? '');
   else originalConsole.log(line, detail ?? '');
 }
 
-/** 把任意 console 参数格式化为面板可读的文本 */
+/** 把任意 console 参数格式化为面板可读的文本。 */
 function formatConsoleArg(arg: unknown): string {
   if (arg instanceof Error) {
     const name = arg.name || 'Error';
@@ -132,32 +386,21 @@ function formatConsoleArgs(args: unknown[]): { message: string; detail?: string 
       lines.push(text);
     }
   }
-  const message = lines.join(' ');
-  return { message, detail: details.length > 0 ? details.join('\n') : undefined };
+  return { message: lines.join(' '), detail: details.length > 0 ? details.join('\n') : undefined };
 }
 
 let consoleCaptureInstalled = false;
 
-/**
- * 捕获全局 console 调用并写入调试日志 store。
- * 这样任何直接调用 console.error / warn / log 的代码（第三方库、
- * 未接入 debugLog 的路径、浏览器内部的 unhandledrejection 打印等）
- * 都会出现在调试面板中。应在应用启动时调用一次。
- *
- * 注意：这会全局 patch console，并为每类日志缓存最多 1000 条，仅在
- * 开发环境或已解锁开发者模式的用户上启用（见 app/layout.tsx 的门控）。
- */
+/** 捕获全局 console 调用并写入调试日志 store。 */
 export function installConsoleCapture() {
-  // SSR 下 window 不存在，跳过；服务端日志不应进入客户端面板
   if (consoleCaptureInstalled || typeof window === 'undefined') return;
   consoleCaptureInstalled = true;
 
   const capture = (
     level: DebugLogLevel,
     native: (...args: unknown[]) => void,
-    args: unknown[]
+    args: unknown[],
   ) => {
-    // 先保持原生控制台输出
     native(...args);
     const { message, detail } = formatConsoleArgs(args);
     try {
@@ -174,10 +417,7 @@ export function installConsoleCapture() {
   console.error = (...args) => capture('error', originalConsole.error, args);
 }
 
-/**
- * 撤销 installConsoleCapture 的 patch，恢复原生 console 方法。
- * 用于生产环境用户在未解锁开发者模式时（或锁定后）关闭全局捕获。
- */
+/** 撤销 installConsoleCapture 的 patch，恢复原生 console 方法。 */
 export function uninstallConsoleCapture() {
   if (!consoleCaptureInstalled || typeof window === 'undefined') return;
   consoleCaptureInstalled = false;

--- a/src/lib/moke-reader.ts
+++ b/src/lib/moke-reader.ts
@@ -179,14 +179,17 @@ function setServerUrlParam(params: URLSearchParams, serverUrl?: string): void {
 
 export function buildEmbeddedReaderHomeUrl({
   eink,
+  debugPanel = false,
   serverUrl,
 }: {
   eink: boolean;
+  debugPanel?: boolean;
   serverUrl?: string;
 }): string {
   const params = new URLSearchParams({
     moke: '1',
     mokeEink: eink ? '1' : '0',
+    mokeDebug: debugPanel ? '1' : '0',
   });
 
   setServerUrlParam(params, serverUrl);
@@ -196,10 +199,12 @@ export function buildEmbeddedReaderHomeUrl({
 
 export async function openEmbeddedReaderHome({
   eink,
+  debugPanel = false,
   serverUrl,
   navigate,
 }: {
   eink: boolean;
+  debugPanel?: boolean;
   serverUrl?: string;
   navigate: (href: string) => void;
 }): Promise<void> {
@@ -242,6 +247,7 @@ export async function openEmbeddedReaderHome({
 
   const href = buildEmbeddedReaderHomeUrl({
     eink,
+    debugPanel,
     serverUrl: includeServerUrl ? serverUrl : undefined,
   });
 
@@ -287,12 +293,14 @@ export async function openEmbeddedReaderHome({
 export function buildEmbeddedReaderUrl({
   filePath,
   eink,
+  debugPanel = false,
   mokeBookId,
   restoreProgress,
   serverUrl,
 }: {
   filePath: string;
   eink: boolean;
+  debugPanel?: boolean;
   mokeBookId: string;
   restoreProgress: ReadingProgressPayload | null;
   serverUrl?: string;
@@ -301,6 +309,7 @@ export function buildEmbeddedReaderUrl({
     file: filePath,
     moke: '1',
     mokeEink: eink ? '1' : '0',
+    mokeDebug: debugPanel ? '1' : '0',
     mokeBookId,
     mokeReturnTo: '/library',
   });

--- a/tests/debug-log.test.mjs
+++ b/tests/debug-log.test.mjs
@@ -8,7 +8,19 @@ import {
 } from '../src/lib/debug-log.ts';
 
 function mockWindow() {
-  Object.defineProperty(globalThis, 'window', { value: {}, configurable: true, writable: true });
+  const values = new Map();
+  const localStorage = {
+    getItem: (key) => values.get(key) ?? null,
+    setItem: (key, value) => values.set(key, String(value)),
+    removeItem: (key) => values.delete(key),
+    clear: () => values.clear(),
+  };
+  Object.defineProperty(globalThis, 'window', {
+    value: { localStorage },
+    configurable: true,
+    writable: true,
+  });
+  return localStorage;
 }
 function restoreWindow() {
   delete globalThis.window;
@@ -37,6 +49,7 @@ test('installConsoleCapture patch console 后日志进入面板，uninstall 后�
   assert.equal(logs[0].level, 'warn');
   assert.equal(logs[0].message, 'capture me');
   assert.equal(logs[0].type, 'console');
+  assert.equal(logs[0].source, 'moke');
 
   uninstallConsoleCapture();
   // 卸载后 console 恢复原生行为，不再写入调试面板
@@ -44,6 +57,25 @@ test('installConsoleCapture patch console 后日志进入面板，uninstall 后�
   logs = useDebugLogStore.getState().logs;
   assert.equal(logs.length, 1);
 
+  restoreWindow();
+});
+
+test('日志持久化，显式清空后不会被旧快照带回', () => {
+  const localStorage = mockWindow();
+  useDebugLogStore.getState().clear();
+  useDebugLogStore.getState().addLog('warn', 'connection', 'before disconnect');
+
+  let stored = JSON.parse(localStorage.getItem('moke-debug-logs-v1'));
+  assert.equal(stored.length, 1);
+  assert.equal(stored[0].message, 'before disconnect');
+
+  useDebugLogStore.getState().clear();
+  useDebugLogStore.getState().addLog('info', 'connection', 'after reconnect');
+
+  stored = JSON.parse(localStorage.getItem('moke-debug-logs-v1'));
+  assert.equal(stored.length, 1);
+  assert.equal(stored[0].message, 'after reconnect');
+  assert.ok(Number(localStorage.getItem('moke-debug-logs-cleared-at-v1')) > 0);
   restoreWindow();
 });
 

--- a/tests/moke-reader.test.mjs
+++ b/tests/moke-reader.test.mjs
@@ -133,6 +133,7 @@ test('buildEmbeddedReaderUrl preserves the mobile reader launch context', () => 
     buildEmbeddedReaderUrl({
       filePath: 'C:\\Users\\reader\\我的书.pdf',
       eink: true,
+      debugPanel: true,
       mokeBookId: '14',
       serverUrl: 'http://192.168.1.5:8080',
       restoreProgress: {
@@ -150,6 +151,7 @@ test('buildEmbeddedReaderUrl preserves the mobile reader launch context', () => 
   assert.equal(url.searchParams.get('file'), 'C:\\Users\\reader\\我的书.pdf');
   assert.equal(url.searchParams.get('moke'), '1');
   assert.equal(url.searchParams.get('mokeEink'), '1');
+  assert.equal(url.searchParams.get('mokeDebug'), '1');
   assert.equal(url.searchParams.get('mokeBookId'), '14');
   assert.equal(url.searchParams.get('mokeReturnTo'), '/library');
   assert.equal(url.searchParams.get('mokeServerUrl'), 'http://192.168.1.5:8080');
@@ -173,6 +175,7 @@ test('buildEmbeddedReaderUrl preserves the mobile reader launch context', () => 
     'https://moke.invalid',
   );
   assert.equal(empty.searchParams.get('moke'), '1');
+  assert.equal(empty.searchParams.get('mokeDebug'), '0');
   assert.equal(empty.searchParams.get('mokeServerUrl'), null);
 });
 
@@ -181,6 +184,7 @@ test('buildEmbeddedReaderHomeUrl carries mokeServerUrl only when non-empty', () 
   const mobile = new URL(
     buildEmbeddedReaderHomeUrl({
       eink: true,
+      debugPanel: true,
       serverUrl: 'http://192.168.1.5:8080',
     }),
     'https://moke.invalid',
@@ -188,6 +192,7 @@ test('buildEmbeddedReaderHomeUrl carries mokeServerUrl only when non-empty', () 
   assert.equal(mobile.pathname, '/readest/');
   assert.equal(mobile.searchParams.get('moke'), '1');
   assert.equal(mobile.searchParams.get('mokeEink'), '1');
+  assert.equal(mobile.searchParams.get('mokeDebug'), '1');
   assert.equal(mobile.searchParams.get('mokeServerUrl'), 'http://192.168.1.5:8080');
 
   // Desktop: callers omit serverUrl, so no mokeServerUrl is emitted and the
@@ -202,6 +207,7 @@ test('buildEmbeddedReaderHomeUrl carries mokeServerUrl only when non-empty', () 
   assert.equal(desktop.pathname, '/readest/');
   assert.equal(desktop.searchParams.get('moke'), '1');
   assert.equal(desktop.searchParams.get('mokeEink'), '0');
+  assert.equal(desktop.searchParams.get('mokeDebug'), '0');
   assert.equal(desktop.searchParams.get('mokeServerUrl'), null);
 
   // Empty serverUrl must not produce a bare `mokeServerUrl=` param either.


### PR DESCRIPTION
## Summary

- persist and cap debug logs so disconnects and lifecycle changes do not clear history
- synchronize log append/history/clear and panel visibility across Moke and Readest windows
- label entries by Moke or Readest source
- propagate the debug launch flag through desktop and mobile reader flows
- update the Readest submodule to the implementation in https://github.com/hehetoshang/readest/pull/12

## Verification

- `pnpm typecheck` passed
- full `pnpm test` passed (184 tests)
- targeted ESLint passed with two pre-existing warnings
- `git diff --check` passed

## Dependency

This draft depends on https://github.com/hehetoshang/readest/pull/12.
