### PR TITLE
fix: 禁止原生应用壳层缩放

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -83,6 +83,15 @@
     -moz-osx-font-smoothing: grayscale;
   }
 
+  /* A native app shell should pan and scroll normally without exposing the
+     browser's pinch-to-zoom canvas. The web deployment keeps browser zoom for
+     accessibility, and Readest owns its separate document and zoom behavior. */
+  html[data-moke-native-app],
+  html[data-moke-native-app] body,
+  html[data-moke-native-app] .moke-app-root {
+    touch-action: pan-x pan-y;
+  }
+
   .moke-app-root {
     min-height: 100dvh;
   }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -39,10 +39,13 @@ function installMokeReaderExitTransition() {
 
 const mokeReaderExitTransitionScript = `(${installMokeReaderExitTransition.toString()})();`;
 
+const isNativeAppBuild = process.env.NEXT_PUBLIC_APP_PLATFORM === 'tauri';
+
 export const viewport: Viewport = {
   width: 'device-width',
   initialScale: 1,
   viewportFit: 'cover',
+  ...(isNativeAppBuild ? { maximumScale: 1, userScalable: false } : {}),
 };
 
 export default function RootLayout({
@@ -51,7 +54,11 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="zh-CN" suppressHydrationWarning>
+    <html
+      lang="zh-CN"
+      data-moke-native-app={isNativeAppBuild ? '' : undefined}
+      suppressHydrationWarning
+    >
       <head>
         <script dangerouslySetInnerHTML={{ __html: mokeReaderExitTransitionScript }} />
         {/* Apply the persisted theme before hydration so the first paint is

--- a/src/components/providers/AppShell.tsx
+++ b/src/components/providers/AppShell.tsx
@@ -8,6 +8,7 @@ import {
   getNativeTopSafeAreaInset,
   shouldApplyTopSafeArea,
 } from '@/lib/moke-reader';
+import { shouldPreventNativeAppZoomShortcut } from '@/lib/native-app-zoom';
 import { useDeveloperStore } from '@/lib/store/developer';
 import { resolveTheme, useSettingsStore } from '@/lib/store/settings';
 import { NativeBackNavigation } from './NativeBackNavigation';
@@ -27,6 +28,8 @@ declare global {
 if (process.env.NODE_ENV !== 'production') {
   installConsoleCapture();
 }
+
+const isNativeAppBuild = process.env.NEXT_PUBLIC_APP_PLATFORM === 'tauri';
 
 export function AppShell({ children }: { children: React.ReactNode }) {
   const eink = useSettingsStore((s) => s.eink);
@@ -69,6 +72,35 @@ export function AppShell({ children }: { children: React.ReactNode }) {
     if (developerUnlocked) installConsoleCapture();
     else uninstallConsoleCapture();
   }, [developerUnlocked]);
+
+  // Keep the Tauri shell at its designed scale on desktop touchpads and
+  // keyboards. Mobile pinch is also declared unavailable in the viewport and
+  // touch-action rules. These listeners intentionally do not run in the web
+  // build, where browser zoom remains an accessibility feature.
+  useEffect(() => {
+    if (!isNativeAppBuild) return;
+
+    const preventGestureZoom = (event: Event) => event.preventDefault();
+    const preventWheelZoom = (event: WheelEvent) => {
+      if (event.ctrlKey) event.preventDefault();
+    };
+    const preventKeyboardZoom = (event: KeyboardEvent) => {
+      if (shouldPreventNativeAppZoomShortcut(event)) event.preventDefault();
+    };
+    const nonPassive = { passive: false } as const;
+
+    window.addEventListener('wheel', preventWheelZoom, nonPassive);
+    window.addEventListener('keydown', preventKeyboardZoom);
+    document.addEventListener('gesturestart', preventGestureZoom, nonPassive);
+    document.addEventListener('gesturechange', preventGestureZoom, nonPassive);
+
+    return () => {
+      window.removeEventListener('wheel', preventWheelZoom);
+      window.removeEventListener('keydown', preventKeyboardZoom);
+      document.removeEventListener('gesturestart', preventGestureZoom);
+      document.removeEventListener('gesturechange', preventGestureZoom);
+    };
+  }, []);
 
   // Android/iOS use edge-to-edge WebViews, while OHOS already lays the WebView
   // out below its status bar. Mark only the runtimes that need the CSS top

--- a/src/lib/native-app-zoom.ts
+++ b/src/lib/native-app-zoom.ts
@@ -1,0 +1,22 @@
+type ZoomShortcutEvent = Pick<
+  KeyboardEvent,
+  'key' | 'code' | 'ctrlKey' | 'metaKey'
+>;
+
+const ZOOM_KEYS = new Set(['+', '=', '-', '_', '0']);
+const ZOOM_CODES = new Set([
+  'Equal',
+  'Minus',
+  'Digit0',
+  'NumpadAdd',
+  'NumpadSubtract',
+  'Numpad0',
+]);
+
+/** Return whether a key event is a browser/WebView zoom shortcut. */
+export function shouldPreventNativeAppZoomShortcut(
+  event: ZoomShortcutEvent,
+): boolean {
+  if (!event.ctrlKey && !event.metaKey) return false;
+  return ZOOM_KEYS.has(event.key) || ZOOM_CODES.has(event.code);
+}

--- a/tests/native-app-zoom.test.mjs
+++ b/tests/native-app-zoom.test.mjs
@@ -1,0 +1,47 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import { shouldPreventNativeAppZoomShortcut } from '../src/lib/native-app-zoom.ts';
+
+const readSource = (relativePath) => readFileSync(
+  fileURLToPath(new URL(relativePath, import.meta.url)),
+  'utf8',
+);
+
+const layoutSource = readSource('../src/app/layout.tsx');
+const appShellSource = readSource('../src/components/providers/AppShell.tsx');
+const globalStyles = readSource('../src/app/globals.css');
+
+const shortcut = (overrides = {}) => ({
+  key: '',
+  code: '',
+  ctrlKey: false,
+  metaKey: false,
+  ...overrides,
+});
+
+test('原生应用 viewport 禁止页面缩放但保留 Web 构建的浏览器缩放', () => {
+  assert.match(layoutSource, /NEXT_PUBLIC_APP_PLATFORM === 'tauri'/);
+  assert.match(layoutSource, /maximumScale: 1, userScalable: false/);
+  assert.match(layoutSource, /data-moke-native-app=\{isNativeAppBuild \? '' : undefined\}/);
+  assert.match(globalStyles, /html\[data-moke-native-app\][\s\S]*touch-action: pan-x pan-y/);
+});
+
+test('识别桌面端 WebView 的键盘缩放快捷键', () => {
+  assert.equal(shouldPreventNativeAppZoomShortcut(shortcut({ ctrlKey: true, key: '=' })), true);
+  assert.equal(shouldPreventNativeAppZoomShortcut(shortcut({ metaKey: true, key: '+' })), true);
+  assert.equal(shouldPreventNativeAppZoomShortcut(shortcut({ ctrlKey: true, code: 'NumpadSubtract' })), true);
+  assert.equal(shouldPreventNativeAppZoomShortcut(shortcut({ ctrlKey: true, key: '0' })), true);
+  assert.equal(shouldPreventNativeAppZoomShortcut(shortcut({ key: '+' })), false);
+  assert.equal(shouldPreventNativeAppZoomShortcut(shortcut({ ctrlKey: true, key: 'a' })), false);
+});
+
+test('原生应用拦截触控板和 Safari 手势缩放', () => {
+  assert.match(appShellSource, /addEventListener\('wheel', preventWheelZoom, nonPassive\)/);
+  assert.match(appShellSource, /event\.ctrlKey/);
+  assert.match(appShellSource, /addEventListener\('gesturestart', preventGestureZoom, nonPassive\)/);
+  assert.match(appShellSource, /addEventListener\('gesturechange', preventGestureZoom, nonPassive\)/);
+  assert.match(appShellSource, /shouldPreventNativeAppZoomShortcut\(event\)/);
+});


### PR DESCRIPTION
## 变更\n\n- 原生移动端固定 Moke 界面 viewport，禁止双指缩放\n- 桌面 Tauri 拦截触控板、Safari 手势和 Ctrl/Cmd 缩放快捷键\n- 限制仅作用于 Moke 应用壳，Web 版和内嵌 Readest 保留各自缩放能力\n- 增加缩放入口与平台隔离的回归测试\n\n## 验证\n\n- pnpm test（186/186）\n- pnpm typecheck\n- pnpm lint（通过，25 条既有 warning）\n- pnpm build\n- pnpm build-web