### PR TITLE
fix(security): anchor asset protocol scope (TB-89)

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -16,8 +16,8 @@ tauri-build = { path = "../vendor/tauri/crates/tauri-build", features = [] }
 
 [dev-dependencies]
 # Same glob crate version tauri resolves (0.3.4, already in Cargo.lock via tauri).
-# Used by the fs-scope regression test that locks the "$APPDATA/** does not
-# match the bare $APPDATA root" security property (HOU-30).
+# Used by the fs/asset-protocol scope regression tests that lock the
+# app-directory boundaries (HOU-30, TB-85 F4 / TB-89).
 glob = "0.3"
 
 [dependencies]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -292,6 +292,90 @@ mod fs_scope_tests {
         }
     }
 
+    // TB-85 F4 / TB-89 security regression: an unanchored pattern such as
+    // `**/Readest/**/*` lets the asset protocol serve any absolute path that
+    // happens to contain a `Readest` directory. Keep every static entry bound
+    // to a known application/system base directory. Readest's managed files
+    // live below `$APPDATA/Readest` and are already covered by `$APPDATA/**/*`;
+    // user-selected files receive an exact runtime grant from the picker flow.
+    #[test]
+    fn asset_protocol_allow_entries_are_anchored_to_known_roots() {
+        let opts = tauri_match_options();
+        let config_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("tauri.conf.json");
+        let text = std::fs::read_to_string(&config_path)
+            .unwrap_or_else(|e| panic!("cannot read {}: {e}", config_path.display()));
+        let config: Value = serde_json::from_str(&text).unwrap();
+        let allow = config["app"]["security"]["assetProtocol"]["scope"]["allow"]
+            .as_array()
+            .expect("asset protocol allow scope must be an array");
+        let known_roots = [
+            ("$RESOURCE", "/resource"),
+            ("$APPDATA", "/appdata"),
+            ("$APPCACHE", "/appcache"),
+            ("$TEMP", "/temp"),
+        ];
+
+        let patterns: Vec<_> = allow
+            .iter()
+            .map(|entry| {
+                let path = entry
+                    .as_str()
+                    .expect("asset protocol allow entries must be strings");
+                assert!(
+                    !path
+                        .split(|c| c == '/' || c == '\\')
+                        .any(|part| part == ".."),
+                    "{} asset allow path {path} contains parent traversal",
+                    config_path.display()
+                );
+                let resolved = known_roots
+                    .iter()
+                    .find_map(|(variable, root)| {
+                        path.strip_prefix(*variable).and_then(|suffix| {
+                            suffix.starts_with('/').then(|| format!("{root}{suffix}"))
+                        })
+                    })
+                    .unwrap_or_else(|| {
+                        panic!(
+                            "{} asset allow path {path} is not anchored to a known root",
+                            config_path.display()
+                        )
+                    });
+                let pattern = Pattern::new(&resolved).unwrap_or_else(|e| {
+                    panic!(
+                        "bad asset glob {resolved} in {} ({path}): {e}",
+                        config_path.display()
+                    )
+                });
+                (path, pattern)
+            })
+            .collect();
+
+        for outside in [
+            "/home/u/Documents/Readest/x.pdf",
+            "C:/Users/u/Downloads/Readest/a.docx",
+        ] {
+            for (configured, pattern) in &patterns {
+                assert!(
+                    !pattern.matches_path_with(Path::new(outside), opts),
+                    "{} asset allow path {configured} exposes unrelated file {outside}",
+                    config_path.display()
+                );
+            }
+        }
+
+        // `nativeAppService.getURL()` sends this representative managed book
+        // path through `convertFileSrc`; removing the unanchored fallback must
+        // not break assets stored in Readest's real AppData subtree.
+        let managed_book = Path::new("/appdata/Readest/Books/hash/book.epub");
+        assert!(
+            patterns
+                .iter()
+                .any(|(_, pattern)| pattern.matches_path_with(managed_book, opts)),
+            "managed Readest AppData files must remain in the asset scope"
+        );
+    }
+
     // HOU-30 security regression: "removing bare roots" only holds if
     // `$APPDATA/**` does NOT match the bare `$APPDATA` directory itself.
     // `remove(appDataDir(), {recursive:true})` / `rename` / `mkdir(appDataDir())`

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -279,25 +279,37 @@ pub fn run() {
 mod fs_scope_tests {
     use glob::{MatchOptions, Pattern};
     use serde_json::Value;
-    use std::path::Path;
+    use std::path::{Path, PathBuf};
 
-    // Mirrors the exact MatchOptions tauri's `fs::Scope::is_allowed` uses
-    // (tauri/src/scope/fs.rs): require_literal_separator: true so `/dir/*`
-    // doesn't match files inside subdirectories.
+    // Mirrors the pinned Tauri `fs::Scope::new` options
+    // (`vendor/tauri/crates/tauri/src/scope/fs.rs`). `glob` derives Default,
+    // so matching is case-insensitive; Tauri overrides only separator and
+    // platform dotfile handling here.
     fn tauri_match_options() -> MatchOptions {
         MatchOptions {
             require_literal_separator: true,
-            require_literal_leading_dot: false,
-            case_sensitive: true,
+            require_literal_leading_dot: cfg!(unix),
+            ..Default::default()
         }
+    }
+
+    // The asset handler percent-decodes the request path and validates it with
+    // SafePathBuf before consulting fs::Scope. Lock that serve-time boundary so
+    // the static glob test below is not mistaken for the traversal defense.
+    #[test]
+    fn asset_protocol_rejects_parent_traversal_before_scope_matching() {
+        let decoded_request_path = PathBuf::from("/appdata/Readest/../../../etc/hosts");
+        assert!(tauri::path::SafePathBuf::new(decoded_request_path).is_err());
     }
 
     // TB-85 F4 / TB-89 security regression: an unanchored pattern such as
     // `**/Readest/**/*` lets the asset protocol serve any absolute path that
     // happens to contain a `Readest` directory. Keep every static entry bound
     // to a known application/system base directory. Readest's managed files
-    // live below `$APPDATA/Readest` and are already covered by `$APPDATA/**/*`;
-    // user-selected files receive an exact runtime grant from the picker flow.
+    // live below `$APPDATA/Readest` and are already covered by `$APPDATA/**/*`.
+    // For external books, Readest's `allow_paths_in_scopes` and
+    // `open_reader_window` explicitly grant the selected file to both fs and
+    // asset scopes after checking the picker/fs authorization.
     #[test]
     fn asset_protocol_allow_entries_are_anchored_to_known_roots() {
         let opts = tauri_match_options();

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -30,8 +30,7 @@
             "$RESOURCE/**",
             "$APPDATA/**/*",
             "$APPCACHE/**/*",
-            "$TEMP/**/*",
-            "**/Readest/**/*"
+            "$TEMP/**/*"
           ],
           "deny": []
         }


### PR DESCRIPTION
## Summary

- remove the unanchored `**/Readest/**/*` asset-protocol grant
- keep managed Readest files available through the existing `$APPDATA/**/*` scope
- add Rust regressions that parse the committed Tauri config, mirror the pinned Tauri glob options, require known anchored roots, verify request traversal is rejected before scope matching, reject unrelated Unix and Windows paths, and verify a representative `convertFileSrc` Readest book remains allowed

References TB-85 F4 and TB-89.

## Validation

- `CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 CARGO_PROFILE_TEST_DEBUG=0 cargo test --manifest-path src-tauri/Cargo.toml --lib --locked` — 21/21 passed
- `pnpm test` — 195/195 passed
- `pnpm typecheck` — passed
- `pnpm lint` — 0 errors (27 pre-existing warnings)

## Residual risk

No native WebView GUI smoke test was available. The static asset scope still intentionally exposes packaged resources plus AppData/AppCache/Temp descendants, and user-selected files can still receive explicit runtime picker grants; this change removes only the filesystem-wide name-based fallback.
