### PR TITLE
fix: 修复 Tauri 二进制正文下载中断

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -30,7 +30,7 @@ tauri = { path = "../vendor/tauri/crates/tauri", default-features = false, featu
   "dynamic-acl",
 ] }
 tauri-plugin-fs = "=2.5.1"
-tauri-plugin-http = { version = "=2.5.9", features = ["cookies", "dangerous-settings"] }
+tauri-plugin-http = { version = "=2.5.9", features = ["cookies", "dangerous-settings", "unsafe-headers"] }
 tauri-plugin-os = "=2.3.2"
 tauri-plugin-shell = "=2.3.5"
 tauri-plugin-opener = "=2.5.4"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -17,7 +17,10 @@ mod extensions;
 
 use serde::{Deserialize, Serialize};
 use std::fs;
+use std::sync::Mutex;
 use tauri::{AppHandle, Manager};
+
+static MOKE_DOWNLOADS_INDEX_LOCK: Mutex<()> = Mutex::new(());
 
 /// Metadata for a book downloaded by Moke.  The reader uses this small host
 /// API instead of reaching into Moke's IndexedDB, which is private to the
@@ -89,15 +92,44 @@ fn write_moke_downloads(app: &AppHandle, books: &[MokeDownloadedBook]) -> Result
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent).map_err(|error| error.to_string())?;
     }
-    // 原子写入：先写同目录临时文件再 rename，避免写入中途崩溃/断电留下截断损坏的索引。
+    // 先写同目录临时文件，再以备份方式替换。Windows 的 fs::rename 不会覆盖
+    // 已存在目标，直接 tmp -> path 会导致第二次更新起全部失败。
     let tmp_path = path.with_extension("json.tmp");
+    let backup_path = path.with_extension("json.bak");
     fs::write(&tmp_path, serde_json::to_vec(books).map_err(|error| error.to_string())?)
         .map_err(|error| error.to_string())?;
-    fs::rename(&tmp_path, &path).map_err(|error| error.to_string())
+
+    if backup_path.exists() {
+        if path.exists() {
+            fs::remove_file(&backup_path).map_err(|error| error.to_string())?;
+        } else {
+            // 上一次替换若在 current -> backup 后中断，先恢复旧索引再继续。
+            fs::rename(&backup_path, &path).map_err(|error| error.to_string())?;
+        }
+    }
+    let had_previous = path.exists();
+    if had_previous {
+        fs::rename(&path, &backup_path).map_err(|error| error.to_string())?;
+    }
+
+    if let Err(error) = fs::rename(&tmp_path, &path) {
+        if had_previous {
+            let _ = fs::rename(&backup_path, &path);
+        }
+        return Err(error.to_string());
+    }
+
+    if had_previous {
+        let _ = fs::remove_file(backup_path);
+    }
+    Ok(())
 }
 
 #[tauri::command]
 fn moke_record_downloaded_book(app: AppHandle, book: MokeDownloadedBook) -> Result<(), String> {
+    let _guard = MOKE_DOWNLOADS_INDEX_LOCK
+        .lock()
+        .map_err(|error| error.to_string())?;
     let mut books = read_moke_downloads(&app)?;
     books.retain(|existing| existing.id != book.id);
     books.push(book);
@@ -106,6 +138,9 @@ fn moke_record_downloaded_book(app: AppHandle, book: MokeDownloadedBook) -> Resu
 
 #[tauri::command]
 fn moke_remove_downloaded_book(app: AppHandle, id: String) -> Result<(), String> {
+    let _guard = MOKE_DOWNLOADS_INDEX_LOCK
+        .lock()
+        .map_err(|error| error.to_string())?;
     let mut books = read_moke_downloads(&app)?;
     books.retain(|book| book.id != id);
     write_moke_downloads(&app, &books)
@@ -115,10 +150,16 @@ fn moke_remove_downloaded_book(app: AppHandle, id: String) -> Result<(), String>
 /// predate the metadata index are still exposed with a filename-derived title.
 #[tauri::command]
 fn moke_list_downloaded_books(app: AppHandle) -> Result<Vec<MokeDownloadedBookResponse>, String> {
+    let _guard = MOKE_DOWNLOADS_INDEX_LOCK
+        .lock()
+        .map_err(|error| error.to_string())?;
     let books_dir = app.path().app_data_dir().map_err(|error| error.to_string())?.join("books");
     let mut indexed = read_moke_downloads(&app)?;
+    let indexed_count = indexed.len();
     indexed.retain(|book| books_dir.join(&book.file_name).is_file());
-    write_moke_downloads(&app, &indexed)?;
+    if indexed.len() != indexed_count {
+        write_moke_downloads(&app, &indexed)?;
+    }
 
     let mut result: Vec<_> = indexed
         .into_iter()
@@ -133,7 +174,10 @@ fn moke_list_downloaded_books(app: AppHandle) -> Result<Vec<MokeDownloadedBookRe
             let entry = entry.map_err(|error| error.to_string())?;
             let path = entry.path();
             let file_name = entry.file_name().to_string_lossy().into_owned();
-            if !path.is_file() || result.iter().any(|book| book.book.file_name == file_name) {
+            if file_name.starts_with('.')
+                || !path.is_file()
+                || result.iter().any(|book| book.book.file_name == file_name)
+            {
                 continue;
             }
             let title = path

--- a/src/app/detail/page.tsx
+++ b/src/app/detail/page.tsx
@@ -308,8 +308,10 @@ function DetailContent() {
         setMessage(`下载失败，服务器返回 ${reason.replace('http.', '')}。`);
       } else if (reason === 'book.epub.invalid') {
         setMessage('下载失败：服务端返回的 EPUB 文件不完整或格式错误，请重新上传该书。');
-      } else if (reason === 'Failed to save book to file system') {
-        setMessage('下载失败：保存文件到本地时出错。');
+      } else if (reason === 'book.download.transfer_failed') {
+        setMessage('下载失败：接收文件内容时连接中断，请重试。');
+      } else if (reason === 'book.download.storage_failed' || reason === 'Failed to save book to file system') {
+        setMessage('下载失败：无法保存到本地，请检查存储空间或权限。');
       } else if (!isTauriApp) {
         setMessage('下载失败：当前浏览器模式下可能被跨域策略拦截。桌面版会走 Tauri 原生下载通道。');
       } else {

--- a/src/lib/api-core.ts
+++ b/src/lib/api-core.ts
@@ -48,14 +48,10 @@ export function buildTauriRequestInit(options?: RequestInit): TauriRequestInit {
   return init;
 }
 
-/**
- * Tauri plugin-http 会在请求带 Range 时自动补 `Accept-Encoding: identity`。
- * 二进制响应禁用透明压缩，可避免部分 NAS/反向代理返回 200 后在正文解压阶段
- * 中断；`bytes=0-` 仍请求完整文件，支持 Range 的服务器返回 206，不支持的会忽略。
- */
+/** 二进制响应禁用透明压缩，避免部分 NAS/反向代理在正文解压阶段中断。 */
 export function buildTauriBinaryHeaders(headers?: HeadersInit): Headers {
   const result = new Headers(headers);
-  if (!result.has('range')) result.set('Range', 'bytes=0-');
+  if (!result.has('accept-encoding')) result.set('Accept-Encoding', 'identity');
   return result;
 }
 

--- a/src/lib/api-core.ts
+++ b/src/lib/api-core.ts
@@ -48,6 +48,17 @@ export function buildTauriRequestInit(options?: RequestInit): TauriRequestInit {
   return init;
 }
 
+/**
+ * Tauri plugin-http 会在请求带 Range 时自动补 `Accept-Encoding: identity`。
+ * 二进制响应禁用透明压缩，可避免部分 NAS/反向代理返回 200 后在正文解压阶段
+ * 中断；`bytes=0-` 仍请求完整文件，支持 Range 的服务器返回 206，不支持的会忽略。
+ */
+export function buildTauriBinaryHeaders(headers?: HeadersInit): Headers {
+  const result = new Headers(headers);
+  if (!result.has('range')) result.set('Range', 'bytes=0-');
+  return result;
+}
+
 export function getErrorMessage(error: unknown, fallback = '操作失败，请稍后重试。') {
   if (error instanceof MokeApiError) return error.message || fallback;
   if (error instanceof Error) {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -158,11 +158,7 @@ export async function fetchImageObjectUrl(imageUrl: string): Promise<string> {
   const startedAt = Date.now();
   debugLog('info', 'image', `→ GET ${imageUrl}`);
   try {
-    const response = await request(imageUrl, {
-      credentials: 'include',
-      // Range 会让 plugin-http 使用 identity 编码，规避部分代理的二进制正文解压中断。
-      ...(isTauriApp ? { headers: buildTauriBinaryHeaders() } : {}),
-    });
+    const response = await request(imageUrl, { credentials: 'include' });
     if (!response.ok) {
       debugLog(
         'error',
@@ -626,6 +622,7 @@ export async function streamBookDownload(
     try {
       result = await reader.read();
     } catch (error) {
+      if (isRequestCancelled(error)) throw error;
       logBinaryTransferFailure(url, response, error, received);
       throw new Error('book.download.transfer_failed');
     }
@@ -637,6 +634,11 @@ export async function streamBookDownload(
     try {
       await options.write(value);
     } catch (error) {
+      try {
+        await reader.cancel(error);
+      } catch {
+        // 原始写入错误更有诊断价值，取消失败不覆盖它。
+      }
       logOfflineWriteFailure(error, received);
       throw new Error('book.download.storage_failed');
     }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -2,6 +2,7 @@ import type { ReaderInfo, ServerCapabilities } from '@/lib/store/server';
 import { debugLog } from '@/lib/debug-log';
 import {
   attachSafeJsonReader,
+  buildTauriBinaryHeaders,
   buildTauriRequestInit,
   getErrorMessage,
   isAbsoluteHttpUrl,
@@ -47,6 +48,33 @@ function isRequestCancelled(error: unknown): boolean {
   if (error instanceof DOMException && error.name === 'AbortError') return true;
   const message = error instanceof Error ? error.message : String(error);
   return /request cancell?ed|aborted?/i.test(message);
+}
+
+function binaryTransferErrorDetail(error: unknown): string {
+  return error instanceof Error ? `${error.name}: ${error.message}` : String(error);
+}
+
+function logBinaryTransferFailure(
+  url: string,
+  response: Response,
+  error: unknown,
+  receivedBytes: number,
+): void {
+  debugLog('error', 'download', `✗ GET ${url} 响应正文读取失败`, {
+    status: response.status,
+    receivedBytes,
+    expectedBytes: Number(response.headers.get('content-length') || 0),
+    contentRange: response.headers.get('content-range'),
+    contentEncoding: response.headers.get('content-encoding'),
+    error: binaryTransferErrorDetail(error),
+  }, 'network');
+}
+
+function logOfflineWriteFailure(error: unknown, receivedBytes: number): void {
+  debugLog('error', 'download', '✗ 下载内容写入本地文件失败', {
+    receivedBytes,
+    error: binaryTransferErrorDetail(error),
+  });
 }
 
 async function validateDownloadedBook(blob: Blob, format: string): Promise<Blob> {
@@ -130,7 +158,11 @@ export async function fetchImageObjectUrl(imageUrl: string): Promise<string> {
   const startedAt = Date.now();
   debugLog('info', 'image', `→ GET ${imageUrl}`);
   try {
-    const response = await request(imageUrl, { credentials: 'include' });
+    const response = await request(imageUrl, {
+      credentials: 'include',
+      // Range 会让 plugin-http 使用 identity 编码，规避部分代理的二进制正文解压中断。
+      ...(isTauriApp ? { headers: buildTauriBinaryHeaders() } : {}),
+    });
     if (!response.ok) {
       debugLog(
         'error',
@@ -457,7 +489,12 @@ export async function downloadBookBlob(
   try {
     const response = await request(url, {
       ...(isTauriApp
-        ? ({ method: 'GET', connectTimeout: 30_000, signal: options?.signal } as any)
+        ? ({
+            method: 'GET',
+            headers: buildTauriBinaryHeaders(),
+            connectTimeout: 30_000,
+            signal: options?.signal,
+          } as any)
         : { credentials: 'include', signal: options?.signal }),
     });
 
@@ -540,7 +577,12 @@ export async function streamBookDownload(
 
   const response = await request(url, {
     ...(isTauriApp
-      ? ({ method: 'GET', connectTimeout: 30_000, signal: options?.signal } as any)
+      ? ({
+          method: 'GET',
+          headers: buildTauriBinaryHeaders(),
+          connectTimeout: 30_000,
+          signal: options?.signal,
+        } as any)
       : { credentials: 'include', signal: options?.signal }),
   });
 
@@ -552,9 +594,21 @@ export async function streamBookDownload(
   const reader = response.body?.getReader();
 
   if (!reader) {
-    const blob = await response.blob();
+    let blob: Blob;
+    try {
+      blob = await response.blob();
+    } catch (error) {
+      logBinaryTransferFailure(url, response, error, 0);
+      throw new Error('book.download.transfer_failed');
+    }
+
     options.onProgress?.(99);
-    await options.write(new Uint8Array(await blob.arrayBuffer()));
+    try {
+      await options.write(new Uint8Array(await blob.arrayBuffer()));
+    } catch (error) {
+      logOfflineWriteFailure(error, blob.size);
+      throw new Error('book.download.storage_failed');
+    }
     if (format.toLowerCase() === 'epub' && !(await hasEpubCentralDirectory(blob))) {
       throw new Error('book.epub.invalid');
     }
@@ -568,12 +622,24 @@ export async function streamBookDownload(
   let received = 0;
 
   while (true) {
-    const { done, value } = await reader.read();
+    let result: ReadableStreamReadResult<Uint8Array>;
+    try {
+      result = await reader.read();
+    } catch (error) {
+      logBinaryTransferFailure(url, response, error, received);
+      throw new Error('book.download.transfer_failed');
+    }
 
+    const { done, value } = result;
     if (done) break;
     if (!value) continue;
 
-    await options.write(value);
+    try {
+      await options.write(value);
+    } catch (error) {
+      logOfflineWriteFailure(error, received);
+      throw new Error('book.download.storage_failed');
+    }
     received += value.length;
     tail = keepTailBytes(tail, value, BOOK_TAIL_WINDOW);
 

--- a/src/lib/offline-books.ts
+++ b/src/lib/offline-books.ts
@@ -19,6 +19,17 @@ export interface OfflineBookRecord {
   filePath?: string;
 }
 
+interface NativeOfflineBookRecord {
+  id: string;
+  serverUrl: string;
+  bookId: string;
+  title: string;
+  fileName: string;
+  mimeType: string;
+  updatedAt: number;
+  filePath: string;
+}
+
 function openDatabase(): Promise<IDBDatabase> {
   return new Promise((resolve, reject) => {
     const request = window.indexedDB.open(DB_NAME, DB_VERSION);
@@ -35,7 +46,7 @@ function openDatabase(): Promise<IDBDatabase> {
   });
 }
 
-export async function getOfflineBook(serverUrl: string, bookId: string): Promise<OfflineBookRecord | null> {
+async function readOfflineBookRecord(serverUrl: string, bookId: string): Promise<OfflineBookRecord | null> {
   const db = await openDatabase();
 
   return new Promise((resolve, reject) => {
@@ -46,6 +57,88 @@ export async function getOfflineBook(serverUrl: string, bookId: string): Promise
     request.onsuccess = () => resolve((request.result as OfflineBookRecord | undefined) ?? null);
     request.onerror = () => reject(request.error);
   });
+}
+
+async function putOfflineBookRecord(record: OfflineBookRecord): Promise<void> {
+  const db = await openDatabase();
+  await new Promise<void>((resolve, reject) => {
+    const transaction = db.transaction(STORE_NAME, 'readwrite');
+    const request = transaction.objectStore(STORE_NAME).put(record);
+    request.onsuccess = () => resolve();
+    request.onerror = () => reject(request.error);
+  });
+}
+
+function sameServer(left: string, right: string): boolean {
+  try {
+    return new URL(left).origin === new URL(right).origin;
+  } catch {
+    return left.replace(/\/+$/, '') === right.replace(/\/+$/, '');
+  }
+}
+
+/**
+ * Tauri 的磁盘文件和原生索引是离线书的最终事实来源。WebView 的 IndexedDB
+ * 可能在应用升级或来源迁移后丢失；此时从原生索引恢复记录，避免磁盘上仍有书
+ * 却把“阅读”误显示成“下载”。
+ */
+export async function getOfflineBook(serverUrl: string, bookId: string): Promise<OfflineBookRecord | null> {
+  let indexedRecord: OfflineBookRecord | null = null;
+  try {
+    indexedRecord = await readOfflineBookRecord(serverUrl, bookId);
+  } catch (error) {
+    if (process.env.NEXT_PUBLIC_APP_PLATFORM !== 'tauri') throw error;
+    debugLog(
+      'warn',
+      'download',
+      '读取 WebView 离线书记录失败，尝试从原生索引恢复',
+      error instanceof Error ? `${error.name}: ${error.message}` : String(error),
+    );
+  }
+  if (process.env.NEXT_PUBLIC_APP_PLATFORM !== 'tauri') return indexedRecord;
+
+  try {
+    const { invoke } = await import('@tauri-apps/api/core');
+    const nativeRecords = await invoke<NativeOfflineBookRecord[]>('moke_list_downloaded_books');
+    const nativeRecord = nativeRecords.find((record) => (
+      record.bookId === bookId && sameServer(record.serverUrl, serverUrl)
+    )) ?? (indexedRecord
+      ? nativeRecords.find((record) => record.fileName === indexedRecord.fileName)
+      : undefined);
+
+    if (!nativeRecord) return null;
+
+    const recovered: OfflineBookRecord = {
+      id: makeOfflineBookKey(serverUrl, bookId),
+      serverUrl,
+      bookId,
+      title: nativeRecord.title || indexedRecord?.title || '',
+      fileName: nativeRecord.fileName,
+      mimeType: nativeRecord.mimeType || indexedRecord?.mimeType || 'application/octet-stream',
+      updatedAt: nativeRecord.updatedAt,
+      filePath: nativeRecord.filePath,
+    };
+    try {
+      await putOfflineBookRecord(recovered);
+    } catch (error) {
+      debugLog(
+        'warn',
+        'download',
+        '原生离线书已恢复，但写回 WebView 记录失败',
+        error instanceof Error ? `${error.name}: ${error.message}` : String(error),
+      );
+    }
+    return recovered;
+  } catch (error) {
+    // 原生索引读取失败时保留 IndexedDB 兜底，避免一次 IPC 异常把按钮错误降级。
+    debugLog(
+      'warn',
+      'download',
+      '读取原生离线书索引失败，回退到 WebView 记录',
+      error instanceof Error ? `${error.name}: ${error.message}` : String(error),
+    );
+    return indexedRecord;
+  }
 }
 
 export async function deleteOfflineBook(serverUrl: string, bookId: string): Promise<void> {
@@ -138,7 +231,11 @@ export interface OfflineFileWriter {
   close(): Promise<void>;
 }
 
-async function openOfflineBookFile(fileName: string): Promise<{ writer: OfflineFileWriter; filePath: string }> {
+async function openOfflineBookFile(fileName: string): Promise<{
+  writer: OfflineFileWriter;
+  filePath: string;
+  temporaryPath: string;
+}> {
   const { open, BaseDirectory, mkdir } = await import('@tauri-apps/plugin-fs');
   const { appDataDir, join } = await import('@tauri-apps/api/path');
 
@@ -148,16 +245,20 @@ async function openOfflineBookFile(fileName: string): Promise<{ writer: OfflineF
     // Ignore if directory already exists
   }
 
-  const relativePath = await join('books', fileName);
-  const file = await open(relativePath, {
+  const token = typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+    ? crypto.randomUUID()
+    : `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  const temporaryName = `.moke-download-${token}.part`;
+  const temporaryRelativePath = await join('books', temporaryName);
+  const file = await open(temporaryRelativePath, {
     write: true,
-    create: true,
-    truncate: true,
+    createNew: true,
     baseDir: BaseDirectory.AppData,
   });
 
   const dir = await appDataDir();
   const filePath = await join(dir, 'books', fileName);
+  const temporaryPath = await join(dir, 'books', temporaryName);
 
   return {
     writer: {
@@ -165,6 +266,37 @@ async function openOfflineBookFile(fileName: string): Promise<{ writer: OfflineF
       close: () => file.close(),
     },
     filePath,
+    temporaryPath,
+  };
+}
+
+async function replaceOfflineBookFile(temporaryPath: string, filePath: string): Promise<() => Promise<void>> {
+  const { exists, remove, rename } = await import('@tauri-apps/plugin-fs');
+  const backupPath = `${temporaryPath}.backup`;
+  const hadPreviousFile = await exists(filePath);
+
+  if (hadPreviousFile) await rename(filePath, backupPath);
+
+  try {
+    await rename(temporaryPath, filePath);
+  } catch (error) {
+    if (hadPreviousFile) {
+      try {
+        await rename(backupPath, filePath);
+      } catch {
+        // 交给外层记录原始安装失败；备份仍留在磁盘，避免静默丢失。
+      }
+    }
+    throw error;
+  }
+
+  return async () => {
+    try {
+      await remove(filePath);
+    } catch {
+      // ignore
+    }
+    if (hadPreviousFile) await rename(backupPath, filePath);
   };
 }
 
@@ -182,15 +314,21 @@ export async function saveOfflineBookStream(input: {
 
   let writer: OfflineFileWriter | null = null;
   let filePath: string | undefined;
+  let temporaryPath: string | undefined;
+  let rollbackReplacement: (() => Promise<void>) | null = null;
 
   try {
     const handle = await openOfflineBookFile(fileName);
     writer = handle.writer;
     filePath = handle.filePath;
+    temporaryPath = handle.temporaryPath;
 
     const actualMime = (await input.write(writer)) || input.mimeType;
     await writer.close();
     writer = null;
+
+    rollbackReplacement = await replaceOfflineBookFile(temporaryPath, filePath);
+    temporaryPath = undefined;
 
     await commitOfflineBookRecord({
       serverUrl: input.serverUrl,
@@ -200,9 +338,27 @@ export async function saveOfflineBookStream(input: {
       mimeType: actualMime,
       filePath,
     });
+
+    // 索引已经提交，旧文件备份不再需要。
+    const { remove } = await import('@tauri-apps/plugin-fs');
+    const backupPath = `${handle.temporaryPath}.backup`;
+    try {
+      await remove(backupPath);
+    } catch {
+      // 原文件不存在或备份清理失败均不影响新下载；隐藏备份不会进入书库扫描。
+    }
+    rollbackReplacement = null;
   } catch (e) {
-    // 清理半成品/孤儿文件，避免被 legacy 扫描重新暴露成幽灵书。
-    if (filePath) {
+    // 下载始终写入隐藏临时文件。失败时恢复原文件，避免一次重试把已下载书籍
+    // 截断或删除；没有原文件时只清理半成品。
+    if (rollbackReplacement) {
+      try {
+        await rollbackReplacement();
+      } catch {
+        // ignore
+      }
+    }
+    if (temporaryPath) {
       try {
         if (writer) await writer.close();
       } catch {
@@ -210,7 +366,7 @@ export async function saveOfflineBookStream(input: {
       }
       try {
         const { remove } = await import('@tauri-apps/plugin-fs');
-        await remove(filePath);
+        await remove(temporaryPath);
       } catch {
         // ignore
       }
@@ -249,7 +405,6 @@ async function commitOfflineBookRecord(input: {
   blob?: Blob;
   filePath?: string;
 }): Promise<void> {
-  const db = await openDatabase();
   const isTauriApp = process.env.NEXT_PUBLIC_APP_PLATFORM === 'tauri';
 
   const record: OfflineBookRecord = {
@@ -264,14 +419,7 @@ async function commitOfflineBookRecord(input: {
     filePath: input.filePath,
   };
 
-  await new Promise<void>((resolve, reject) => {
-    const transaction = db.transaction(STORE_NAME, 'readwrite');
-    const store = transaction.objectStore(STORE_NAME);
-    const request = store.put(record);
-
-    request.onsuccess = () => resolve();
-    request.onerror = () => reject(request.error);
-  });
+  await putOfflineBookRecord(record);
 
   if (isTauriApp) {
     try {

--- a/src/lib/offline-books.ts
+++ b/src/lib/offline-books.ts
@@ -1,5 +1,6 @@
 'use client';
 
+import { debugLog } from './debug-log.ts';
 import { makeOfflineBookKey, sanitizeOfflineFileName } from './offline-book-core.ts';
 
 const DB_NAME = 'moke-offline-books';
@@ -214,7 +215,17 @@ export async function saveOfflineBookStream(input: {
         // ignore
       }
     }
-    throw e;
+
+    if (e instanceof Error && (e.message === 'book.epub.invalid' || e.message.startsWith('book.download.'))) {
+      throw e;
+    }
+    debugLog(
+      'error',
+      'download',
+      '✗ 创建、关闭或登记离线书籍文件失败',
+      e instanceof Error ? `${e.name}: ${e.message}` : String(e),
+    );
+    throw new Error('book.download.storage_failed');
   }
 
   // M1：同书换格式/改名再下载时，删除旧的残留磁盘文件，避免目录扫描

--- a/src/lib/offline-books.ts
+++ b/src/lib/offline-books.ts
@@ -5,7 +5,6 @@ import { makeOfflineBookKey, sanitizeOfflineFileName } from './offline-book-core
 
 const DB_NAME = 'moke-offline-books';
 const STORE_NAME = 'books';
-const DB_VERSION = 1;
 
 export interface OfflineBookRecord {
   id: string;
@@ -32,7 +31,10 @@ interface NativeOfflineBookRecord {
 
 function openDatabase(): Promise<IDBDatabase> {
   return new Promise((resolve, reject) => {
-    const request = window.indexedDB.open(DB_NAME, DB_VERSION);
+    // 不指定版本：当前逻辑只依赖 books store，不需要执行 schema 升级。
+    // 这样既能创建全新 v1 数据库，也能打开曾被下载管理中心升级到 v2（或更高）
+    // 的用户数据库，避免用较低固定版本打开时抛 VersionError。
+    const request = window.indexedDB.open(DB_NAME);
 
     request.onupgradeneeded = () => {
       const db = request.result;
@@ -48,15 +50,26 @@ function openDatabase(): Promise<IDBDatabase> {
 
 async function readOfflineBookRecord(serverUrl: string, bookId: string): Promise<OfflineBookRecord | null> {
   const db = await openDatabase();
-
-  return new Promise((resolve, reject) => {
-    const transaction = db.transaction(STORE_NAME, 'readonly');
-    const store = transaction.objectStore(STORE_NAME);
+  const store = db.transaction(STORE_NAME, 'readonly').objectStore(STORE_NAME);
+  const direct = await new Promise<OfflineBookRecord | null>((resolve, reject) => {
     const request = store.get(makeOfflineBookKey(serverUrl, bookId));
-
     request.onsuccess = () => resolve((request.result as OfflineBookRecord | undefined) ?? null);
     request.onerror = () => reject(request.error);
   });
+  if (direct) return direct;
+
+  // v2 会把格式加入 key（server::book::format）。按记录身份兜底查找，保证从
+  // 下载管理中心版本切回当前客户端时，已有书仍能被识别。
+  if (typeof store.getAll === 'function') {
+    const records = await new Promise<OfflineBookRecord[]>((resolve, reject) => {
+      const request = store.getAll();
+      request.onsuccess = () => resolve(request.result as OfflineBookRecord[]);
+      request.onerror = () => reject(request.error);
+    });
+    return records.find((record) => record.bookId === bookId && sameServer(record.serverUrl, serverUrl)) ?? null;
+  }
+
+  return null;
 }
 
 async function putOfflineBookRecord(record: OfflineBookRecord): Promise<void> {
@@ -109,7 +122,7 @@ export async function getOfflineBook(serverUrl: string, bookId: string): Promise
     if (!nativeRecord) return null;
 
     const recovered: OfflineBookRecord = {
-      id: makeOfflineBookKey(serverUrl, bookId),
+      id: nativeRecord.id || indexedRecord?.id || makeOfflineBookKey(serverUrl, bookId),
       serverUrl,
       bookId,
       title: nativeRecord.title || indexedRecord?.title || '',
@@ -168,7 +181,7 @@ export async function deleteOfflineBook(serverUrl: string, bookId: string): Prom
   await new Promise<void>((resolve, reject) => {
     const transaction = db.transaction(STORE_NAME, 'readwrite');
     const store = transaction.objectStore(STORE_NAME);
-    const request = store.delete(makeOfflineBookKey(serverUrl, bookId));
+    const request = store.delete(record?.id ?? makeOfflineBookKey(serverUrl, bookId));
 
     request.onsuccess = () => resolve();
     request.onerror = () => reject(request.error);

--- a/tests/api-core.test.mjs
+++ b/tests/api-core.test.mjs
@@ -159,13 +159,13 @@ test('错误提示映射覆盖地址丢失、HTTP 错误和未知错误', () => 
   assert.equal(getErrorMessage(new MokeApiError('没有权限', 'permission.denied', 403)), '没有权限');
 });
 
-test('Tauri 二进制请求使用完整 Range 以禁用透明压缩', () => {
+test('Tauri 二进制请求显式禁用透明压缩', () => {
   const headers = buildTauriBinaryHeaders({ Accept: 'application/epub+zip' });
-  assert.equal(headers.get('range'), 'bytes=0-');
+  assert.equal(headers.get('accept-encoding'), 'identity');
   assert.equal(headers.get('accept'), 'application/epub+zip');
 
-  const customRange = buildTauriBinaryHeaders({ Range: 'bytes=1024-2047' });
-  assert.equal(customRange.get('range'), 'bytes=1024-2047');
+  const customEncoding = buildTauriBinaryHeaders({ 'Accept-Encoding': 'br' });
+  assert.equal(customEncoding.get('accept-encoding'), 'br');
 });
 
 test('Web 与 Tauri 平台分支生成不同的安全请求配置', () => {

--- a/tests/api-core.test.mjs
+++ b/tests/api-core.test.mjs
@@ -4,6 +4,7 @@ import assert from 'node:assert/strict';
 import {
   attachSafeJsonReader,
   MokeApiError,
+  buildTauriBinaryHeaders,
   buildTauriRequestInit,
   getErrorMessage,
   isAbsoluteHttpUrl,
@@ -156,6 +157,15 @@ test('错误提示映射覆盖地址丢失、HTTP 错误和未知错误', () => 
   assert.equal(getErrorMessage(new Error('Failed to fetch'), '网络异常'), '网络异常');
   // MokeApiError 保留服务端业务提示
   assert.equal(getErrorMessage(new MokeApiError('没有权限', 'permission.denied', 403)), '没有权限');
+});
+
+test('Tauri 二进制请求使用完整 Range 以禁用透明压缩', () => {
+  const headers = buildTauriBinaryHeaders({ Accept: 'application/epub+zip' });
+  assert.equal(headers.get('range'), 'bytes=0-');
+  assert.equal(headers.get('accept'), 'application/epub+zip');
+
+  const customRange = buildTauriBinaryHeaders({ Range: 'bytes=1024-2047' });
+  assert.equal(customRange.get('range'), 'bytes=1024-2047');
 });
 
 test('Web 与 Tauri 平台分支生成不同的安全请求配置', () => {

--- a/tests/offline-books.test.mjs
+++ b/tests/offline-books.test.mjs
@@ -227,3 +227,54 @@ test('删除只移除目标离线书籍，删除不存在的记录也不会失�
   assert.equal(await getOfflineBook('https://a.example', '1'), null);
   assert.equal((await getOfflineBook('https://a.example', '2'))?.bookId, '2');
 });
+
+test('桌面版 IndexedDB 记录丢失后会从原生磁盘索引恢复已下载状态', async () => {
+  const indexedDB = createFakeIndexedDb();
+  process.env.NEXT_PUBLIC_APP_PLATFORM = 'tauri';
+  globalThis.window = {
+    indexedDB,
+    __TAURI_INTERNALS__: {
+      invoke: async (command) => {
+        assert.equal(command, 'moke_list_downloaded_books');
+        return [{
+          id: 'https://a.example::42',
+          serverUrl: 'https://a.example:443',
+          bookId: '42',
+          title: '西游记',
+          fileName: '西游记.epub',
+          mimeType: 'application/epub+zip',
+          updatedAt: 123,
+          filePath: '/app-data/books/西游记.epub',
+        }];
+      },
+    },
+  };
+
+  const recovered = await getOfflineBook('https://a.example', '42');
+  assert.equal(recovered?.title, '西游记');
+  assert.equal(recovered?.filePath, '/app-data/books/西游记.epub');
+  assert.equal(indexedDB.records.get('https://a.example::42')?.title, '西游记');
+});
+
+test('桌面版以磁盘索引校验 IndexedDB，文件已不存在时不误显示阅读按钮', async () => {
+  const indexedDB = createFakeIndexedDb();
+  indexedDB.records.set('https://a.example::42', {
+    id: 'https://a.example::42',
+    serverUrl: 'https://a.example',
+    bookId: '42',
+    title: '西游记',
+    fileName: '西游记.epub',
+    mimeType: 'application/epub+zip',
+    updatedAt: 123,
+    filePath: '/app-data/books/西游记.epub',
+  });
+  process.env.NEXT_PUBLIC_APP_PLATFORM = 'tauri';
+  globalThis.window = {
+    indexedDB,
+    __TAURI_INTERNALS__: {
+      invoke: async () => [],
+    },
+  };
+
+  assert.equal(await getOfflineBook('https://a.example', '42'), null);
+});

--- a/tests/offline-books.test.mjs
+++ b/tests/offline-books.test.mjs
@@ -72,6 +72,9 @@ function createFakeIndexedDb() {
     get(key) {
       return makeAsyncRequest(() => records.get(key));
     },
+    getAll() {
+      return makeAsyncRequest(() => [...records.values()]);
+    },
     put(record) {
       return makeAsyncRequest(() => {
         records.set(record.id, record);
@@ -254,6 +257,37 @@ test('桌面版 IndexedDB 记录丢失后会从原生磁盘索引恢复已下载
   assert.equal(recovered?.title, '西游记');
   assert.equal(recovered?.filePath, '/app-data/books/西游记.epub');
   assert.equal(indexedDB.records.get('https://a.example::42')?.title, '西游记');
+});
+
+test('兼容已升级到 v2 的 IndexedDB，不用较低版本打开且可识别格式化 key', async () => {
+  const indexedDB = createFakeIndexedDb();
+  const open = indexedDB.open.bind(indexedDB);
+  const requestedVersions = [];
+  indexedDB.open = (name, version) => {
+    requestedVersions.push(version);
+    if (version !== undefined && version < 2) {
+      return makeAsyncRequest(() => {
+        throw new DOMException('Requested version is lower than existing version', 'VersionError');
+      });
+    }
+    return open(name, version);
+  };
+  indexedDB.records.set('https://a.example::42::epub', {
+    id: 'https://a.example::42::epub',
+    serverUrl: 'https://a.example',
+    bookId: '42',
+    format: 'epub',
+    title: '西游记',
+    fileName: '西游记.epub',
+    mimeType: 'application/epub+zip',
+    updatedAt: 123,
+  });
+  globalThis.window = { indexedDB };
+  process.env.NEXT_PUBLIC_APP_PLATFORM = 'web';
+
+  const record = await getOfflineBook('https://a.example', '42');
+  assert.equal(record?.id, 'https://a.example::42::epub');
+  assert.deepEqual(requestedVersions, [undefined]);
 });
 
 test('桌面版以磁盘索引校验 IndexedDB，文件已不存在时不误显示阅读按钮', async () => {


### PR DESCRIPTION
## 背景

Moke v1.0.2 配合 Talebook v26.08.11 下载 EPUB 时，页面显示下载失败。现场日志确认接口已经认证并返回成功响应，但 Tauri/plugin-http 在二进制正文阶段中断。后续实机复测还发现：磁盘上已有的《西游记》会从“阅读”退化成“下载”，并且再次下载失败。

## 根因与修复

- 书籍请求显式使用 `Accept-Encoding: identity`，不再通过 `Range` 的副作用关闭压缩，也不再给封面/头像扩大 Range 请求范围。
- 桌面版以磁盘文件和原生下载索引为最终事实来源；WebView IndexedDB 在升级或来源迁移后丢失时，会自动恢复“已下载”状态并回填缓存。
- 下载改为先写隐藏临时文件，文件接收、EPUB 校验和索引提交成功后才替换正式文件；失败时恢复旧文件，避免一次重试截断或删除原有书籍。
- 修复 Windows 上原生下载索引第二次更新时 `rename` 无法覆盖已有目标的问题，并为读改写增加互斥保护和中断恢复。
- 写盘失败时主动取消剩余响应流，用户取消保留取消语义；临时文件不会进入原生书库扫描。

## 验证

- `pnpm test`：198/198 通过（新增 IndexedDB 丢失恢复、磁盘缺失校验测试）
- `pnpm typecheck`：通过
- `pnpm lint`：0 error（保留仓库已有 27 warnings）
- `pnpm build`：通过
- `cargo check --lib`：当前 checkout 的 `vendor/openharmony-ability` 子模块未初始化，因缺少其 `Cargo.toml` 无法启动；已确认固定版本 `tauri-plugin-http 2.5.9` 提供所启用的 `unsafe-headers` feature

## 实机复测重点

1. 已下载的《西游记》进入详情页后保持“阅读”，且可以正常打开。
2. 下载一本新 EPUB，进度完成后按钮切换为“阅读”。
3. 对已下载书籍制造网络中断后重试，失败时原文件仍可阅读。
4. 若仍失败，请导出开发者日志；新版日志会区分请求、正文传输与本地存储阶段。
