### PR TITLE
fix: 避免点击阅读后显示无效资源报错

### DIFF
--- a/src/lib/book-read.ts
+++ b/src/lib/book-read.ts
@@ -7,17 +7,29 @@ const READ_RECORD_TIMEOUT_MS = 10_000;
 export const READ_RECORD_NAV_TIMEOUT_MS = 3_000;
 
 /**
- * Build a record timeout signal that also works on WebViews without
- * `AbortSignal.timeout` (some OHOS / older iOS WebViews); without any abort
- * mechanism the request runs unbounded, which is still better than throwing
- * and losing the record silently.
+ * Build a timeout that can be disarmed after the response body is consumed.
+ *
+ * Do not use `AbortSignal.timeout` here: Tauri plugin-http keeps its abort
+ * listeners after a completed body read. A later autonomous abort then tries
+ * to cancel an already-released native response and surfaces an unhandled
+ * `The resource id ... is invalid` rejection even though reading succeeded.
  */
-function buildTimeoutSignal(timeoutMs: number): AbortSignal | undefined {
-  if (typeof AbortSignal.timeout === 'function') return AbortSignal.timeout(timeoutMs);
-  if (typeof AbortController !== 'function') return undefined;
+function buildRequestTimeout(timeoutMs: number): {
+  signal: AbortSignal | undefined;
+  clear: () => void;
+} {
+  if (typeof AbortController !== 'function') {
+    // Without an abort mechanism the request runs unbounded, which is still
+    // better than throwing and silently losing the read record.
+    return { signal: undefined, clear: () => {} };
+  }
+
   const controller = new AbortController();
-  setTimeout(() => controller.abort(), timeoutMs);
-  return controller.signal;
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  return {
+    signal: controller.signal,
+    clear: () => clearTimeout(timer),
+  };
 }
 
 /** Pathname of an absolute URL with trailing slashes stripped; null if unparseable. */
@@ -41,29 +53,37 @@ export async function recordBookRead(
   timeoutMs = READ_RECORD_TIMEOUT_MS,
 ): Promise<void> {
   const readUrl = `${serverUrl}/read/${encodeURIComponent(String(bookId))}`;
-  const response = await requestLike(readUrl, {
-    credentials: 'include',
-    signal: buildTimeoutSignal(timeoutMs),
-  });
+  const timeout = buildRequestTimeout(timeoutMs);
 
-  // Drain the body promptly so the underlying connection is released; the
-  // online-reader page can be hundreds of KB of HTML this client never uses.
   try {
-    await response.arrayBuffer();
-  } catch {
-    // A body-read failure does not invalidate an otherwise successful record.
-  }
+    const response = await requestLike(readUrl, {
+      credentials: 'include',
+      signal: timeout.signal,
+    });
 
-  if (!response.ok) {
-    throw new Error(`book.read_record.http.${response.status}`);
-  }
+    // Drain the body promptly so the underlying connection is released; the
+    // online-reader page can be hundreds of KB of HTML this client never uses.
+    try {
+      await response.arrayBuffer();
+    } catch {
+      // A body-read failure does not invalidate an otherwise successful record.
+    }
 
-  // A 200 from a login page means the session expired and the server
-  // redirected `/read/{id}` away — the record was never persisted.
-  const finalUrl = response.url || readUrl;
-  const finalPath = pathnameOf(finalUrl);
-  if (finalPath && finalPath !== pathnameOf(readUrl)) {
-    throw new Error('book.read_record.redirect');
+    if (!response.ok) {
+      throw new Error(`book.read_record.http.${response.status}`);
+    }
+
+    // A 200 from a login page means the session expired and the server
+    // redirected `/read/{id}` away — the record was never persisted.
+    const finalUrl = response.url || readUrl;
+    const finalPath = pathnameOf(finalUrl);
+    if (finalPath && finalPath !== pathnameOf(readUrl)) {
+      throw new Error('book.read_record.redirect');
+    }
+  } finally {
+    // Prevent a successful plugin-http response from being aborted later,
+    // after its native body resource has already been released.
+    timeout.clear();
   }
 }
 

--- a/src/lib/book-read.ts
+++ b/src/lib/book-read.ts
@@ -83,6 +83,8 @@ export async function recordBookRead(
   } finally {
     // Prevent a successful plugin-http response from being aborted later,
     // after its native body resource has already been released.
+    // This is a no-op after a real timeout has fired; do not abort the
+    // controller here, as that would recreate the late plugin-http failure.
     timeout.clear();
   }
 }

--- a/tests/book-read.test.mjs
+++ b/tests/book-read.test.mjs
@@ -124,18 +124,30 @@ test('记录请求会排空响应体以尽早释放连接', async () => {
   assert.equal(drained, true);
 });
 
-test('WebView 缺少 AbortSignal.timeout 时仍会携带超时信号', async () => {
-  const original = AbortSignal.timeout;
-  delete AbortSignal.timeout;
-  try {
-    let capturedSignal;
-    await recordBookRead(async (url, init) => {
-      capturedSignal = init.signal;
-      return new Response('', { status: 200 });
-    }, 'https://books.example', 'a', 100);
+test('记录完成后取消超时，避免晚到 abort 操作已释放的 Tauri resource', async () => {
+  let capturedSignal;
+  let lateAbortCalls = 0;
 
-    assert.ok(capturedSignal instanceof AbortSignal);
-  } finally {
-    AbortSignal.timeout = original;
-  }
+  await recordBookRead(async (url, init) => {
+    capturedSignal = init.signal;
+    capturedSignal.addEventListener('abort', () => { lateAbortCalls += 1; });
+    return new Response('', { status: 200 });
+  }, 'https://books.example', 'a', 1);
+
+  await new Promise((resolve) => setTimeout(resolve, 10));
+
+  assert.ok(capturedSignal instanceof AbortSignal);
+  assert.equal(capturedSignal.aborted, false);
+  assert.equal(lateAbortCalls, 0);
+});
+
+test('记录请求超时后仍会中止未完成的请求', async () => {
+  await assert.rejects(
+    recordBookRead(async (url, init) => new Promise((resolve, reject) => {
+      init.signal.addEventListener('abort', () => {
+        reject(new DOMException('The operation was aborted', 'AbortError'));
+      }, { once: true });
+    }), 'https://books.example', 'a', 1),
+    (error) => error instanceof DOMException && error.name === 'AbortError',
+  );
 });

--- a/tests/book-read.test.mjs
+++ b/tests/book-read.test.mjs
@@ -141,6 +141,26 @@ test('记录完成后取消超时，避免晚到 abort 操作已释放的 Tauri 
   assert.equal(lateAbortCalls, 0);
 });
 
+test('记录请求失败后也取消超时，避免晚到 abort', async () => {
+  let capturedSignal;
+  let lateAbortCalls = 0;
+
+  await assert.rejects(
+    recordBookRead(async (url, init) => {
+      capturedSignal = init.signal;
+      capturedSignal.addEventListener('abort', () => { lateAbortCalls += 1; });
+      throw new Error('network failed');
+    }, 'https://books.example', 'a', 1),
+    /network failed/,
+  );
+
+  await new Promise((resolve) => setTimeout(resolve, 10));
+
+  assert.ok(capturedSignal instanceof AbortSignal);
+  assert.equal(capturedSignal.aborted, false);
+  assert.equal(lateAbortCalls, 0);
+});
+
 test('记录请求超时后仍会中止未完成的请求', async () => {
   await assert.rejects(
     recordBookRead(async (url, init) => new Promise((resolve, reject) => {


### PR DESCRIPTION
## 问题

点击“阅读”后，书籍能正常打开，但开发环境会在稍后显示 `The resource id ... is invalid.` Runtime Error。

## 原因

阅读记录请求使用了不可取消计时器的 `AbortSignal.timeout()`。响应体已经读取并释放 Tauri plugin-http 的原生资源后，超时信号仍会触发；plugin-http 的遗留 abort listener 随后再次操作已释放的 resource id，形成未处理 rejection。

## 修改

- 改用可清理的 `AbortController` 计时器。
- 请求完成、失败或响应体读取结束后统一清理计时器，阻止晚到的 abort。
- 保留真实超时时中止未完成请求的行为。
- 添加正常完成后不再 abort 及超时仍可中止的回归测试。

## 验证

- `pnpm test`
- `pnpm typecheck`
- `pnpm lint`（仅已有 warning，无 error）
- `pnpm build`
