### PR TITLE
build: reduce packaged and intermediate artifacts

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,9 +17,11 @@
     "lint": "eslint src tests",
     "test": "node --test --experimental-strip-types tests/*.test.mjs",
     "typecheck": "tsc --noEmit",
-    "build:reader": "cd readest && pnpm --filter @readest/readest-app build",
+    "clean:build": "node scripts/clean-build-artifacts.mjs",
+    "clean:build:full": "node scripts/clean-build-artifacts.mjs --rust",
+    "build:reader": "cd readest && pnpm --filter @readest/readest-app build && cd .. && node scripts/strip-reader-sourcemaps.mjs readest/out/readest",
     "dev:reader": "cd readest && pnpm --filter @readest/readest-app dev",
-    "copy:reader": "node -e \"require('fs').cpSync('readest/out/readest','out/readest',{recursive:true})\""
+    "copy:reader": "node -e \"require('fs').cpSync('readest/out/readest','out/readest',{recursive:true})\" && node scripts/strip-reader-sourcemaps.mjs out/readest"
   },
   "dependencies": {
     "@tauri-apps/api": "^2.10.1",

--- a/scripts/clean-build-artifacts.mjs
+++ b/scripts/clean-build-artifacts.mjs
@@ -1,0 +1,81 @@
+import { existsSync, readdirSync, rmSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const BUILD_ARTIFACTS = [
+  '.next',
+  'out',
+  'tsconfig.tsbuildinfo',
+  'readest/out',
+  'readest/apps/readest-app/.next',
+  'readest/apps/readest-app/tsconfig.tsbuildinfo',
+  'src-tauri/gen/android/.gradle',
+  'src-tauri/gen/android/build',
+  'src-tauri/gen/android/app/build',
+  'src-tauri/gen/apple/build',
+  'src-tauri/gen/ohos/.hvigor',
+  'src-tauri/gen/ohos/build',
+  'src-tauri/gen/ohos/entry/build',
+];
+
+function removeIfPresent(target, removed) {
+  if (!existsSync(target)) return;
+  rmSync(target, { recursive: true, force: true });
+  removed.push(target);
+}
+
+function removeIncrementalDirectories(directory, removed) {
+  if (!existsSync(directory)) return;
+
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+
+    const fullPath = path.join(directory, entry.name);
+    if (entry.name === 'incremental') {
+      removeIfPresent(fullPath, removed);
+    } else {
+      removeIncrementalDirectories(fullPath, removed);
+    }
+  }
+}
+
+export function cleanBuildArtifacts({ projectRoot, removeRustTarget = false }) {
+  const removed = [];
+
+  for (const artifact of BUILD_ARTIFACTS) {
+    removeIfPresent(path.join(projectRoot, artifact), removed);
+  }
+
+  const rustTarget = path.join(projectRoot, 'src-tauri', 'target');
+  if (removeRustTarget) {
+    removeIfPresent(rustTarget, removed);
+  } else {
+    removeIncrementalDirectories(rustTarget, removed);
+  }
+
+  return removed.map((target) => path.relative(projectRoot, target));
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const unsupported = args.filter((arg) => arg !== '--rust');
+  if (unsupported.length > 0) {
+    throw new Error(`Unsupported option(s): ${unsupported.join(', ')}`);
+  }
+
+  const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+  const removeRustTarget = args.includes('--rust');
+  const removed = cleanBuildArtifacts({ projectRoot, removeRustTarget });
+
+  if (removed.length === 0) {
+    console.log('Build cleanup: nothing to remove.');
+    return;
+  }
+
+  console.log(`Build cleanup: removed ${removed.length} path(s):`);
+  for (const target of removed) console.log(`- ${target}`);
+}
+
+if (process.argv[1] && pathToFileURL(path.resolve(process.argv[1])).href === import.meta.url) {
+  main();
+}

--- a/scripts/strip-reader-sourcemaps.mjs
+++ b/scripts/strip-reader-sourcemaps.mjs
@@ -1,0 +1,73 @@
+import { existsSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const SOURCE_MAP_REFERENCE =
+  /(?:\r?\n)?[ \t]*(?:\/\/[#@][ \t]*sourceMappingURL=[^\r\n]*|\/\*[#@][ \t]*sourceMappingURL=.*?\*\/)[ \t]*(?=\r?\n|$)/gs;
+
+export function stripSourceMapReferences(source) {
+  return source.replace(SOURCE_MAP_REFERENCE, '');
+}
+
+export function stripReaderSourceMaps(root) {
+  if (!existsSync(root)) {
+    throw new Error(`Reader output does not exist: ${root}`);
+  }
+
+  const result = {
+    removedFiles: 0,
+    removedBytes: 0,
+    rewrittenFiles: 0,
+  };
+
+  const visit = (directory) => {
+    for (const entry of readdirSync(directory, { withFileTypes: true })) {
+      const fullPath = path.join(directory, entry.name);
+      if (entry.isDirectory()) {
+        visit(fullPath);
+        continue;
+      }
+
+      if (/\.(?:[cm]?js|css)\.map$/.test(entry.name)) {
+        result.removedBytes += statSync(fullPath).size;
+        rmSync(fullPath);
+        result.removedFiles += 1;
+        continue;
+      }
+
+      if (!/\.(?:[cm]?js|css)$/.test(entry.name)) continue;
+
+      const source = readFileSync(fullPath, 'utf8');
+      const stripped = stripSourceMapReferences(source);
+      if (stripped === source) continue;
+
+      writeFileSync(fullPath, stripped);
+      result.rewrittenFiles += 1;
+    }
+  };
+
+  visit(root);
+  return result;
+}
+
+function formatBytes(bytes) {
+  return `${(bytes / 1024 / 1024).toFixed(1)} MiB`;
+}
+
+function main() {
+  const target = process.argv[2];
+  if (!target) {
+    throw new Error('Usage: node scripts/strip-reader-sourcemaps.mjs <reader-output>');
+  }
+
+  const root = path.resolve(target);
+  const result = stripReaderSourceMaps(root);
+  console.log(
+    `Reader sourcemaps: removed ${result.removedFiles} file(s) (${formatBytes(result.removedBytes)}), ` +
+      `rewrote ${result.rewrittenFiles} asset(s).`,
+  );
+}
+
+if (process.argv[1] && pathToFileURL(path.resolve(process.argv[1])).href === import.meta.url) {
+  main();
+}

--- a/src-tauri/.cargo/config.toml
+++ b/src-tauri/.cargo/config.toml
@@ -6,10 +6,11 @@ linker = "rust-lld"
 [target.aarch64-pc-windows-msvc]
 linker = "rust-lld"
 
-# Dev profile: max compilation speed, zero optimization.
+# Dev profile: keep line-table diagnostics without the multi-gigabyte
+# incremental cache produced by Moke + Readest's large dependency graph.
 [profile.dev]
-codegen-units = 256
-incremental = true
+codegen-units = 16
+incremental = false
 opt-level = 0
 debug = 1
 

--- a/tests/clean-build-artifacts.test.mjs
+++ b/tests/clean-build-artifacts.test.mjs
@@ -1,0 +1,60 @@
+import assert from 'node:assert/strict';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import { cleanBuildArtifacts } from '../scripts/clean-build-artifacts.mjs';
+
+test('Rust dev profile avoids the large incremental object cache', () => {
+  const cargoConfig = readFileSync(new URL('../src-tauri/.cargo/config.toml', import.meta.url), 'utf8');
+
+  assert.match(cargoConfig, /\[profile\.dev\][\s\S]*codegen-units = 16/);
+  assert.match(cargoConfig, /\[profile\.dev\][\s\S]*incremental = false/);
+  assert.match(cargoConfig, /\[profile\.dev\][\s\S]*debug = 1/);
+});
+
+function createFile(root, relativePath) {
+  const target = path.join(root, relativePath);
+  mkdirSync(path.dirname(target), { recursive: true });
+  writeFileSync(target, 'build artifact');
+}
+
+test('default cleanup removes frontend outputs and Rust incremental caches', () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), 'moke-build-clean-'));
+  createFile(root, '.next/cache/frontend');
+  createFile(root, 'out/index.html');
+  createFile(root, 'readest/out/readest/index.html');
+  createFile(root, 'readest/apps/readest-app/.next/cache/reader');
+  createFile(root, 'src-tauri/gen/android/app/build/outputs/app.apk');
+  createFile(root, 'src-tauri/gen/apple/build/Moke.app/binary');
+  createFile(root, 'src-tauri/gen/ohos/entry/build/default/outputs/app.hap');
+  createFile(root, 'src-tauri/target/debug/incremental/moke/cache');
+  createFile(root, 'src-tauri/target/x86_64-pc-windows-msvc/debug/incremental/moke/cache');
+  createFile(root, 'src-tauri/target/debug/deps/libmoke.rlib');
+
+  const removed = cleanBuildArtifacts({ projectRoot: root });
+
+  assert.deepEqual(removed.sort(), [
+    '.next',
+    'out',
+    'readest/apps/readest-app/.next',
+    'readest/out',
+    'src-tauri/gen/android/app/build',
+    'src-tauri/gen/apple/build',
+    'src-tauri/gen/ohos/entry/build',
+    'src-tauri/target/debug/incremental',
+    'src-tauri/target/x86_64-pc-windows-msvc/debug/incremental',
+  ]);
+  assert.equal(existsSync(path.join(root, 'src-tauri/target/debug/deps/libmoke.rlib')), true);
+});
+
+test('full cleanup also removes the complete Rust target directory', () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), 'moke-build-clean-full-'));
+  createFile(root, 'src-tauri/target/release/moke');
+
+  const removed = cleanBuildArtifacts({ projectRoot: root, removeRustTarget: true });
+
+  assert.deepEqual(removed, ['src-tauri/target']);
+  assert.equal(existsSync(path.join(root, 'src-tauri/target')), false);
+});

--- a/tests/strip-reader-sourcemaps.test.mjs
+++ b/tests/strip-reader-sourcemaps.test.mjs
@@ -1,0 +1,61 @@
+import assert from 'node:assert/strict';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  writeFileSync,
+} from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import {
+  stripReaderSourceMaps,
+  stripSourceMapReferences,
+} from '../scripts/strip-reader-sourcemaps.mjs';
+
+test('stripSourceMapReferences handles JavaScript and CSS comments', () => {
+  assert.equal(
+    stripSourceMapReferences('const value = 1;\n//# sourceMappingURL=app.js.map'),
+    'const value = 1;',
+  );
+  assert.equal(
+    stripSourceMapReferences('body { color: black; }\r\n/*# sourceMappingURL=app.css.map */\r\n'),
+    'body { color: black; }\r\n',
+  );
+});
+
+test('stripReaderSourceMaps removes maps recursively and preserves runtime assets', () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), 'moke-reader-sourcemaps-'));
+  const chunks = path.join(root, '_next', 'static', 'chunks');
+  mkdirSync(chunks, { recursive: true });
+
+  writeFileSync(path.join(chunks, 'app.js'), 'console.log("app");\n//# sourceMappingURL=app.js.map');
+  writeFileSync(path.join(chunks, 'app.js.map'), '{"version":3}');
+  writeFileSync(path.join(chunks, 'styles.css'), 'body{}\n/*# sourceMappingURL=styles.css.map */');
+  writeFileSync(path.join(chunks, 'styles.css.map'), '{"version":3,"sources":[]}');
+  writeFileSync(path.join(root, 'navigation.map'), 'runtime data');
+  writeFileSync(path.join(root, 'runtime.json'), '{"required":true}');
+
+  const result = stripReaderSourceMaps(root);
+
+  assert.deepEqual(result, {
+    removedFiles: 2,
+    removedBytes: 39,
+    rewrittenFiles: 2,
+  });
+  assert.equal(existsSync(path.join(chunks, 'app.js.map')), false);
+  assert.equal(existsSync(path.join(chunks, 'styles.css.map')), false);
+  assert.equal(readFileSync(path.join(chunks, 'app.js'), 'utf8'), 'console.log("app");');
+  assert.equal(readFileSync(path.join(chunks, 'styles.css'), 'utf8'), 'body{}');
+  assert.equal(readFileSync(path.join(root, 'navigation.map'), 'utf8'), 'runtime data');
+  assert.equal(readFileSync(path.join(root, 'runtime.json'), 'utf8'), '{"required":true}');
+});
+
+test('stripReaderSourceMaps fails when the expected reader output is absent', () => {
+  assert.throws(
+    () => stripReaderSourceMaps(path.join(os.tmpdir(), 'moke-reader-output-does-not-exist')),
+    /Reader output does not exist/,
+  );
+});


### PR DESCRIPTION
## Summary

- strip generated Readest JavaScript/CSS sourcemaps before Tauri packages the frontend
- reduce Rust dev artifact growth by disabling incremental compilation and lowering codegen units
- add safe normal/full cleanup commands for frontend, mobile, and Rust build artifacts
- cover sourcemap stripping, cleanup behavior, and the compact Cargo dev profile with tests

## Size impact

The current Readest production build generated 158 sourcemaps totaling 148.7 MiB before compression. The optimized build removes all of them and their dangling `sourceMappingURL` references. Based on current release artifacts, this should reduce desktop installers by about 29 MiB and the universal Android APK by about 118 MiB.

For local build storage, `pnpm clean:build` removes frontend/mobile outputs and Rust incremental caches while preserving compiled Rust dependencies. `pnpm clean:build:full` also removes the complete `src-tauri/target` directory for maximum recovery at the cost of a cold Rust rebuild.

## Verification

- `pnpm test` — 246 passed
- `pnpm typecheck`
- `pnpm lint` — 0 errors (23 existing warnings)
- focused cleanup and sourcemap tests
- full Readest production build; 158 maps / 148.7 MiB removed, 0 maps or map references remaining
