### PR TITLE
fix: allow embedded reader to set window title

### DIFF
--- a/src-tauri/capabilities-dev/ohos.json
+++ b/src-tauri/capabilities-dev/ohos.json
@@ -44,6 +44,7 @@
     "core:window:allow-maximize",
     "core:window:allow-unmaximize",
     "core:window:allow-set-size",
+    "core:window:allow-set-title",
     "core:window:allow-set-focus",
     "core:window:allow-is-maximized",
     "core:window:allow-start-dragging",

--- a/src-tauri/capabilities/ohos.json
+++ b/src-tauri/capabilities/ohos.json
@@ -36,6 +36,7 @@
     "core:window:allow-maximize",
     "core:window:allow-unmaximize",
     "core:window:allow-set-size",
+    "core:window:allow-set-title",
     "core:window:allow-set-focus",
     "core:window:allow-is-maximized",
     "core:window:allow-start-dragging",

--- a/src-tauri/capabilities/reader-mobile.json
+++ b/src-tauri/capabilities/reader-mobile.json
@@ -18,6 +18,7 @@
     "core:window:allow-maximize",
     "core:window:allow-unmaximize",
     "core:window:allow-set-size",
+    "core:window:allow-set-title",
     "core:window:allow-set-focus",
     "core:window:allow-start-dragging",
     "core:window:allow-toggle-maximize",

--- a/src-tauri/capabilities/reader.json
+++ b/src-tauri/capabilities/reader.json
@@ -20,6 +20,7 @@
     "core:window:allow-maximize",
     "core:window:allow-unmaximize",
     "core:window:allow-set-size",
+    "core:window:allow-set-title",
     "core:window:allow-set-focus",
     "core:window:allow-start-dragging",
     "core:window:allow-toggle-maximize",

--- a/tests/capabilities-scope.test.mjs
+++ b/tests/capabilities-scope.test.mjs
@@ -140,6 +140,20 @@ test('desktop and mobile reader variants grant the same reader operations', () =
   assert.deepEqual(mobile.permissions, desktop.permissions);
 });
 
+test('embedded reader windows can update their native window title', () => {
+  for (const file of [
+    'src-tauri/capabilities/reader.json',
+    'src-tauri/capabilities/reader-mobile.json',
+    'src-tauri/capabilities/ohos.json',
+  ]) {
+    const capability = readCapability(file);
+    assert.ok(
+      capability.permissions.includes('core:window:allow-set-title'),
+      `${file} must allow Readest to update the active book title`,
+    );
+  }
+});
+
 test('main window does not inherit reader-only plugins', () => {
   const main = readCapability('src-tauri/capabilities/default.json');
   const identifiers = new Set(main.permissions.map(permissionIdentifier));


### PR DESCRIPTION
Fixes the embedded Readest runtime error where window.set_title is rejected by Moke's own Tauri ACL. Grants core:window:allow-set-title to the desktop reader, mobile reader, and OpenHarmony production/development capabilities, and adds regression coverage. Verification: 336 tests passed; TypeScript check passed; ESLint passed with 0 errors and 23 pre-existing warnings.