### PR TITLE
fix: 修复 iOS 与 Android 移动端编译失败

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -268,13 +268,16 @@ fn moke_remove_downloaded_book(app: AppHandle, id: String) -> Result<(), String>
 
 #[tauri::command]
 async fn moke_select_download_directory(app: AppHandle) -> Result<Option<String>, String> {
-    #[cfg(target_env = "ohos")]
+    // Tauri's folder picker is desktop-only. Keep it out of every mobile
+    // target at compile time: Android/iOS expose `FileDialogBuilder`, but do
+    // not implement `blocking_pick_folder`.
+    #[cfg(any(target_env = "ohos", mobile))]
     {
         let _ = app;
         Err("custom download directory is not supported on this platform".into())
     }
 
-    #[cfg(not(target_env = "ohos"))]
+    #[cfg(not(any(target_env = "ohos", mobile)))]
     {
         use tauri_plugin_dialog::DialogExt;
 

--- a/tests/download-settings.test.mjs
+++ b/tests/download-settings.test.mjs
@@ -30,6 +30,17 @@ test('下载目录选择由 Tauri 后端打开系统对话框', () => {
   assert.equal(packageJson.dependencies['@tauri-apps/plugin-dialog'], undefined);
 });
 
+test('移动端不会编译仅桌面可用的目录选择器', () => {
+  assert.match(
+    tauriSource,
+    /#\[cfg\(any\(target_env = "ohos", mobile\)\)\][\s\S]*?custom download directory is not supported on this platform/,
+  );
+  assert.match(
+    tauriSource,
+    /#\[cfg\(not\(any\(target_env = "ohos", mobile\)\)\)\][\s\S]*?blocking_pick_folder\(\)/,
+  );
+});
+
 test('下载目录从后端恢复且 Windows verbatim 前缀不会展示', () => {
   assert.match(appShellSource, /invoke<string \| null>\('moke_get_download_directory'\)/);
   assert.match(tauriSource, /download_directory_for_frontend/);


### PR DESCRIPTION
## 问题

`moke_select_download_directory` 在 iOS/Android 编译时引用了仅桌面提供的 `blocking_pick_folder`，导致两端均报 E0599。

## 修复

- 在编译期将桌面目录选择器限制到非移动端
- iOS、Android 与 OHOS 统一返回不支持自定义下载目录
- 增加回归测试，锁定移动端与桌面端的 cfg 分支

## 验证

- `pnpm test`（337/337）
- `pnpm lint`（0 errors，保留已有 warnings）
- `pnpm typecheck`
- `cargo check --manifest-path src-tauri/Cargo.toml --lib --locked`