### PR TITLE
fix(android): restore embedded reader navigation

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -68,12 +68,11 @@ fn moke_runtime_platform() -> &'static str {
     std::env::consts::OS
 }
 
-/// Performs a full-document navigation inside the current OpenHarmony WebView.
-/// ArkWeb cannot reliably execute Next.js App Router's RSC navigation over
-/// the custom `tauri://` scheme, and Moke/Readest are separate Next apps.
-/// Other platforms use normal browser navigation and do not register this
-/// privileged command.
-#[cfg(target_env = "ohos")]
+/// Performs a full-document navigation inside the current Android/OpenHarmony
+/// WebView. Browser navigation is unreliable when crossing between the bundled
+/// Moke and Readest Next apps on these runtimes. The command accepts only
+/// same-origin absolute paths and is not compiled for desktop or iOS.
+#[cfg(any(target_env = "ohos", target_os = "android"))]
 #[tauri::command]
 fn moke_navigate(webview: tauri::Webview, path: String) -> Result<(), String> {
     if !path.starts_with('/') || path.starts_with("//") {
@@ -525,7 +524,7 @@ fn moke_invoke_handler() -> impl Fn(tauri::ipc::Invoke<tauri::Wry>) -> bool + Se
 {
     tauri::generate_handler![
         moke_runtime_platform,
-        #[cfg(target_env = "ohos")]
+        #[cfg(any(target_env = "ohos", target_os = "android"))]
         moke_navigate,
         moke_record_downloaded_book,
         moke_remove_downloaded_book,

--- a/src/lib/moke-reader.ts
+++ b/src/lib/moke-reader.ts
@@ -3,7 +3,8 @@ import type { ReadingProgressPayload } from './reading-progress';
 export const isSingleWebviewRuntime = (platform: string): boolean =>
   platform === 'ohos' || platform === 'android' || platform === 'ios';
 
-export const requiresMokeNavigate = (platform: string): boolean => platform === 'ohos';
+export const requiresMokeNavigate = (platform: string): boolean =>
+  platform === 'ohos' || platform === 'android';
 
 /**
  * Android/iOS render the main WebView edge-to-edge, so Moke's controls need
@@ -162,10 +163,11 @@ export function isSafeAppNavigationPath(href: string): boolean {
  *
  * ArkWeb cannot reliably execute Next.js App Router RSC navigation over the
  * custom `tauri://` scheme, and URL params across pages are unreliable there
- * (see the welcome page). OHOS therefore uses the narrowly registered native
- * `moke_navigate` command. Android/iOS still need a real document load when
- * crossing between the separate Moke and Readest Next apps, but can use the
- * browser navigation API without exposing a native navigation command.
+ * (see the welcome page). OHOS and Android therefore use the narrowly
+ * registered native `moke_navigate` command. Android WebView can otherwise
+ * leave the bundled reader on a blank document when browser navigation crosses
+ * between the separate Moke and Readest Next apps. iOS can use the browser
+ * navigation API.
  */
 export async function navigateFullDocument(
   href: string,

--- a/tests/moke-reader.test.mjs
+++ b/tests/moke-reader.test.mjs
@@ -25,9 +25,9 @@ test('OHOS uses the single-WebView reader flow', () => {
   assert.equal(isSingleWebviewRuntime('windows'), false);
 });
 
-test('only OpenHarmony exposes the native full-document navigation command', () => {
+test('Android and OpenHarmony use native full-document navigation', () => {
   assert.equal(requiresMokeNavigate('ohos'), true);
-  assert.equal(requiresMokeNavigate('android'), false);
+  assert.equal(requiresMokeNavigate('android'), true);
   assert.equal(requiresMokeNavigate('ios'), false);
   assert.equal(requiresMokeNavigate('linux'), false);
   assert.equal(requiresMokeNavigate('windows'), false);

--- a/tests/security-config.test.mjs
+++ b/tests/security-config.test.mjs
@@ -140,14 +140,14 @@ test('embedded reader stylesheet hosts remain available without extra hosts', ()
   ].sort());
 });
 
-test('moke_navigate is compiled and registered only for OpenHarmony', () => {
+test('moke_navigate is compiled and registered only for Android and OpenHarmony', () => {
   const source = readFileSync(join(repoRoot, 'src-tauri/src/lib.rs'), 'utf8');
   assert.match(
     source,
-    /#\[cfg\(target_env = "ohos"\)\]\s*#\[tauri::command\]\s*fn moke_navigate/,
+    /#\[cfg\(any\(target_env = "ohos", target_os = "android"\)\)\]\s*#\[tauri::command\]\s*fn moke_navigate/,
   );
   assert.match(
     source,
-    /#\[cfg\(target_env = "ohos"\)\]\s*moke_navigate,/,
+    /#\[cfg\(any\(target_env = "ohos", target_os = "android"\)\)\]\s*moke_navigate,/,
   );
 });


### PR DESCRIPTION
## 问题

安全加固提交将 Android 的跨应用全文档导航从受限的原生 `moke_navigate` 改为 `window.location.assign()`。Android WebView 在 Moke 与打包的 Readest 两个 Next 应用之间跳转时会停在空白文档，导致阅读器和调试面板按钮都无法渲染；桌面端使用独立窗口，因此不受影响。

## 修复

- 仅在 Android 和 OpenHarmony 编译、注册同源路径受限的 `moke_navigate` 命令
- Android 进入内嵌阅读器时恢复原生全文档导航
- iOS 和桌面导航行为保持不变
- 更新平台路由及安全边界回归测试

## 验证

- `pnpm test`：346 passed
- `pnpm typecheck`
- `pnpm lint`：0 errors（23 条既有 warnings）
- `cargo test --manifest-path src-tauri/Cargo.toml --lib`：41 passed
- `rustfmt --edition 2021 --check --config skip_children=true src-tauri/src/lib.rs`
