### PR TITLE
fix(android): roll back Readest blank-screen regression

### DIFF
--- a/RELEASE_vx.x.x.md
+++ b/RELEASE_vx.x.x.md
@@ -1,17 +1,17 @@
-# Moke v1.0.5
+# Moke v1.0.6
 
 ## 优化与修复
 
-- 修复安全权限拆分后，Android 内嵌 Readest 因无法检查和创建应用私有目录而启动失败、持续白屏且调试面板按钮不显示的问题。
-- 保持 Moke 下载书籍目录只读，并将新增权限限制在 Readest 的设置、缓存和应用私有目录。
+- 回退引发 Android 内嵌阅读器白屏的 Readest 升级，恢复到已验证可用的版本。
+- 保留 Android 内嵌阅读器原生导航和 Readest 应用私有目录权限修复。
 
 ## 下载
 
 | 平台 | 安装包 |
 |---|---|
-| Windows | `Moke_1.0.5_x64_en-US.msi` / `.exe` |
-| macOS | `Moke_1.0.5_aarch64.dmg` |
-| Linux | `Moke_1.0.5_amd64.AppImage` / `.deb` |
+| Windows | `Moke_1.0.6_x64_en-US.msi` / `.exe` |
+| macOS | `Moke_1.0.6_aarch64.dmg` |
+| Linux | `Moke_1.0.6_amd64.AppImage` / `.deb` |
 | Android | `moke-android-release.apk` |
 | iOS/iPadOS | `Moke.ipa`（自签名安装） |
 | OpenHarmony（鸿蒙） | `entry-default-unsigned.hap`（alpha，未签名，可能需要自签名安装） |
@@ -24,4 +24,4 @@
 
 遇到问题或建议请提交 [GitHub Issues](https://github.com/talebook/moke/issues)。安全漏洞请通过[私密报告](https://github.com/talebook/moke/security/advisories/new)提交。
 
-**Full Changelog**: https://github.com/talebook/moke/compare/v1.0.4...v1.0.5
+**Full Changelog**: https://github.com/talebook/moke/compare/v1.0.5...v1.0.6

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moke",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@9.15.9",


### PR DESCRIPTION
## Summary
- roll the embedded Readest gitlink back from `9654196` to the last known-good `bc833bf`
- keep the Android native full-document navigation and reader private-directory permissions added after the regression
- bump Moke from 1.0.5 to 1.0.6 and update release notes

## Verification
- `pnpm test` (347 passed)
- `pnpm typecheck`
- `pnpm lint` (0 errors; existing warnings only)
- `pnpm build`
- Readest production static build
- Readest `pnpm lint`
- Readest unit suite: 8940 passed, 16 skipped, 10 existing Blob/ZIP environment failures