### PR TITLE
fix(android): recover embedded reader startup

### DIFF
--- a/RELEASE_vx.x.x.md
+++ b/RELEASE_vx.x.x.md
@@ -1,19 +1,19 @@
-# Moke v1.0.7
+# Moke v1.0.8
 
 ## 优化与修复
 
-- 将内嵌 Readest 更新到最新上游版本，并重新应用 Moke v1.0.3 使用的定制改动。
-- 合入 Readest 启动失败恢复逻辑，避免初始化异常后持续显示白屏。
-- 保留 Android 内嵌阅读器原生导航、调试面板、阅读进度与标注同步功能。
-- 保留进入内嵌阅读器时的应用切换动画，并同步更新 foliate-js 依赖与 PDF 资源路径适配。
+- 修复 Android 内嵌 Readest 启动时无法检查应用配置和缓存根目录、导致初始化失败白屏的问题。
+- Readest 原生服务初始化失败时显示具体错误和重试入口，不再永久白屏。
+- 调试面板在原生服务初始化阶段也会挂载，便于直接查看启动错误。
+- 保留进入内嵌阅读器时的应用切换动画，以及原有阅读进度、标注同步等 Moke 定制功能。
 
 ## 下载
 
 | 平台 | 安装包 |
 |---|---|
-| Windows | `Moke_1.0.7_x64_en-US.msi` / `.exe` |
-| macOS | `Moke_1.0.7_aarch64.dmg` |
-| Linux | `Moke_1.0.7_amd64.AppImage` / `.deb` |
+| Windows | `Moke_1.0.8_x64_en-US.msi` / `.exe` |
+| macOS | `Moke_1.0.8_aarch64.dmg` |
+| Linux | `Moke_1.0.8_amd64.AppImage` / `.deb` |
 | Android | `moke-android-release.apk` |
 | iOS/iPadOS | `Moke.ipa`（自签名安装） |
 | OpenHarmony（鸿蒙） | `entry-default-unsigned.hap`（alpha，未签名，可能需要自签名安装） |
@@ -26,4 +26,4 @@
 
 遇到问题或建议请提交 [GitHub Issues](https://github.com/talebook/moke/issues)。安全漏洞请通过[私密报告](https://github.com/talebook/moke/security/advisories/new)提交。
 
-**Full Changelog**: https://github.com/talebook/moke/compare/v1.0.6...v1.0.7
+**Full Changelog**: https://github.com/talebook/moke/compare/v1.0.7...v1.0.8

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moke",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@9.15.9",

--- a/src-tauri/capabilities/reader-mobile.json
+++ b/src-tauri/capabilities/reader-mobile.json
@@ -45,6 +45,8 @@
     {
       "identifier": "fs:read-dirs",
       "allow": [
+        { "path": "$APPCONFIG" },
+        { "path": "$APPCACHE" },
         { "path": "$APPDATA/books" },
         { "path": "$APPDATA/books/**" },
         { "path": "$APPDATA/Readest" },

--- a/src-tauri/capabilities/reader.json
+++ b/src-tauri/capabilities/reader.json
@@ -47,6 +47,8 @@
     {
       "identifier": "fs:read-dirs",
       "allow": [
+        { "path": "$APPCONFIG" },
+        { "path": "$APPCACHE" },
         { "path": "$APPDATA/books" },
         { "path": "$APPDATA/books/**" },
         { "path": "$APPDATA/Readest" },

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -892,11 +892,13 @@ mod fs_scope_tests {
         assert!(!p.matches_path_with(Path::new("/home/u/AppDataX/evil"), opts));
     }
 
-    // Every `$VAR/**` entry in the committed capability files must keep the
-    // bare `$VAR` root out of scope. Parse the real production/dev files and
-    // exercise the same matching `is_allowed` performs.
+    // Bare app-directory roots stay out of scope except for the reader's two
+    // metadata-only roots. NativeAppService checks these roots with `exists`
+    // before writing root-level settings/cache files; no write permission is
+    // granted for either root. Parse the committed files and exercise the same
+    // matching `is_allowed` performs.
     #[test]
-    fn capability_fs_allow_entries_keep_bare_roots_out_of_scope() {
+    fn capability_fs_allow_entries_grant_only_required_bare_roots() {
         let opts = tauri_match_options();
         let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
         let files = [
@@ -941,11 +943,17 @@ mod fs_scope_tests {
                         Some("$TEMP") => "/temp",
                         _ => continue,
                     };
+                    let is_reader_capability = file.ends_with("capabilities/reader.json")
+                        || file.ends_with("capabilities/reader-mobile.json");
+                    let is_required_metadata_root = is_reader_capability
+                        && id == "fs:read-dirs"
+                        && matches!(path, "$APPCONFIG" | "$APPCACHE");
                     let p = Pattern::new(&resolved).unwrap_or_else(|e| {
                         panic!("bad glob {resolved} in {} ({id}): {e}", file.display())
                     });
                     assert!(
-                        !p.matches_path_with(Path::new(bare_root), opts),
+                        is_required_metadata_root
+                            || !p.matches_path_with(Path::new(bare_root), opts),
                         "{} {id} allow path {path} matches bare root {bare_root}",
                         file.display()
                     );

--- a/tests/capabilities-scope.test.mjs
+++ b/tests/capabilities-scope.test.mjs
@@ -62,7 +62,18 @@ function hasParentDirTraversal(path) {
 function isRestrictedToPrivateDirs(path) {
   if (hasParentDirTraversal(path)) return false;
   return PRIVATE_BASES.some(
-    (prefix) => path.startsWith(`${prefix}/`) || path.startsWith(`${prefix}\\`),
+    (prefix) =>
+      path === prefix || path.startsWith(`${prefix}/`) || path.startsWith(`${prefix}\\`),
+  );
+}
+
+function isApprovedAppDirectoryRoot(file, identifier, path) {
+  return (
+    ['src-tauri/capabilities/reader.json', 'src-tauri/capabilities/reader-mobile.json'].includes(
+      file,
+    ) &&
+    identifier === 'fs:read-dirs' &&
+    ['$APPCONFIG', '$APPCACHE'].includes(path)
   );
 }
 
@@ -74,9 +85,12 @@ for (const file of ALL_CAPABILITY_FILES) {
     assert.deepEqual(offenders, []);
   });
 
-  test(`${file} does not grant an app-directory root`, () => {
+  test(`${file} grants only required app-directory roots`, () => {
     const offenders = collectFsOpenerAllowEntries(readCapability(file))
-      .filter(({ path }) => PRIVATE_BASES.includes(path))
+      .filter(
+        ({ identifier, path }) =>
+          PRIVATE_BASES.includes(path) && !isApprovedAppDirectoryRoot(file, identifier, path),
+      )
       .map(({ identifier, path }) => `${identifier}: ${path}`);
     assert.deepEqual(offenders, []);
   });
@@ -212,6 +226,8 @@ test('reader startup can inspect scoped paths and create app-private base direct
     const metadataPaths = permissionPaths(findPermission(capability, 'fs:read-dirs'));
 
     assert.ok(identifiers.has('fs:create-app-specific-dirs'));
+    assert.ok(metadataPaths.includes('$APPCONFIG'));
+    assert.ok(metadataPaths.includes('$APPCACHE'));
     assert.ok(metadataPaths.includes('$APPCONFIG/settings.json'));
     assert.ok(metadataPaths.includes('$APPDATA/Readest'));
     assert.ok(metadataPaths.includes('$APPDATA/Readest/**'));


### PR DESCRIPTION
## Summary
- allow the embedded reader to inspect the AppConfig and AppCache roots needed before root-level settings writes
- update Readest so app-service failures show an error/retry state and keep the debug launcher mounted
- retain scoped writes, read-only Moke books, and the existing reader transition animation
- prepare v1.0.8

## Verification
- Readest lint and production build
- pnpm test (347 passed)
- pnpm typecheck
- pnpm lint
- pnpm build:reader
- pnpm build
- Rust capability regression test