### PR TITLE
chore(release): prepare cumulative v1.0.9

### DIFF
--- a/RELEASE_vx.x.x.md
+++ b/RELEASE_vx.x.x.md
@@ -1,19 +1,48 @@
-# Moke v1.0.8
+# Moke v1.0.9
 
-## 优化与修复
+这是从 `v1.0.2` 升级到 `v1.0.9` 的累计版本，包含此前 `v1.0.3` 至 `v1.0.8` 的全部代码更改。
 
-- 修复 Android 内嵌 Readest 启动时无法检查应用配置和缓存根目录、导致初始化失败白屏的问题。
-- Readest 原生服务初始化失败时显示具体错误和重试入口，不再永久白屏。
-- 调试面板在原生服务初始化阶段也会挂载，便于直接查看启动错误。
-- 保留进入内嵌阅读器时的应用切换动画，以及原有阅读进度、标注同步等 Moke 定制功能。
+## 内嵌阅读器
+
+- 将内嵌 Readest 升级到 `v0.12.1`，随后同步到最新上游版本，并更新 foliate-js 与 PDF 资源适配。
+- 修复 Android 内嵌阅读器无法检查应用配置、缓存和私有目录而启动白屏的问题。
+- 修复 Android 单 WebView 阅读器的进入、返回和原生导航流程，并允许阅读器更新窗口标题。
+- 保留进入和退出阅读器时的应用切换动画。
+- Readest 原生服务初始化失败时显示具体错误和重试入口，同时保留右下角调试面板按钮。
+- 修复调试 IPC 递归、窗口创建降级时阅读进度丢失，以及标注定位与进度事件关联问题。
+- 保留阅读进度、标注同步、调试日志和 Moke 本地模式等定制功能。
+
+## 离线下载与阅读记录
+
+- 新增离线下载管理中心，支持暂停、继续、删除、断点恢复、多格式书籍和任务状态持久化。
+- 修复 IndexedDB 升级、异常退出恢复、磁盘文件索引恢复和重复下载状态问题。
+- Tauri 默认下载改用 AppData 相对路径，并稳定二进制、Range 和大文件下载流程。
+- 修复阅读记录请求的超时、响应清理和失败生命周期，避免成功打开被误报为失败。
+- 游客模式不再请求需要登录的书籍标注接口。
+
+## 标注、扩展与内容处理
+
+- 统一 Talebook 与 Moke 标注来源、客户端标识和响应契约。
+- 加固标注能力探测、缓存、重试、导航完成事件和迟到监听清理。
+- 修复扩展命令 `request_id` 关联、响应契约和并发请求隔离。
+- 加固书籍简介的 HTML 转纯文本处理、异常恢复及恶意标签过滤。
+- 阻止服务端验证码和电子书内容中的非预期脚本执行。
+
+## 平台体验与安全
+
+- 统一并本地化 Windows、Linux、macOS、Android、iOS/iPadOS 的应用名称和发布产物名称。
+- 修复 Android 状态栏恢复、返回手势状态、分屏安全区和应用外壳缩放问题。
+- 优化移动端低高度隐私弹窗、长书库标题和侧边栏图标显示。
+- 收紧 Tauri capabilities、CSP、asset protocol 与文件系统访问范围，保持 Moke 下载书籍目录只读。
+- 升级存在安全告警的前端与 Rust 依赖，并减少安装包和中间构建产物体积。
 
 ## 下载
 
 | 平台 | 安装包 |
 |---|---|
-| Windows | `Moke_1.0.8_x64_en-US.msi` / `.exe` |
-| macOS | `Moke_1.0.8_aarch64.dmg` |
-| Linux | `Moke_1.0.8_amd64.AppImage` / `.deb` |
+| Windows | `Moke_1.0.9_x64_en-US.msi` / `.exe` |
+| macOS | `Moke_1.0.9_aarch64.dmg` |
+| Linux | `Moke_1.0.9_amd64.AppImage` / `.deb` |
 | Android | `moke-android-release.apk` |
 | iOS/iPadOS | `Moke.ipa`（自签名安装） |
 | OpenHarmony（鸿蒙） | `entry-default-unsigned.hap`（alpha，未签名，可能需要自签名安装） |
@@ -26,4 +55,4 @@
 
 遇到问题或建议请提交 [GitHub Issues](https://github.com/talebook/moke/issues)。安全漏洞请通过[私密报告](https://github.com/talebook/moke/security/advisories/new)提交。
 
-**Full Changelog**: https://github.com/talebook/moke/compare/v1.0.7...v1.0.8
+**Full Changelog**: https://github.com/talebook/moke/compare/v1.0.2...v1.0.9

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moke",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@9.15.9",


### PR DESCRIPTION
## Summary
- bump package version to 1.0.9
- replace release notes with a cumulative v1.0.2-to-v1.0.9 changelog
- document the embedded reader, offline downloads, annotations, platform UX, and security changes

## Verification
- pnpm test (347 passed)
- package.json version check
- git diff --check