### PR TITLE
test(android): release reader regression coverage

### DIFF
--- a/RELEASE_vx.x.x.md
+++ b/RELEASE_vx.x.x.md
@@ -1,12 +1,13 @@
-# Moke v1.0.10
+# Moke v1.0.11
 
-这是从 `v1.0.2` 升级到 `v1.0.10` 的累计版本，包含此前 `v1.0.3` 至 `v1.0.9` 的全部代码更改。
+这是从 `v1.0.2` 升级到 `v1.0.11` 的累计版本，包含此前 `v1.0.3` 至 `v1.0.10` 的全部代码更改。
 
 ## 内嵌阅读器
 
 - 将内嵌 Readest 升级到 `v0.12.1`，随后同步到最新上游版本，并更新 foliate-js 与 PDF 资源适配。
 - 修复 Android 内嵌阅读器无法检查应用配置、缓存和私有目录而启动白屏的问题。
 - 修复 Android 打开书籍时本地文件分片请求悬空、阅读器一直停留在加载动画的问题。
+- 为 Android 书籍分片响应、超时、异常头信息、并发范围读取和初始化失败补充回归测试；协议异常时不再无限等待。
 - 修复 Android 单 WebView 阅读器的进入、返回和原生导航流程，并允许阅读器更新窗口标题。
 - 保留进入和退出阅读器时的应用切换动画。
 - Readest 原生服务初始化失败时显示具体错误和重试入口，同时保留右下角调试面板按钮。
@@ -41,9 +42,9 @@
 
 | 平台 | 安装包 |
 |---|---|
-| Windows | `Moke_1.0.10_x64_en-US.msi` / `.exe` |
-| macOS | `Moke_1.0.10_aarch64.dmg` |
-| Linux | `Moke_1.0.10_amd64.AppImage` / `.deb` |
+| Windows | `Moke_1.0.11_x64_en-US.msi` / `.exe` |
+| macOS | `Moke_1.0.11_aarch64.dmg` |
+| Linux | `Moke_1.0.11_amd64.AppImage` / `.deb` |
 | Android | `moke-android-release.apk` |
 | iOS/iPadOS | `Moke.ipa`（自签名安装） |
 | OpenHarmony（鸿蒙） | `entry-default-unsigned.hap`（alpha，未签名，可能需要自签名安装） |
@@ -56,4 +57,4 @@
 
 遇到问题或建议请提交 [GitHub Issues](https://github.com/talebook/moke/issues)。安全漏洞请通过[私密报告](https://github.com/talebook/moke/security/advisories/new)提交。
 
-**Full Changelog**: https://github.com/talebook/moke/compare/v1.0.2...v1.0.10
+**Full Changelog**: https://github.com/talebook/moke/compare/v1.0.2...v1.0.11

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moke",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@9.15.9",


### PR DESCRIPTION
## Summary
- update embedded Readest to hehetoshang/readest#24
- add regression coverage for Android WebView response dispatch, byte-range boundaries, protocol timeouts, invalid headers, concurrent reads, and bootstrap failures
- abort an unresponsive local rangefile request after 15 seconds instead of spinning forever
- bump package.json to 1.0.11 and update cumulative release notes

## Validation
- Readest Rust rangefile tests: 13 passed
- targeted Readest Vitest tests: 16 passed
- Readest tsgo, Biome, cargo fmt: passed
- Moke tests: 347 passed
- Moke typecheck: passed
- embedded Readest production build: passed