### PR TITLE
fix(android): restore embedded reader debug panel

### DIFF
--- a/RELEASE_vx.x.x.md
+++ b/RELEASE_vx.x.x.md
@@ -1,6 +1,6 @@
-# Moke v1.0.11
+# Moke v1.0.12
 
-这是从 `v1.0.2` 升级到 `v1.0.11` 的累计版本，包含此前 `v1.0.3` 至 `v1.0.10` 的全部代码更改。
+这是从 `v1.0.2` 升级到 `v1.0.12` 的累计版本，包含此前 `v1.0.3` 至 `v1.0.11` 的全部代码更改。
 
 ## 内嵌阅读器
 
@@ -11,6 +11,7 @@
 - 修复 Android 单 WebView 阅读器的进入、返回和原生导航流程，并允许阅读器更新窗口标题。
 - 保留进入和退出阅读器时的应用切换动画。
 - Readest 原生服务初始化失败时显示具体错误和重试入口，同时保留右下角调试面板按钮。
+- 修复 Android 原生整页导航与 Zustand 状态恢复的竞态：已开启调试面板时，进入 Readest 后右下角按钮不再因过期的 `mokeDebug=0` 而消失。
 - 修复调试 IPC 递归、窗口创建降级时阅读进度丢失，以及标注定位与进度事件关联问题。
 - 保留阅读进度、标注同步、调试日志和 Moke 本地模式等定制功能。
 
@@ -42,9 +43,9 @@
 
 | 平台 | 安装包 |
 |---|---|
-| Windows | `Moke_1.0.11_x64_en-US.msi` / `.exe` |
-| macOS | `Moke_1.0.11_aarch64.dmg` |
-| Linux | `Moke_1.0.11_amd64.AppImage` / `.deb` |
+| Windows | `Moke_1.0.12_x64_en-US.msi` / `.exe` |
+| macOS | `Moke_1.0.12_aarch64.dmg` |
+| Linux | `Moke_1.0.12_amd64.AppImage` / `.deb` |
 | Android | `moke-android-release.apk` |
 | iOS/iPadOS | `Moke.ipa`（自签名安装） |
 | OpenHarmony（鸿蒙） | `entry-default-unsigned.hap`（alpha，未签名，可能需要自签名安装） |
@@ -57,4 +58,4 @@
 
 遇到问题或建议请提交 [GitHub Issues](https://github.com/talebook/moke/issues)。安全漏洞请通过[私密报告](https://github.com/talebook/moke/security/advisories/new)提交。
 
-**Full Changelog**: https://github.com/talebook/moke/compare/v1.0.2...v1.0.11
+**Full Changelog**: https://github.com/talebook/moke/compare/v1.0.2...v1.0.12

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moke",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@9.15.9",

--- a/src/app/detail/page.tsx
+++ b/src/app/detail/page.tsx
@@ -13,7 +13,7 @@ import {
   endOfflineDownload,
 } from '@/lib/offline-download';
 import { useServerStore } from '@/lib/store/server';
-import { useDeveloperStore } from '@/lib/store/developer';
+import { getDebugPanelLaunchState, useDeveloperStore } from '@/lib/store/developer';
 import { useSettingsStore } from '@/lib/store/settings';
 import { fetchReadingProgress } from '@/lib/reading-progress';
 import { buildEmbeddedReaderUrl, getMokeRuntimePlatform, isSingleWebviewRuntime, openEmbeddedReaderBook } from '@/lib/moke-reader';
@@ -393,7 +393,7 @@ function DetailContent() {
           const href = buildEmbeddedReaderUrl({
             filePath: record.filePath,
             eink: useSettingsStore.getState().eink,
-            debugPanel: useDeveloperStore.getState().showDebugPanel,
+            debugPanel: getDebugPanelLaunchState(),
             mokeBookId: String(book.id),
             restoreProgress,
             // The explicit navigation id lets the reader skip only startup and
@@ -421,7 +421,7 @@ function DetailContent() {
             await invoke('open_reader', {
               filePath: record.filePath,
               eink: useSettingsStore.getState().eink,
-              debugPanel: useDeveloperStore.getState().showDebugPanel,
+              debugPanel: getDebugPanelLaunchState(),
               mokeBookId: String(book.id),
               restoreProgress,
             });

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -7,7 +7,7 @@ import { ArrowRight, BookOpen, Copy, Download, FolderOpen, LogOut, Moon, Package
 import { DesktopLayout } from '@/components/layout/DesktopLayout';
 import { fetchServerInfo, request } from '@/lib/api';
 import { useServerStore } from '@/lib/store/server';
-import { useDeveloperStore } from '@/lib/store/developer';
+import { getDebugPanelLaunchState, useDeveloperStore } from '@/lib/store/developer';
 import { resolveTheme, useSettingsStore } from '@/lib/store/settings';
 import type { ThemeMode } from '@/lib/store/settings';
 import { cn } from '@/lib/utils';
@@ -119,7 +119,7 @@ export default function SettingsPage() {
     try {
       await openEmbeddedReaderHome({
         eink: useSettingsStore.getState().eink,
-        debugPanel: useDeveloperStore.getState().showDebugPanel,
+        debugPanel: getDebugPanelLaunchState(),
         serverUrl,
         navigate: (href) => router.push(href),
       });

--- a/src/app/welcome/page.tsx
+++ b/src/app/welcome/page.tsx
@@ -6,7 +6,7 @@ import { BookOpen, Check, Copy } from 'lucide-react';
 import { checkWelcomeRequirement, validateServerConnection } from '@/lib/api';
 import { logErrorMetadata } from '@/lib/api-log';
 import { useServerStore } from '@/lib/store/server';
-import { useDeveloperStore } from '@/lib/store/developer';
+import { getDebugPanelLaunchState, useDeveloperStore } from '@/lib/store/developer';
 import { useSettingsStore } from '@/lib/store/settings';
 import { safeGetLocalStorageItem, safeSetLocalStorageItem } from '@/lib/browser-storage';
 import { debugLog } from '@/lib/debug-log';
@@ -118,7 +118,7 @@ export default function WelcomePage() {
     try {
       await openEmbeddedReaderHome({
         eink: useSettingsStore.getState().eink,
-        debugPanel: useDeveloperStore.getState().showDebugPanel,
+        debugPanel: getDebugPanelLaunchState(),
         serverUrl: useServerStore.getState().serverUrl,
         navigate: (href) => router.push(href),
       });

--- a/src/components/providers/AppShell.tsx
+++ b/src/components/providers/AppShell.tsx
@@ -16,7 +16,7 @@ import {
 } from '@/lib/moke-reader';
 import { createBoundedRetryCache } from '@/lib/bounded-retry-cache';
 import { shouldPreventNativeAppZoomShortcut } from '@/lib/native-app-zoom';
-import { useDeveloperStore } from '@/lib/store/developer';
+import { getDebugPanelLaunchState, useDeveloperStore } from '@/lib/store/developer';
 import { resolveTheme, useSettingsStore } from '@/lib/store/settings';
 import { NativeBackNavigation } from './NativeBackNavigation';
 import { PrivacyConsentGate } from './PrivacyConsentGate';
@@ -70,7 +70,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
     let cleanup: (() => void) | undefined;
     void installDebugLogBridge({
       source: 'moke',
-      getPanelVisible: () => useDeveloperStore.getState().showDebugPanel,
+      getPanelVisible: getDebugPanelLaunchState,
     }).then((uninstall) => {
       if (disposed) uninstall();
       else cleanup = uninstall;

--- a/src/lib/store/developer.ts
+++ b/src/lib/store/developer.ts
@@ -60,4 +60,30 @@ export const useDeveloperStore = create<DeveloperState>()(
   )
 );
 
+/**
+ * Resolve the value carried into a new embedded-reader document.
+ *
+ * Android replaces the current WebView document. A click can happen while the
+ * persisted Zustand store is still hydrating, so also consult the durable
+ * value instead of allowing a transient in-memory false to hide the panel.
+ */
+export function getDebugPanelLaunchState(
+  storage?: Pick<Storage, 'getItem'>,
+): boolean {
+  if (useDeveloperStore.getState().showDebugPanel) return true;
+  const target = storage ?? (typeof window !== 'undefined' ? window.localStorage : undefined);
+  if (!target) return false;
+  try {
+    const value: unknown = JSON.parse(target.getItem('moke-developer-storage') || '{}');
+    const state = value && typeof value === 'object' ? (value as { state?: unknown }).state : null;
+    return !!(
+      state &&
+      typeof state === 'object' &&
+      (state as { showDebugPanel?: unknown }).showDebugPanel === true
+    );
+  } catch {
+    return false;
+  }
+}
+
 export { UNLOCK_THRESHOLD };

--- a/tests/developer-debug-panel.test.mjs
+++ b/tests/developer-debug-panel.test.mjs
@@ -1,0 +1,40 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  getDebugPanelLaunchState,
+  useDeveloperStore,
+} from '../src/lib/store/developer.ts';
+
+const storage = (value) => ({
+  getItem(key) {
+    assert.equal(key, 'moke-developer-storage');
+    return value;
+  },
+});
+
+test('embedded reader launch uses the current in-memory debug switch', () => {
+  useDeveloperStore.setState({ showDebugPanel: true });
+  assert.equal(getDebugPanelLaunchState(storage(null)), true);
+  useDeveloperStore.setState({ showDebugPanel: false });
+});
+
+test('embedded reader launch recovers a persisted true during hydration', () => {
+  useDeveloperStore.setState({ showDebugPanel: false });
+  const persisted = JSON.stringify({
+    state: { unlocked: true, enabled: true, showDebugPanel: true },
+    version: 0,
+  });
+  assert.equal(getDebugPanelLaunchState(storage(persisted)), true);
+});
+
+test('embedded reader launch stays disabled for false or malformed persisted state', () => {
+  useDeveloperStore.setState({ showDebugPanel: false });
+  assert.equal(
+    getDebugPanelLaunchState(
+      storage(JSON.stringify({ state: { showDebugPanel: false }, version: 0 })),
+    ),
+    false,
+  );
+  assert.equal(getDebugPanelLaunchState(storage('{broken')), false);
+});


### PR DESCRIPTION
## Summary
- resolve the embedded-reader debug flag from both current and persisted developer settings
- update Readest to recover the shared persisted switch when Android navigation carries a stale zero flag
- preserve the existing enter/exit transition behavior
- bump the package and cumulative release notes to v1.0.12

## Verification
- Moke tests: 350/350 passed
- Moke TypeScript check passed
- Readest launch-context tests: 8/8 passed
- Readest TypeScript check passed
- production reader export succeeded and contains the persisted debug bootstrap

Readest dependency PR: https://github.com/hehetoshang/readest/pull/25