### PR TITLE
TB-121: harden book cover loading

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4113,6 +4113,7 @@ dependencies = [
  "tauri-plugin-updater",
  "tauri-plugin-websocket",
  "tiny_http",
+ "tokio",
  "tungstenite 0.24.0",
  "uuid 1.24.0",
 ]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -52,6 +52,7 @@ uuid = { version = "1", features = ["v4"] }
 log = "0.4"
 tiny_http = "0.12"
 tungstenite = "0.24"
+tokio = { version = "1", features = ["time"] }
 
 # Plugins that depend on native Linux libraries (gtk/x11)
 # and cannot cross-compile to OHOS.

--- a/src-tauri/src/cover_fetch.rs
+++ b/src-tauri/src/cover_fetch.rs
@@ -1,0 +1,310 @@
+//! Credential-free, SSRF-resistant downloader for explicitly allowed public
+//! book covers. Library-origin covers keep using the shared plugin HTTP cookie
+//! jar; this command is only for cross-origin resources and never accepts
+//! caller-provided headers or credentials.
+
+use std::collections::HashSet;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, ToSocketAddrs};
+use std::time::{Duration, Instant};
+use tauri_plugin_http::reqwest::{
+    header::{ACCEPT, ACCEPT_ENCODING, CONTENT_LENGTH, CONTENT_TYPE, LOCATION},
+    redirect::Policy,
+    Client, Url,
+};
+
+const MAX_COVER_BYTES: usize = 5 * 1024 * 1024;
+const MAX_REDIRECTS: usize = 3;
+const TOTAL_TIMEOUT: Duration = Duration::from_secs(12);
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(4);
+
+fn ipv4_is_non_public(ip: Ipv4Addr) -> bool {
+    let [a, b, c, _] = ip.octets();
+    a == 0
+        || a == 10
+        || a == 127
+        || (a == 100 && (64..=127).contains(&b))
+        || (a == 169 && b == 254)
+        || (a == 172 && (16..=31).contains(&b))
+        || (a == 192 && b == 0 && c == 0)
+        || (a == 192 && b == 0 && c == 2)
+        || (a == 192 && b == 88 && c == 99)
+        || (a == 192 && b == 168)
+        || (a == 198 && (b == 18 || b == 19))
+        || (a == 198 && b == 51 && c == 100)
+        || (a == 203 && b == 0 && c == 113)
+        || a >= 224
+}
+
+fn ipv6_is_non_public(ip: Ipv6Addr) -> bool {
+    if let Some(ipv4) = ip.to_ipv4_mapped() {
+        return ipv4_is_non_public(ipv4);
+    }
+
+    let segments = ip.segments();
+    ip.is_unspecified()
+        || ip.is_loopback()
+        || segments[..6].iter().all(|segment| *segment == 0) // deprecated IPv4-compatible ::/96
+        || (segments[0] & 0xfe00) == 0xfc00 // unique-local fc00::/7
+        || (segments[0] & 0xffc0) == 0xfe80 // link-local fe80::/10
+        || (segments[0] & 0xff00) == 0xff00 // multicast
+        || (segments[0] == 0x0064 && segments[1] == 0xff9b) // NAT64
+        || (segments[0] == 0x0100 && segments[1] == 0) // discard-only
+        || (segments[0] == 0x2001 && (segments[1] < 0x0200 || segments[1] == 0x0db8)) // special/documentation
+        || segments[0] == 0x2002 // 6to4 embeds an IPv4 destination
+        || (segments[0] & 0xfff0) == 0x3ff0 // documentation 3fff::/20
+        || segments[0] == 0x5f00 // segment-routing SIDs, not a public endpoint
+}
+
+fn address_is_non_public(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(ip) => ipv4_is_non_public(ip),
+        IpAddr::V6(ip) => ipv6_is_non_public(ip),
+    }
+}
+
+fn normalized_host(url: &Url) -> Result<String, String> {
+    Ok(url
+        .host_str()
+        .ok_or_else(|| "image.url.invalid".to_string())?
+        .trim_start_matches('[')
+        .trim_end_matches(']')
+        .trim_end_matches('.')
+        .to_ascii_lowercase())
+}
+
+fn validate_url(url: &Url) -> Result<(), String> {
+    if url.scheme() != "http" && url.scheme() != "https" {
+        return Err("image.url.invalid".into());
+    }
+    if !url.username().is_empty() || url.password().is_some() {
+        return Err("image.url.credentials".into());
+    }
+    let normalized = normalized_host(url)?;
+    if normalized == "localhost"
+        || normalized.ends_with(".localhost")
+        || normalized.ends_with(".local")
+        || normalized == "metadata.google.internal"
+        || normalized.ends_with(".metadata.google.internal")
+    {
+        return Err("image.url.private".into());
+    }
+    if let Ok(ip) = normalized.parse::<IpAddr>() {
+        if address_is_non_public(ip) {
+            return Err("image.url.private".into());
+        }
+    }
+    Ok(())
+}
+
+async fn resolve_public_addrs(url: &Url, timeout: Duration) -> Result<Vec<SocketAddr>, String> {
+    let host = normalized_host(url)?;
+    let port = url
+        .port_or_known_default()
+        .ok_or_else(|| "image.url.invalid".to_string())?;
+    let host_for_lookup = host.clone();
+    let lookup = tauri::async_runtime::spawn_blocking(move || {
+        (host_for_lookup.as_str(), port)
+            .to_socket_addrs()
+            .map(|iter| iter.collect::<Vec<_>>())
+    });
+    let addresses = tokio::time::timeout(timeout, lookup)
+        .await
+        .map_err(|_| "image.dns.timeout".to_string())?
+        .map_err(|_| "image.dns.failed".to_string())?
+        .map_err(|_| "image.dns.failed".to_string())?;
+
+    let mut unique = HashSet::new();
+    let addresses: Vec<_> = addresses
+        .into_iter()
+        .filter(|address| unique.insert(*address))
+        .collect();
+    if addresses.is_empty()
+        || addresses
+            .iter()
+            .any(|address| address_is_non_public(address.ip()))
+    {
+        return Err("image.url.private".into());
+    }
+    Ok(addresses)
+}
+
+fn allowed_content_type(value: &str) -> bool {
+    matches!(
+        value
+            .split(';')
+            .next()
+            .unwrap_or("")
+            .trim()
+            .to_ascii_lowercase()
+            .as_str(),
+        "image/gif" | "image/jpeg" | "image/jpg" | "image/png" | "image/webp"
+    )
+}
+
+fn build_pinned_client(
+    url: &Url,
+    addresses: &[SocketAddr],
+    remaining: Duration,
+) -> Result<Client, String> {
+    let host = normalized_host(url)?;
+    Client::builder()
+        .redirect(Policy::none())
+        .referer(false)
+        // Environment proxies would bypass the pinned DNS destination and
+        // make the private-address decision unverifiable.
+        .no_proxy()
+        .resolve_to_addrs(&host, addresses)
+        .connect_timeout(CONNECT_TIMEOUT.min(remaining))
+        .timeout(remaining)
+        .build()
+        .map_err(|_| "image.client.failed".to_string())
+}
+
+async fn fetch_public_cover_bytes(image_url: String) -> Result<Vec<u8>, String> {
+    let mut url = Url::parse(&image_url).map_err(|_| "image.url.invalid".to_string())?;
+    let started = Instant::now();
+    let mut redirects = 0;
+
+    loop {
+        validate_url(&url)?;
+        let remaining = TOTAL_TIMEOUT
+            .checked_sub(started.elapsed())
+            .ok_or_else(|| "image.timeout".to_string())?;
+        let addresses = resolve_public_addrs(&url, CONNECT_TIMEOUT.min(remaining)).await?;
+        let remaining = TOTAL_TIMEOUT
+            .checked_sub(started.elapsed())
+            .ok_or_else(|| "image.timeout".to_string())?;
+        let client = build_pinned_client(&url, &addresses, remaining)?;
+        let mut response = client
+            .get(url.clone())
+            .header(ACCEPT, "image/webp,image/png,image/jpeg,image/gif;q=0.8")
+            .header(ACCEPT_ENCODING, "identity")
+            .send()
+            .await
+            .map_err(|_| "image.request.failed".to_string())?;
+
+        if response.status().is_redirection() {
+            if redirects >= MAX_REDIRECTS {
+                return Err("image.redirect.exceeded".into());
+            }
+            let location = response
+                .headers()
+                .get(LOCATION)
+                .and_then(|value| value.to_str().ok())
+                .ok_or_else(|| "image.redirect.invalid".to_string())?;
+            url = url
+                .join(location)
+                .map_err(|_| "image.redirect.invalid".to_string())?;
+            redirects += 1;
+            continue;
+        }
+
+        if !response.status().is_success() {
+            return Err(format!("image.http.{}", response.status().as_u16()));
+        }
+        if let Some(content_type) = response.headers().get(CONTENT_TYPE) {
+            let content_type = content_type
+                .to_str()
+                .map_err(|_| "image.content_type.invalid".to_string())?;
+            if !allowed_content_type(content_type) {
+                return Err("image.content_type.invalid".into());
+            }
+        }
+        if let Some(content_length) = response.headers().get(CONTENT_LENGTH) {
+            if content_length
+                .to_str()
+                .ok()
+                .and_then(|value| value.parse::<u64>().ok())
+                .is_some_and(|length| length > MAX_COVER_BYTES as u64)
+            {
+                return Err("image.size.exceeded".into());
+            }
+        }
+
+        let mut bytes = Vec::new();
+        while let Some(chunk) = response
+            .chunk()
+            .await
+            .map_err(|_| "image.body.failed".to_string())?
+        {
+            if bytes.len().saturating_add(chunk.len()) > MAX_COVER_BYTES {
+                return Err("image.size.exceeded".into());
+            }
+            bytes.extend_from_slice(&chunk);
+        }
+        if bytes.is_empty() {
+            return Err("image.body.missing".into());
+        }
+        return Ok(bytes);
+    }
+}
+
+#[tauri::command]
+pub(crate) async fn moke_fetch_public_cover(
+    image_url: String,
+) -> Result<tauri::ipc::Response, String> {
+    fetch_public_cover_bytes(image_url)
+        .await
+        .map(tauri::ipc::Response::new)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{address_is_non_public, allowed_content_type, validate_url};
+    use std::net::IpAddr;
+    use tauri_plugin_http::reqwest::Url;
+
+    #[test]
+    fn rejects_private_special_and_metadata_addresses() {
+        for value in [
+            "127.0.0.1",
+            "10.0.0.1",
+            "100.64.0.1",
+            "169.254.169.254",
+            "172.16.0.1",
+            "192.168.1.1",
+            "198.18.0.1",
+            "::1",
+            "::8.8.8.8",
+            "::ffff:127.0.0.1",
+            "fc00::1",
+            "fe80::1",
+            "64:ff9b::a00:1",
+            "2001:db8::1",
+            "3fff::1",
+            "5f00::1",
+        ] {
+            let ip: IpAddr = value.parse().unwrap();
+            assert!(address_is_non_public(ip), "{value} must be rejected");
+        }
+        for value in ["1.1.1.1", "8.8.8.8", "2606:4700:4700::1111"] {
+            let ip: IpAddr = value.parse().unwrap();
+            assert!(!address_is_non_public(ip), "{value} should be public");
+        }
+    }
+
+    #[test]
+    fn url_policy_rejects_non_http_credentials_and_local_names() {
+        for value in [
+            "file:///etc/passwd",
+            "https://user:pass@example.com/cover.jpg",
+            "http://localhost/cover.jpg",
+            "http://metadata.google.internal/computeMetadata/v1/",
+            "http://[::1]/cover.jpg",
+            "http://2130706433/cover.jpg",
+            "http://0x7f000001/cover.jpg",
+        ] {
+            let url = Url::parse(value).unwrap();
+            assert!(validate_url(&url).is_err(), "{value} must be rejected");
+        }
+        assert!(validate_url(&Url::parse("https://cdn.example/cover.jpg").unwrap()).is_ok());
+    }
+
+    #[test]
+    fn only_raster_cover_content_types_are_accepted() {
+        assert!(allowed_content_type("image/jpeg; charset=binary"));
+        assert!(allowed_content_type("image/webp"));
+        assert!(!allowed_content_type("image/svg+xml"));
+        assert!(!allowed_content_type("text/html"));
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,3 +1,4 @@
+mod cover_fetch;
 /// Moke 桌面客户端入口。
 ///
 /// 阅读器（readest）的 Rust 后端通过 `readestlib` 以库形式编译进本应用：
@@ -524,6 +525,7 @@ fn moke_invoke_handler() -> impl Fn(tauri::ipc::Invoke<tauri::Wry>) -> bool + Se
 {
     tauri::generate_handler![
         moke_runtime_platform,
+        cover_fetch::moke_fetch_public_cover,
         #[cfg(any(target_env = "ohos", target_os = "android"))]
         moke_navigate,
         moke_record_downloaded_book,

--- a/src/app/detail/page.tsx
+++ b/src/app/detail/page.tsx
@@ -510,6 +510,7 @@ function DetailContent() {
                 {coverUrl ? (
                   <AuthImage
                     src={coverUrl}
+                    allowPublicCrossOrigin
                     alt={book.title}
                     className="w-full h-full object-cover"
                     fallback={<BookOpen className="w-16 h-16 text-muted-foreground/40" />}

--- a/src/app/library/page.tsx
+++ b/src/app/library/page.tsx
@@ -788,6 +788,7 @@ export default function LibraryPage() {
                         {coverUrl ? (
                           <AuthImage
                             src={coverUrl}
+                            allowPublicCrossOrigin
                             alt={book.title}
                             className="book-cover-media w-full h-full object-cover transition-transform duration-500 group-hover:scale-105"
                             loading={index === 0 ? 'eager' : 'lazy'}
@@ -827,6 +828,7 @@ export default function LibraryPage() {
                         {coverUrl ? (
                           <AuthImage
                             src={coverUrl}
+                            allowPublicCrossOrigin
                             alt={book.title}
                             className="w-full h-full object-cover"
                             loading={index === 0 ? 'eager' : 'lazy'}
@@ -1179,12 +1181,18 @@ function NetworkBookGrid({
             <>
               <div className="book-cover-motion relative w-full overflow-hidden rounded-[18px] bg-white book-cover-shadow ring-1 ring-black/5 transition-all duration-300 ease-out group-hover:-translate-y-1.5" style={{ aspectRatio: '2/3' }}>
                 {coverUrl ? (
-                  <img
+                  <AuthImage
                     src={coverUrl}
+                    allowPublicCrossOrigin
                     alt={title}
                     className="book-cover-media w-full h-full object-cover transition-transform duration-500 group-hover:scale-105"
                     loading={idx === 0 ? 'eager' : 'lazy'}
                     fetchPriority={idx === 0 ? 'high' : 'auto'}
+                    fallback={
+                      <div className={cn('book-cover-media w-full h-full flex items-center justify-center', colors[ci])}>
+                        <span className="text-foreground/20 text-2xl font-bold font-serif">{title[0]}</span>
+                      </div>
+                    }
                   />
                 ) : (
                   <div className={cn('book-cover-media w-full h-full flex items-center justify-center', colors[ci])}>
@@ -1215,12 +1223,18 @@ function NetworkBookGrid({
           <>
             <div className="book-list-cover-motion h-[72px] w-12 rounded-md overflow-hidden shadow-card shrink-0 flex items-center justify-center relative sm:h-[84px] sm:w-14">
               {coverUrl ? (
-                <img
+                <AuthImage
                   src={coverUrl}
+                  allowPublicCrossOrigin
                   alt={title}
                   className="w-full h-full object-cover"
                   loading={idx === 0 ? 'eager' : 'lazy'}
                   fetchPriority={idx === 0 ? 'high' : 'auto'}
+                  fallback={
+                    <div className={cn('w-full h-full flex items-center justify-center', colors[ci])}>
+                      <span className="text-foreground/30 text-xs font-bold font-serif">{title[0]}</span>
+                    </div>
+                  }
                 />
               ) : (
                 <div className={cn('w-full h-full flex items-center justify-center', colors[ci])}>

--- a/src/app/network-book/page.tsx
+++ b/src/app/network-book/page.tsx
@@ -5,6 +5,7 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import { AlertTriangle, ArrowLeft, BookOpen, CheckCircle2, Loader2, Save } from 'lucide-react';
 import { requestAnimatedBack } from '@/lib/native-back';
 import { DesktopLayout } from '@/components/layout/DesktopLayout';
+import { AuthImage } from '@/components/ui/AuthImage';
 import { getErrorMessage, MokeApiError } from '@/lib/api';
 import { useServerStore } from '@/lib/store/server';
 import {
@@ -170,7 +171,13 @@ function NetworkBookContent() {
               <div className="w-full overflow-hidden rounded-[24px] border border-amber-950/10 bg-white book-cover-shadow md:w-[220px]">
                 <div className="relative flex aspect-[2/3] items-center justify-center bg-muted/60">
                   {coverUrl ? (
-                    <img src={coverUrl} alt={book.name || '封面'} className="h-full w-full object-cover" />
+                    <AuthImage
+                      src={coverUrl}
+                      allowPublicCrossOrigin
+                      alt={book.name || '封面'}
+                      className="h-full w-full object-cover"
+                      fallback={<BookOpen className="h-16 w-16 text-muted-foreground/40" />}
+                    />
                   ) : (
                     <BookOpen className="h-16 w-16 text-muted-foreground/40" />
                   )}

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -418,6 +418,7 @@ function SearchContent() {
                         {coverUrl ? (
                           <AuthImage
                             src={coverUrl}
+                            allowPublicCrossOrigin
                             alt={book.title}
                             className="book-cover-media w-full h-full object-cover transition-transform duration-500 group-hover:scale-105"
                             loading="lazy"
@@ -460,6 +461,7 @@ function SearchContent() {
                       {coverUrl ? (
                         <AuthImage
                           src={coverUrl}
+                          allowPublicCrossOrigin
                           alt={book.title}
                           className="w-full h-full object-cover"
                           loading="lazy"

--- a/src/app/shelf/page.tsx
+++ b/src/app/shelf/page.tsx
@@ -107,6 +107,7 @@ function BookCard({
           {coverUrl ? (
             <AuthImage
               src={coverUrl}
+              allowPublicCrossOrigin
               alt={book.title}
               className="book-cover-media w-full h-full object-cover transition-transform duration-500 ease-out group-hover:scale-105"
               loading={priority ? 'eager' : 'lazy'}
@@ -161,6 +162,7 @@ function BookCard({
         {coverUrl ? (
           <AuthImage
             src={coverUrl}
+            allowPublicCrossOrigin
             alt={book.title}
             className="w-full h-full object-cover"
             loading={priority ? 'eager' : 'lazy'}
@@ -548,4 +550,3 @@ export default function ShelfPage() {
     </DesktopLayout>
   );
 }
-

--- a/src/app/user/history/page.tsx
+++ b/src/app/user/history/page.tsx
@@ -214,6 +214,7 @@ export default function UserHistoryPage() {
                     {coverUrl ? (
                       <AuthImage
                         src={coverUrl}
+                        allowPublicCrossOrigin
                         alt={item.title}
                         className="w-full h-full object-cover"
                         loading="lazy"

--- a/src/components/book/BookTable.tsx
+++ b/src/components/book/BookTable.tsx
@@ -126,6 +126,7 @@ function TinyCover({ title, src }: { title: string; src: string }) {
   return (
     <AuthImage
       src={src}
+      allowPublicCrossOrigin
       alt={title}
       className="w-6 h-9 rounded-sm object-cover shrink-0"
       loading="lazy"
@@ -144,6 +145,7 @@ function MobileCover({ title, src }: { title: string; src: string }) {
   return (
     <AuthImage
       src={src}
+      allowPublicCrossOrigin
       alt={title}
       className="h-[72px] w-12 shrink-0 rounded-md object-cover shadow-sm"
       loading="lazy"

--- a/src/components/ui/AuthImage.tsx
+++ b/src/components/ui/AuthImage.tsx
@@ -1,75 +1,77 @@
 'use client';
 
-import { useEffect, useRef, useState, type ImgHTMLAttributes } from 'react';
+import { useEffect, useState, type ImgHTMLAttributes } from 'react';
 import { fetchImageObjectUrl } from '@/lib/api';
-
-const isTauriApp = process.env.NEXT_PUBLIC_APP_PLATFORM === 'tauri';
+import { useServerStore } from '@/lib/store/server';
 
 interface AuthImageProps extends Omit<ImgHTMLAttributes<HTMLImageElement>, 'src'> {
-  /** 完整的图片 URL（已通过 resolveServerAssetUrl 拼好） */
+  /** 图片 URL；相对地址始终以当前书库地址为基准解析。 */
   src: string;
   /** 加载失败时渲染的回退内容（如占位封面） */
   fallback?: React.ReactNode;
+  /** 明确允许无凭据加载公网 CDN / 网络书源封面。 */
+  allowPublicCrossOrigin?: boolean;
 }
 
 /**
  * 带认证的图片组件。
  *
- * - Web 端：服务器与前端同源，cookie 会自动随 <img> 发送，直接用原生 <img>。
- * - Tauri 端：前端在 tauri:// 协议下，与 http(s):// 服务器跨源，<img> 不会带 session，
- *   会 401。因此改用 fetchImageObjectUrl 走带认证的 tauriFetch 拉取后转 blob URL。
+ * 所有平台都先通过安全加载器做协议、来源、重定向、大小和像素限制，再把经过
+ * 校验的字节转成 object URL。只有书库同源请求可以携带 session；跨源必须由
+ * 调用点显式允许且始终匿名。
  */
-export function AuthImage({ src, fallback, alt = '', ...imgProps }: AuthImageProps) {
-  const [objectUrl, setObjectUrl] = useState<string | null>(null);
+export function AuthImage({
+  src,
+  fallback,
+  allowPublicCrossOrigin = false,
+  alt = '',
+  onError,
+  ...imgProps
+}: AuthImageProps) {
+  const serverUrl = useServerStore((state) => state.serverUrl);
+  const loadKey = `${serverUrl}\n${allowPublicCrossOrigin ? 'public' : 'same'}\n${src}`;
+  const [loaded, setLoaded] = useState<{ key: string; objectUrl: string } | null>(null);
   const [failed, setFailed] = useState(false);
-  const currentObjectUrl = useRef<string | null>(null);
 
   useEffect(() => {
-    // 每次换源都重置失败标记（不区分平台）：
-    // web 模式下 effect 会在平台分支提前 return，若不先重置，src 更换后
-    // failed 仍为 true，一直显示占位封面。
     setFailed(false);
-    if (!isTauriApp || !src) return;
+    if (!serverUrl || !src) return;
 
-    let cancelled = false;
+    let disposed = false;
+    let ownedObjectUrl: string | null = null;
 
-    fetchImageObjectUrl(src)
+    fetchImageObjectUrl(src, { serverUrl, allowPublicCrossOrigin })
       .then((url) => {
-        if (cancelled) {
+        if (disposed) {
           URL.revokeObjectURL(url);
           return;
         }
-        // 释放上一张
-        if (currentObjectUrl.current) URL.revokeObjectURL(currentObjectUrl.current);
-        currentObjectUrl.current = url;
-        setObjectUrl(url);
+        ownedObjectUrl = url;
+        setLoaded({ key: loadKey, objectUrl: url });
       })
       .catch(() => {
-        if (!cancelled) setFailed(true);
+        if (!disposed) setFailed(true);
       });
 
     return () => {
-      cancelled = true;
+      disposed = true;
+      if (ownedObjectUrl) URL.revokeObjectURL(ownedObjectUrl);
     };
-  }, [src]);
+  }, [allowPublicCrossOrigin, loadKey, serverUrl, src]);
 
-  // 组件卸载时释放最后一张 blob
-  useEffect(() => {
-    return () => {
-      if (currentObjectUrl.current) URL.revokeObjectURL(currentObjectUrl.current);
-    };
-  }, []);
-
-  // Web 端：直接用原生 <img>（同源自动带 cookie）
-  if (!isTauriApp) {
-    if (!src || failed) return <>{fallback ?? null}</>;
+  if (failed || !src || loaded?.key !== loadKey) return <>{fallback ?? null}</>;
+  return (
     // eslint-disable-next-line @next/next/no-img-element
-    return <img src={src} alt={alt} onError={() => setFailed(true)} {...imgProps} />;
-  }
-
-  // Tauri 端
-  if (failed || !src) return <>{fallback ?? null}</>;
-  if (!objectUrl) return <>{fallback ?? null}</>;
-  // eslint-disable-next-line @next/next/no-img-element
-  return <img src={objectUrl} alt={alt} {...imgProps} />;
+    <img
+      src={loaded.objectUrl}
+      alt={alt}
+      onError={(event) => {
+        URL.revokeObjectURL(loaded.objectUrl);
+        setLoaded(null);
+        setFailed(true);
+        onError?.(event);
+      }}
+      {...imgProps}
+    />
+  );
 }

--- a/src/lib/api-core.ts
+++ b/src/lib/api-core.ts
@@ -36,7 +36,9 @@ export function isAbsoluteHttpUrl(url: string): boolean {
 
 export function buildTauriRequestInit(options?: RequestInit): TauriRequestInit {
   const init = { ...(options ?? {}) } as TauriRequestInit;
-  init.maxRedirections = 5;
+  // Security-sensitive callers (covers) opt into manual redirect handling so
+  // every destination can be revalidated before a request is sent.
+  if (!Number.isInteger(init.maxRedirections)) init.maxRedirections = 5;
   init.danger = {
     acceptInvalidCerts: true,
     acceptInvalidHostnames: true,

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -24,6 +24,11 @@ import {
   type UserInfoResponse,
 } from '@/lib/server-session';
 import { discoverGeneralServerCapabilities } from '@/lib/server-capabilities';
+import {
+  fetchCoverBytes,
+  MAX_COVER_DIMENSION,
+  MAX_COVER_PIXELS,
+} from '@/lib/cover-image-core';
 export { getErrorMessage, MokeApiError, readApiJson, readJsonResponse } from '@/lib/api-core';
 
 const appPlatform = resolveAppPlatform(process.env.NEXT_PUBLIC_APP_PLATFORM);
@@ -126,47 +131,173 @@ export async function request(url: string | URL, options?: RequestInit): Promise
   return attachSafeJsonReader(response);
 }
 
-/**
- * 通过带认证的 request 获取图片资源，返回可直接用于 <img src> 的 object URL。
- *
- * 为什么需要它：在 Tauri 桌面端，前端运行在自定义协议（tauri://localhost），
- * 与 http(s):// 服务器跨源。<img src> 由 WebView 直接发起，绕过 tauriFetch 插件，
- * 也拿不到登录后由 Rust 侧 cookie jar 维护的 session，因此会 401。
- * 这里改为用 request()（Tauri 下走 tauriFetch、自动带认证）拉取字节再转 blob。
- *
- * 调用方负责在不再使用时 URL.revokeObjectURL 释放。
- */
-export async function fetchImageObjectUrl(imageUrl: string): Promise<string> {
-  if (!/^https?:\/\//i.test(imageUrl)) {
-    throw new Error('image.url.invalid');
-  }
-  const startedAt = Date.now();
-  debugLog('info', 'image', `→ GET ${imageUrl}`);
+export interface FetchImageObjectUrlOptions {
+  /** Configured Talebook origin. Relative covers resolve against this URL. */
+  serverUrl: string;
+  /** Explicit policy switch for credential-free, publicly routed CDN/source covers. */
+  allowPublicCrossOrigin?: boolean;
+}
+
+const COVER_TIMEOUT_MS = 12_000;
+const COVER_FAILURE_COOLDOWN_MS = 30_000;
+const coverLoads = new Map<string, Promise<Blob>>();
+const coverFailureUntil = new Map<string, number>();
+
+function binaryResponse(bytes: Uint8Array): Response {
+  const copy = bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
+  return new Response(copy, { status: 200 });
+}
+
+function ipcBytes(value: ArrayBuffer | Uint8Array | number[]): Uint8Array {
+  if (value instanceof Uint8Array) return value;
+  if (value instanceof ArrayBuffer) return new Uint8Array(value);
+  if (Array.isArray(value)) return Uint8Array.from(value);
+  throw new Error('image.body.invalid');
+}
+
+function coverLogUrl(value: string, serverUrl: string): string {
   try {
-    const response = await request(imageUrl, { credentials: 'include' });
-    if (!response.ok) {
-      debugLog(
-        'error',
-        'image',
-        `✗ ${response.status} 封面/图片加载失败 ${imageUrl} (${Date.now() - startedAt}ms)`,
-        response.status === 401 ? '未授权：登录会话可能未携带或已失效' : `HTTP ${response.status}`,
-      );
-      throw new Error(`image.http.${response.status}`);
-    }
-    const blob = await response.blob();
-    const objectUrl = URL.createObjectURL(blob);
-    debugLog(
-      'success',
-      'image',
-      `← 图片加载成功 ${imageUrl} (${Date.now() - startedAt}ms)`,
-      { type: blob.type, size: blob.size },
-    );
-    return objectUrl;
-  } catch (e) {
-    const errMsg = e instanceof Error ? `${e.name}: ${e.message}` : String(e);
-    debugLog('error', 'image', `✗ 图片加载异常 ${imageUrl}`, errMsg);
-    throw e;
+    const url = new URL(value, serverUrl);
+    return `${url.origin}${url.pathname}`;
+  } catch {
+    return '[invalid cover URL]';
   }
+}
+
+async function verifyBrowserDecode(blob: Blob): Promise<void> {
+  if (typeof createImageBitmap === 'function') {
+    const bitmap = await createImageBitmap(blob).catch(() => {
+      throw new Error('image.decode.invalid');
+    });
+    try {
+      if (
+        bitmap.width > MAX_COVER_DIMENSION ||
+        bitmap.height > MAX_COVER_DIMENSION ||
+        bitmap.width * bitmap.height > MAX_COVER_PIXELS
+      ) {
+        throw new Error('image.dimensions.exceeded');
+      }
+    } finally {
+      bitmap.close();
+    }
+    return;
+  }
+
+  // Older WebViews do not expose createImageBitmap. Decode once through an
+  // off-DOM image and revoke its short-lived URL on every completion path.
+  if (typeof Image !== 'function') return;
+  const decodeUrl = URL.createObjectURL(blob);
+  try {
+    await new Promise<void>((resolve, reject) => {
+      const image = new Image();
+      image.onload = () => {
+        if (
+          image.naturalWidth > MAX_COVER_DIMENSION ||
+          image.naturalHeight > MAX_COVER_DIMENSION ||
+          image.naturalWidth * image.naturalHeight > MAX_COVER_PIXELS
+        ) {
+          reject(new Error('image.dimensions.exceeded'));
+          return;
+        }
+        resolve();
+      };
+      image.onerror = () => reject(new Error('image.decode.invalid'));
+      image.src = decodeUrl;
+    });
+  } finally {
+    URL.revokeObjectURL(decodeUrl);
+  }
+}
+
+async function fetchImageBlob(
+  imageUrl: string,
+  { serverUrl, allowPublicCrossOrigin = false }: FetchImageObjectUrlOptions,
+): Promise<Blob> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), COVER_TIMEOUT_MS);
+  const startedAt = Date.now();
+  debugLog('info', 'image', `→ GET ${coverLogUrl(imageUrl, serverUrl)}`);
+
+  try {
+    const result = await fetchCoverBytes(
+      { imageUrl, libraryUrl: serverUrl, allowPublicCrossOrigin },
+      {
+        fetchLibrary: (url) => request(url, {
+          credentials: 'include',
+          redirect: 'manual',
+          signal: controller.signal,
+          // Consumed by plugin-http; native fetch safely ignores the extra key.
+          maxRedirections: 0,
+        } as RequestInit & { maxRedirections: number }),
+        fetchPublic: async (url) => {
+          if (isTauriApp) {
+            const { invoke } = await import('@tauri-apps/api/core');
+            const value = await invoke<ArrayBuffer | Uint8Array | number[]>('moke_fetch_public_cover', {
+              imageUrl: url,
+            });
+            return binaryResponse(ipcBytes(value));
+          }
+          return fetch(url, {
+            credentials: 'omit',
+            redirect: 'manual',
+            referrerPolicy: 'no-referrer',
+            signal: controller.signal,
+            headers: { Accept: 'image/webp,image/png,image/jpeg,image/gif;q=0.8' },
+          });
+        },
+      },
+    );
+    const blob = new Blob([result.bytes], { type: result.contentType });
+    await verifyBrowserDecode(blob);
+    debugLog('success', 'image', `← 图片加载成功 ${coverLogUrl(result.finalUrl, serverUrl)} (${Date.now() - startedAt}ms)`, {
+      type: blob.type,
+      size: blob.size,
+      width: result.info.width,
+      height: result.info.height,
+    });
+    return blob;
+  } catch (error) {
+    const detail = error instanceof Error ? `${error.name}: ${error.message}` : String(error);
+    debugLog('error', 'image', `✗ 图片加载异常 ${coverLogUrl(imageUrl, serverUrl)}`, detail);
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+/**
+ * Load every book cover through one bounded policy gate and return an object
+ * URL. Same-library requests may use the session cookie; explicitly allowed
+ * cross-origin requests are credential-free and, on Tauri, DNS-pinned by the
+ * native public-cover command. Callers own and must revoke the returned URL.
+ * Concurrent mounts share one download and failures cool down briefly to
+ * avoid virtualized-list/remount retry storms.
+ */
+export async function fetchImageObjectUrl(
+  imageUrl: string,
+  options: FetchImageObjectUrlOptions,
+): Promise<string> {
+  const key = `${options.serverUrl}\n${options.allowPublicCrossOrigin === true ? 'public' : 'same'}\n${imageUrl}`;
+  const blockedUntil = coverFailureUntil.get(key) ?? 0;
+  if (blockedUntil > Date.now()) throw new Error('image.retry_later');
+  if (blockedUntil) coverFailureUntil.delete(key);
+
+  let load = coverLoads.get(key);
+  if (!load) {
+    load = fetchImageBlob(imageUrl, options);
+    coverLoads.set(key, load);
+    void load.then(
+      () => coverFailureUntil.delete(key),
+      () => {
+        coverFailureUntil.set(key, Date.now() + COVER_FAILURE_COOLDOWN_MS);
+        if (coverFailureUntil.size > 256) {
+          coverFailureUntil.delete(coverFailureUntil.keys().next().value ?? key);
+        }
+      },
+    ).finally(() => coverLoads.delete(key));
+  }
+  const blob = await load;
+  return URL.createObjectURL(blob);
 }
 
 export async function welcomeCheck(code?: string): Promise<{ err: string; msg?: string }> {

--- a/src/lib/cover-image-core.ts
+++ b/src/lib/cover-image-core.ts
@@ -1,0 +1,416 @@
+/**
+ * Security policy and bounded response reader for book covers.
+ *
+ * This module deliberately has no React/Tauri imports so the redirect, URL,
+ * byte and pixel limits can be exercised with Node's built-in test runner.
+ */
+
+export const MAX_COVER_BYTES = 5 * 1024 * 1024;
+export const MAX_COVER_PIXELS = 16 * 1024 * 1024;
+export const MAX_COVER_DIMENSION = 8192;
+export const MAX_COVER_REDIRECTS = 3;
+
+const ALLOWED_CONTENT_TYPES = new Set([
+  'image/gif',
+  'image/jpeg',
+  'image/jpg',
+  'image/png',
+  'image/webp',
+]);
+
+export type CoverAccess = 'library' | 'public';
+
+export interface ParsedCoverUrl {
+  url: URL;
+  access: CoverAccess;
+}
+
+export interface CoverImageInfo {
+  format: 'gif' | 'jpeg' | 'png' | 'webp';
+  width: number;
+  height: number;
+}
+
+export interface CoverFetchDependencies {
+  fetchLibrary: (url: string) => Promise<Response>;
+  fetchPublic: (url: string) => Promise<Response>;
+  /** Native callers resolve and pin DNS themselves; tests can inject a resolver. */
+  resolvePublicHost?: (hostname: string) => Promise<string[]>;
+}
+
+export interface FetchCoverBytesOptions {
+  imageUrl: string;
+  libraryUrl: string;
+  allowPublicCrossOrigin?: boolean;
+  maxBytes?: number;
+  maxRedirects?: number;
+}
+
+export interface CoverBytesResult {
+  bytes: Uint8Array;
+  contentType: string;
+  finalUrl: string;
+  info: CoverImageInfo;
+}
+
+function coverError(code: string): Error {
+  return new Error(`image.${code}`);
+}
+
+function normalizeHostname(hostname: string): string {
+  return hostname.replace(/^\[|\]$/g, '').replace(/\.$/, '').toLowerCase();
+}
+
+function parseIpv4(hostname: string): number[] | null {
+  const parts = hostname.split('.');
+  if (parts.length !== 4 || parts.some((part) => !/^\d+$/.test(part))) return null;
+  const octets = parts.map(Number);
+  return octets.every((octet) => octet >= 0 && octet <= 255) ? octets : null;
+}
+
+function parseIpv6(hostname: string): number[] | null {
+  const input = normalizeHostname(hostname);
+  if (!input.includes(':') || input.includes('%')) return null;
+
+  const halves = input.split('::');
+  if (halves.length > 2) return null;
+  const parseHalf = (half: string): number[] | null => {
+    if (!half) return [];
+    const fields = half.split(':');
+    const result: number[] = [];
+    for (const field of fields) {
+      if (field.includes('.')) {
+        const ipv4 = parseIpv4(field);
+        if (!ipv4) return null;
+        result.push((ipv4[0] << 8) | ipv4[1], (ipv4[2] << 8) | ipv4[3]);
+      } else {
+        if (!/^[0-9a-f]{1,4}$/i.test(field)) return null;
+        result.push(Number.parseInt(field, 16));
+      }
+    }
+    return result;
+  };
+
+  const left = parseHalf(halves[0]);
+  const right = parseHalf(halves[1] ?? '');
+  if (!left || !right) return null;
+  if (halves.length === 1) return left.length === 8 ? left : null;
+  const omitted = 8 - left.length - right.length;
+  if (omitted < 1) return null;
+  return [...left, ...Array<number>(omitted).fill(0), ...right];
+}
+
+function ipv4IsNonPublic(octets: number[]): boolean {
+  const [a, b, c] = octets;
+  return (
+    a === 0 ||
+    a === 10 ||
+    a === 127 ||
+    (a === 100 && b >= 64 && b <= 127) ||
+    (a === 169 && b === 254) ||
+    (a === 172 && b >= 16 && b <= 31) ||
+    (a === 192 && b === 0 && c === 0) ||
+    (a === 192 && b === 0 && c === 2) ||
+    (a === 192 && b === 88 && c === 99) ||
+    (a === 192 && b === 168) ||
+    (a === 198 && (b === 18 || b === 19)) ||
+    (a === 198 && b === 51 && c === 100) ||
+    (a === 203 && b === 0 && c === 113) ||
+    a >= 224
+  );
+}
+
+function ipv6IsNonPublic(parts: number[]): boolean {
+  const first = parts[0];
+  const second = parts[1];
+  const allZeroBeforeV4 = parts.slice(0, 6).every((part) => part === 0);
+  const mappedV4 = parts.slice(0, 5).every((part) => part === 0) && parts[5] === 0xffff;
+  if (mappedV4) {
+    return ipv4IsNonPublic([
+      parts[6] >> 8,
+      parts[6] & 0xff,
+      parts[7] >> 8,
+      parts[7] & 0xff,
+    ]);
+  }
+  // Deprecated IPv4-compatible space (::/96) has no legitimate CDN use and
+  // is handled inconsistently by operating-system network stacks.
+  if (allZeroBeforeV4) return true;
+
+  return (
+    parts.every((part) => part === 0) ||
+    parts.slice(0, 7).every((part) => part === 0) && parts[7] === 1 ||
+    (first & 0xfe00) === 0xfc00 || // unique-local fc00::/7
+    (first & 0xffc0) === 0xfe80 || // link-local fe80::/10
+    (first & 0xff00) === 0xff00 || // multicast
+    (first === 0x0064 && second === 0xff9b) || // NAT64 well-known/local prefixes
+    (first === 0x0100 && second === 0) || // discard-only 100::/64
+    (first === 0x2001 && (second < 0x0200 || second === 0x0db8)) || // special/documentation
+    first === 0x2002 || // 6to4 can encode otherwise-forbidden IPv4 targets
+    (first & 0xfff0) === 0x3ff0 || // documentation 3fff::/20
+    first === 0x5f00 // segment-routing SIDs, not a public endpoint
+  );
+}
+
+/** Reject literal or resolved addresses that are not globally routable. */
+export function isForbiddenCoverAddress(address: string): boolean {
+  const hostname = normalizeHostname(address);
+  const ipv4 = parseIpv4(hostname);
+  if (ipv4) return ipv4IsNonPublic(ipv4);
+  const ipv6 = parseIpv6(hostname);
+  return ipv6 ? ipv6IsNonPublic(ipv6) : false;
+}
+
+export function assertPublicCoverUrl(url: URL): void {
+  const hostname = normalizeHostname(url.hostname);
+  if (
+    hostname === 'localhost' ||
+    hostname.endsWith('.localhost') ||
+    hostname.endsWith('.local') ||
+    hostname === 'metadata.google.internal' ||
+    hostname.endsWith('.metadata.google.internal') ||
+    isForbiddenCoverAddress(hostname)
+  ) {
+    throw coverError('url.private');
+  }
+}
+
+/** Parse relative covers against the configured library, never the WebView origin. */
+export function parseCoverUrl(
+  imageUrl: string,
+  libraryUrl: string,
+  allowPublicCrossOrigin = false,
+): ParsedCoverUrl {
+  let library: URL;
+  let url: URL;
+  try {
+    library = new URL(libraryUrl);
+    url = new URL(imageUrl, library);
+  } catch {
+    throw coverError('url.invalid');
+  }
+
+  if (!['http:', 'https:'].includes(library.protocol) || !['http:', 'https:'].includes(url.protocol)) {
+    throw coverError('url.invalid');
+  }
+  if (url.username || url.password) throw coverError('url.credentials');
+  url.hash = '';
+
+  if (url.origin === library.origin) return { url, access: 'library' };
+  if (!allowPublicCrossOrigin) throw coverError('url.cross_origin');
+  assertPublicCoverUrl(url);
+  return { url, access: 'public' };
+}
+
+function readUint24Le(bytes: Uint8Array, offset: number): number {
+  return bytes[offset] | (bytes[offset + 1] << 8) | (bytes[offset + 2] << 16);
+}
+
+function inspectPng(bytes: Uint8Array): CoverImageInfo | null {
+  const signature = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+  if (bytes.length < 24 || !signature.every((value, index) => bytes[index] === value)) return null;
+  if (String.fromCharCode(...bytes.slice(12, 16)) !== 'IHDR') return null;
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  return { format: 'png', width: view.getUint32(16), height: view.getUint32(20) };
+}
+
+function inspectGif(bytes: Uint8Array): CoverImageInfo | null {
+  if (bytes.length < 13) return null;
+  const signature = String.fromCharCode(...bytes.slice(0, 6));
+  if (signature !== 'GIF87a' && signature !== 'GIF89a') return null;
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  return { format: 'gif', width: view.getUint16(6, true), height: view.getUint16(8, true) };
+}
+
+function inspectJpeg(bytes: Uint8Array): CoverImageInfo | null {
+  if (bytes.length < 4 || bytes[0] !== 0xff || bytes[1] !== 0xd8) return null;
+  const sofMarkers = new Set([0xc0, 0xc1, 0xc2, 0xc3, 0xc5, 0xc6, 0xc7, 0xc9, 0xca, 0xcb, 0xcd, 0xce, 0xcf]);
+  let offset = 2;
+  while (offset + 3 < bytes.length) {
+    if (bytes[offset] !== 0xff) {
+      offset += 1;
+      continue;
+    }
+    while (offset < bytes.length && bytes[offset] === 0xff) offset += 1;
+    const marker = bytes[offset++];
+    if (marker === 0xd9 || marker === 0xda) break;
+    if (marker === 0x01 || (marker >= 0xd0 && marker <= 0xd8)) continue;
+    if (offset + 1 >= bytes.length) break;
+    const length = (bytes[offset] << 8) | bytes[offset + 1];
+    if (length < 2 || offset + length > bytes.length) break;
+    if (sofMarkers.has(marker) && length >= 7) {
+      return {
+        format: 'jpeg',
+        height: (bytes[offset + 3] << 8) | bytes[offset + 4],
+        width: (bytes[offset + 5] << 8) | bytes[offset + 6],
+      };
+    }
+    offset += length;
+  }
+  return null;
+}
+
+function inspectWebp(bytes: Uint8Array): CoverImageInfo | null {
+  if (
+    bytes.length < 30 ||
+    String.fromCharCode(...bytes.slice(0, 4)) !== 'RIFF' ||
+    String.fromCharCode(...bytes.slice(8, 12)) !== 'WEBP'
+  ) return null;
+
+  let offset = 12;
+  while (offset + 8 <= bytes.length) {
+    const type = String.fromCharCode(...bytes.slice(offset, offset + 4));
+    const size = new DataView(bytes.buffer, bytes.byteOffset + offset + 4, 4).getUint32(0, true);
+    const data = offset + 8;
+    if (data + size > bytes.length) return null;
+    if (type === 'VP8X' && size >= 10) {
+      return {
+        format: 'webp',
+        width: 1 + readUint24Le(bytes, data + 4),
+        height: 1 + readUint24Le(bytes, data + 7),
+      };
+    }
+    if (type === 'VP8 ' && size >= 10 && bytes[data + 3] === 0x9d && bytes[data + 4] === 0x01 && bytes[data + 5] === 0x2a) {
+      return {
+        format: 'webp',
+        width: ((bytes[data + 7] << 8) | bytes[data + 6]) & 0x3fff,
+        height: ((bytes[data + 9] << 8) | bytes[data + 8]) & 0x3fff,
+      };
+    }
+    if (type === 'VP8L' && size >= 5 && bytes[data] === 0x2f) {
+      return {
+        format: 'webp',
+        width: 1 + (((bytes[data + 2] & 0x3f) << 8) | bytes[data + 1]),
+        height: 1 + (((bytes[data + 4] & 0x0f) << 10) | (bytes[data + 3] << 2) | (bytes[data + 2] >> 6)),
+      };
+    }
+    offset = data + size + (size % 2);
+  }
+  return null;
+}
+
+export function inspectCoverImage(bytes: Uint8Array): CoverImageInfo {
+  const info = inspectPng(bytes) ?? inspectGif(bytes) ?? inspectJpeg(bytes) ?? inspectWebp(bytes);
+  if (!info) throw coverError('format.invalid');
+  if (
+    info.width < 1 ||
+    info.height < 1 ||
+    info.width > MAX_COVER_DIMENSION ||
+    info.height > MAX_COVER_DIMENSION ||
+    info.width * info.height > MAX_COVER_PIXELS
+  ) {
+    throw coverError('dimensions.exceeded');
+  }
+  return info;
+}
+
+function normalizedContentType(value: string | null): string {
+  return (value ?? '').split(';', 1)[0].trim().toLowerCase();
+}
+
+async function readBoundedBody(response: Response, maxBytes: number): Promise<Uint8Array> {
+  const rawLength = response.headers.get('content-length');
+  if (rawLength && /^\d+$/.test(rawLength) && Number(rawLength) > maxBytes) {
+    await response.body?.cancel().catch(() => undefined);
+    throw coverError('size.exceeded');
+  }
+  if (!response.body) throw coverError('body.missing');
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > maxBytes) {
+        await reader.cancel().catch(() => undefined);
+        throw coverError('size.exceeded');
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  const result = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    result.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return result;
+}
+
+function contentTypeMatchesFormat(contentType: string, format: CoverImageInfo['format']): boolean {
+  if (!contentType) return true;
+  if (!ALLOWED_CONTENT_TYPES.has(contentType)) return false;
+  if (format === 'jpeg') return contentType === 'image/jpeg' || contentType === 'image/jpg';
+  return contentType === `image/${format}`;
+}
+
+/**
+ * Follow redirects manually so policy is re-evaluated before every request.
+ * Once a route becomes public it stays anonymous, even if it redirects back
+ * to the library origin, preventing credentials from being reintroduced.
+ */
+export async function fetchCoverBytes(
+  options: FetchCoverBytesOptions,
+  dependencies: CoverFetchDependencies,
+): Promise<CoverBytesResult> {
+  const maxBytes = options.maxBytes ?? MAX_COVER_BYTES;
+  const maxRedirects = options.maxRedirects ?? MAX_COVER_REDIRECTS;
+  let parsed = parseCoverUrl(options.imageUrl, options.libraryUrl, options.allowPublicCrossOrigin);
+  let anonymous = parsed.access === 'public';
+  let redirects = 0;
+
+  for (;;) {
+    if (anonymous) {
+      assertPublicCoverUrl(parsed.url);
+      if (dependencies.resolvePublicHost) {
+        const addresses = await dependencies.resolvePublicHost(normalizeHostname(parsed.url.hostname));
+        if (addresses.length === 0 || addresses.some(isForbiddenCoverAddress)) {
+          throw coverError('url.private');
+        }
+      }
+    }
+
+    const response = anonymous
+      ? await dependencies.fetchPublic(parsed.url.toString())
+      : await dependencies.fetchLibrary(parsed.url.toString());
+
+    if (response.status >= 300 && response.status < 400) {
+      if (redirects >= maxRedirects) {
+        await response.body?.cancel().catch(() => undefined);
+        throw coverError('redirect.exceeded');
+      }
+      const location = response.headers.get('location');
+      await response.body?.cancel().catch(() => undefined);
+      if (!location) throw coverError('redirect.invalid');
+      parsed = parseCoverUrl(
+        new URL(location, parsed.url).toString(),
+        options.libraryUrl,
+        options.allowPublicCrossOrigin,
+      );
+      anonymous ||= parsed.access === 'public';
+      redirects += 1;
+      continue;
+    }
+
+    if (!response.ok) {
+      await response.body?.cancel().catch(() => undefined);
+      throw coverError(`http.${response.status}`);
+    }
+
+    const contentType = normalizedContentType(response.headers.get('content-type'));
+    if (contentType && !ALLOWED_CONTENT_TYPES.has(contentType)) {
+      await response.body?.cancel().catch(() => undefined);
+      throw coverError('content_type.invalid');
+    }
+    const bytes = await readBoundedBody(response, maxBytes);
+    const info = inspectCoverImage(bytes);
+    if (!contentTypeMatchesFormat(contentType, info.format)) throw coverError('content_type.invalid');
+    return { bytes, contentType: contentType || `image/${info.format}`, finalUrl: parsed.url.toString(), info };
+  }
+}

--- a/tests/cover-image-security.test.mjs
+++ b/tests/cover-image-security.test.mjs
@@ -1,0 +1,305 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+import {
+  fetchCoverBytes,
+  isForbiddenCoverAddress,
+  MAX_COVER_BYTES,
+  parseCoverUrl,
+} from '../src/lib/cover-image-core.ts';
+
+const LIBRARY_URL = 'https://library.example';
+
+function pngHeader(width = 1, height = 1) {
+  const bytes = new Uint8Array(24);
+  bytes.set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a], 0);
+  bytes.set([0x49, 0x48, 0x44, 0x52], 12);
+  const view = new DataView(bytes.buffer);
+  view.setUint32(16, width);
+  view.setUint32(20, height);
+  return bytes;
+}
+
+function imageResponse(bytes = pngHeader(), headers = {}) {
+  return new Response(bytes, {
+    status: 200,
+    headers: { 'Content-Type': 'image/png', ...headers },
+  });
+}
+
+function redirectResponse(location) {
+  return new Response(null, { status: 302, headers: { Location: location } });
+}
+
+test('封面 URL 只接受相对书库或显式允许的 HTTP(S) 公网地址', () => {
+  assert.equal(parseCoverUrl('/cover/1.jpg', LIBRARY_URL).url.href, 'https://library.example/cover/1.jpg');
+  assert.equal(parseCoverUrl('https://library.example/cover/1.jpg', LIBRARY_URL).access, 'library');
+
+  for (const value of [
+    'file:///etc/passwd',
+    'data:image/png;base64,AAAA',
+    'javascript:alert(1)',
+    'ftp://cdn.example/cover.jpg',
+    'https://user:secret@cdn.example/cover.jpg',
+  ]) {
+    assert.throws(() => parseCoverUrl(value, LIBRARY_URL, true), /image\.url\./, value);
+  }
+  assert.throws(
+    () => parseCoverUrl('https://cdn.example/cover.jpg', LIBRARY_URL),
+    /image\.url\.cross_origin/,
+  );
+  assert.equal(
+    parseCoverUrl('https://cdn.example/cover.jpg', LIBRARY_URL, true).access,
+    'public',
+  );
+});
+
+test('IPv4/IPv6 私网、特殊地址和非常规 IPv4 写法均被拒绝', () => {
+  for (const address of [
+    '0.0.0.0',
+    '10.0.0.1',
+    '100.64.0.1',
+    '127.0.0.1',
+    '169.254.169.254',
+    '172.31.255.255',
+    '192.168.1.1',
+    '198.18.0.1',
+    '224.0.0.1',
+    '::1',
+    '::8.8.8.8',
+    '::ffff:127.0.0.1',
+    'fc00::1',
+    'fe80::1',
+    '64:ff9b::a00:1',
+    '2001:db8::1',
+    '3fff::1',
+    '5f00::1',
+  ]) {
+    assert.equal(isForbiddenCoverAddress(address), true, address);
+  }
+  for (const address of ['1.1.1.1', '8.8.8.8', '2606:4700:4700::1111']) {
+    assert.equal(isForbiddenCoverAddress(address), false, address);
+  }
+  for (const url of [
+    'http://127.0.0.1/cover.jpg',
+    'http://2130706433/cover.jpg',
+    'http://0x7f000001/cover.jpg',
+    'http://[::1]/cover.jpg',
+    'http://metadata.google.internal/computeMetadata/v1/',
+  ]) {
+    assert.throws(() => parseCoverUrl(url, LIBRARY_URL, true), /image\.url\.private/, url);
+  }
+});
+
+test('DNS 解析到任一私网地址时在发请求前拒绝', async () => {
+  let requests = 0;
+  await assert.rejects(
+    fetchCoverBytes(
+      {
+        imageUrl: 'https://cdn.example/cover.png',
+        libraryUrl: LIBRARY_URL,
+        allowPublicCrossOrigin: true,
+      },
+      {
+        fetchLibrary: async () => { throw new Error('unexpected library request'); },
+        fetchPublic: async () => { requests += 1; return imageResponse(); },
+        resolvePublicHost: async () => ['203.0.113.8', '10.0.0.8'],
+      },
+    ),
+    /image\.url\.private/,
+  );
+  assert.equal(requests, 0);
+});
+
+test('同源重定向到私网会在访问重定向目标前拒绝', async () => {
+  let publicRequests = 0;
+  await assert.rejects(
+    fetchCoverBytes(
+      {
+        imageUrl: '/cover/1.png',
+        libraryUrl: LIBRARY_URL,
+        allowPublicCrossOrigin: true,
+      },
+      {
+        fetchLibrary: async () => redirectResponse('https://rebind.example/cover.png'),
+        fetchPublic: async () => { publicRequests += 1; return imageResponse(); },
+        resolvePublicHost: async () => ['192.168.1.20'],
+      },
+    ),
+    /image\.url\.private/,
+  );
+  assert.equal(publicRequests, 0);
+});
+
+test('跨域重定向切换到匿名传输且不会重新启用书库凭据', async () => {
+  const calls = [];
+  const result = await fetchCoverBytes(
+    {
+      imageUrl: '/cover/1.png',
+      libraryUrl: LIBRARY_URL,
+      allowPublicCrossOrigin: true,
+    },
+    {
+      fetchLibrary: async (url) => {
+        calls.push(['library-with-cookie', url]);
+        return redirectResponse('https://cdn.example/cover.png');
+      },
+      fetchPublic: async (url) => {
+        calls.push(['public-without-cookie', url]);
+        if (url.startsWith('https://cdn.example')) {
+          return redirectResponse('https://library.example/cdn-return.png');
+        }
+        return imageResponse();
+      },
+      resolvePublicHost: async () => ['1.1.1.1'],
+    },
+  );
+
+  assert.equal(result.info.width, 1);
+  assert.deepEqual(calls.map(([transport]) => transport), [
+    'library-with-cookie',
+    'public-without-cookie',
+    'public-without-cookie',
+  ]);
+});
+
+test('Content-Length 超限时不读取正文', async () => {
+  let bodyPulls = 0;
+  const response = new Response(new ReadableStream({
+    pull(controller) {
+      bodyPulls += 1;
+      controller.enqueue(pngHeader());
+      controller.close();
+    },
+  }), {
+    status: 200,
+    headers: {
+      'Content-Type': 'image/png',
+      'Content-Length': String(MAX_COVER_BYTES + 1),
+    },
+  });
+
+  await assert.rejects(
+    fetchCoverBytes(
+      { imageUrl: '/cover.png', libraryUrl: LIBRARY_URL },
+      {
+        fetchLibrary: async () => response,
+        fetchPublic: async () => { throw new Error('unexpected public request'); },
+      },
+    ),
+    /image\.size\.exceeded/,
+  );
+  // Node may pull once while constructing a Response, but the loader never
+  // consumes the advertised-oversize stream further.
+  assert.ok(bodyPulls <= 1);
+});
+
+for (const [name, advertisedLength] of [
+  ['缺失 Content-Length', undefined],
+  ['伪造过小 Content-Length', '1'],
+]) {
+  test(`${name} 仍按流式实际字节限制`, async () => {
+    const bytes = new Uint8Array(65);
+    bytes.set(pngHeader());
+    const headers = advertisedLength ? { 'Content-Length': advertisedLength } : {};
+    await assert.rejects(
+      fetchCoverBytes(
+        { imageUrl: '/cover.png', libraryUrl: LIBRARY_URL, maxBytes: 64 },
+        {
+          fetchLibrary: async () => imageResponse(bytes, headers),
+          fetchPublic: async () => { throw new Error('unexpected public request'); },
+        },
+      ),
+      /image\.size\.exceeded/,
+    );
+  });
+}
+
+test('超大像素、SVG 和超出重定向次数的响应均被拒绝', async () => {
+  await assert.rejects(
+    fetchCoverBytes(
+      { imageUrl: '/cover.png', libraryUrl: LIBRARY_URL },
+      {
+        fetchLibrary: async () => imageResponse(pngHeader(8193, 1)),
+        fetchPublic: async () => { throw new Error('unexpected public request'); },
+      },
+    ),
+    /image\.dimensions\.exceeded/,
+  );
+  await assert.rejects(
+    fetchCoverBytes(
+      { imageUrl: '/cover.svg', libraryUrl: LIBRARY_URL },
+      {
+        fetchLibrary: async () => new Response('<svg/>', { headers: { 'Content-Type': 'image/svg+xml' } }),
+        fetchPublic: async () => { throw new Error('unexpected public request'); },
+      },
+    ),
+    /image\.content_type\.invalid/,
+  );
+  await assert.rejects(
+    fetchCoverBytes(
+      { imageUrl: '/cover.png', libraryUrl: LIBRARY_URL, maxRedirects: 1 },
+      {
+        fetchLibrary: async () => redirectResponse('/again.png'),
+        fetchPublic: async () => { throw new Error('unexpected public request'); },
+      },
+    ),
+    /image\.redirect\.exceeded/,
+  );
+});
+
+test('正常同源封面与显式允许的公网 CDN 封面可加载', async () => {
+  const library = await fetchCoverBytes(
+    { imageUrl: '/cover.png', libraryUrl: LIBRARY_URL },
+    {
+      fetchLibrary: async () => imageResponse(pngHeader(600, 900)),
+      fetchPublic: async () => { throw new Error('unexpected public request'); },
+    },
+  );
+  assert.deepEqual(library.info, { format: 'png', width: 600, height: 900 });
+
+  let resolvedHost = '';
+  const cdn = await fetchCoverBytes(
+    {
+      imageUrl: 'https://cdn.example/book.webp',
+      libraryUrl: LIBRARY_URL,
+      allowPublicCrossOrigin: true,
+    },
+    {
+      fetchLibrary: async () => { throw new Error('unexpected library request'); },
+      fetchPublic: async () => imageResponse(pngHeader(400, 600)),
+      resolvePublicHost: async (host) => { resolvedHost = host; return ['1.1.1.1']; },
+    },
+  );
+  assert.equal(resolvedHost, 'cdn.example');
+  assert.equal(cdn.info.height, 600);
+});
+
+test('书库与网络书封面统一经过安全组件并保留 object URL 回收与失败冷却', () => {
+  for (const file of [
+    'src/app/detail/page.tsx',
+    'src/app/library/page.tsx',
+    'src/app/network-book/page.tsx',
+    'src/app/search/page.tsx',
+    'src/app/shelf/page.tsx',
+    'src/app/user/history/page.tsx',
+    'src/components/book/BookTable.tsx',
+  ]) {
+    const source = readFileSync(new URL(`../${file}`, import.meta.url), 'utf8');
+    assert.match(source, /<AuthImage\b/, `${file} must use AuthImage for covers`);
+    assert.doesNotMatch(
+      source,
+      /<img[\s\S]{0,160}src=\{(?:coverUrl|book\.(?:cover_url|img|thumb))\}/,
+      `${file} must not hand a server cover URL directly to img`,
+    );
+  }
+
+  const authImage = readFileSync(new URL('../src/components/ui/AuthImage.tsx', import.meta.url), 'utf8');
+  assert.match(authImage, /fetchImageObjectUrl\(src, \{ serverUrl, allowPublicCrossOrigin \}\)/);
+  assert.match(authImage, /URL\.revokeObjectURL\(ownedObjectUrl\)/);
+  assert.match(authImage, /URL\.revokeObjectURL\(loaded\.objectUrl\)/);
+
+  const api = readFileSync(new URL('../src/lib/api.ts', import.meta.url), 'utf8');
+  assert.match(api, /const coverLoads = new Map<string, Promise<Blob>>\(\)/);
+  assert.match(api, /COVER_FAILURE_COOLDOWN_MS/);
+});


### PR DESCRIPTION
## Summary

- route every book-cover surface through one policy gate that only accepts bounded raster HTTP(S) content
- retain credentials only for the configured Talebook origin; use a DNS-validated, address-pinned, credential-free Tauri downloader for explicitly allowed public cover origins
- revalidate redirects, enforce 5 MiB and image-dimension limits, deduplicate concurrent loads, and clean up object URLs
- add focused SSRF, credential, redirect, size, format, surface-coverage, cleanup, and retry-cooldown regressions

## Verification

- `pnpm test` (360 passed)
- `pnpm typecheck`
- `pnpm lint` (no errors; existing warnings only)
- `cargo test --manifest-path src-tauri/Cargo.toml --lib cover_fetch::tests` (3 passed)
- `pnpm build`
- `git diff --check`

Closes TB-121
