### PR TITLE
fix(security): harden clip and rangefile boundaries

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -61,9 +61,22 @@
             "$RESOURCE/**",
             "$APPDATA/**/*",
             "$APPCACHE/**/*",
-            "$TEMP/**/*"
+            "$TEMP/readest/**/*"
           ],
-          "deny": []
+          "deny": [
+            "$APPDATA/moke-downloads.json",
+            "$APPDATA/moke-downloads.json.tmp",
+            "$APPDATA/download-directory.json",
+            "$APPDATA/download-directory.json.tmp",
+            "$APPDATA/settings.json",
+            "$APPDATA/settings.json.bak",
+            "$APPDATA/feeds.json",
+            "$APPDATA/feeds.json.bak",
+            "$APPCONFIG/settings.json",
+            "$APPCONFIG/settings.json.bak",
+            "$APPCONFIG/feeds.json",
+            "$APPCONFIG/feeds.json.bak"
+          ]
         }
       }
     }

--- a/tests/security-config.test.mjs
+++ b/tests/security-config.test.mjs
@@ -102,6 +102,23 @@ test('production and development CSPs do not allow unregistered customprotocol U
   }
 });
 
+test('asset protocol keeps temporary and sensitive application data out of reach', () => {
+  const { allow, deny } = security.assetProtocol.scope;
+  assert.ok(!allow.includes('$TEMP/**/*'));
+  assert.ok(!allow.includes('$TEMP/**'));
+  assert.ok(allow.some((path) => path.startsWith('$TEMP/readest/')));
+  assert.ok(!allow.some((path) => path.startsWith('**/')), 'asset roots must stay anchored');
+
+  for (const path of [
+    '$APPDATA/moke-downloads.json',
+    '$APPDATA/download-directory.json',
+    '$APPCONFIG/settings.json',
+    '$APPCONFIG/feeds.json',
+  ]) {
+    assert.ok(deny.includes(path), `${path} must be explicitly denied`);
+  }
+});
+
 test('production script hosts are limited to shipped runtime loaders', () => {
   const scripts = sources(security.csp, 'script-src');
   assert.deepEqual([...scripts].sort(), [


### PR DESCRIPTION
## Summary

- bump embedded Readest to the `clip_url` / `rangefile` hardening from hehetoshang/readest#29
- replace Moke's system-wide `$TEMP/**/*` asset grant with `$TEMP/readest/**/*`
- explicitly deny Moke download indexes plus Readest settings/feed files from the asset protocol
- add config regressions that preserve the anchored capability/CSP work from TB-89/TB-91

Refs TB-124 (R2-M5/R2-M6).

## Validation

- `pnpm test` — 351 passed
- `CARGO_INCREMENTAL=0 cargo test --manifest-path src-tauri/Cargo.toml --lib --locked` — 41 passed (embedded Readest compiled at the bumped revision)
- Readest validation in hehetoshang/readest#29: 123 Rust tests, clippy, and 7 clip-conversion tests passed

## Integration order

1. Merge hehetoshang/readest#29.
2. Merge this PR after the submodule commit is present on Readest `master` (or update this gitlink to the merge commit if the project requires first-parent-only submodule pins).

## Residual validation

The Linux environment cannot run native Android/iOS WebViews. Release smoke testing should cover a public article, a public-to-private redirect, and a legal local range read on both mobile platforms.