### PR TITLE
fix(android): bootstrap reader debug context synchronously

### DIFF
--- a/RELEASE_vx.x.x.md
+++ b/RELEASE_vx.x.x.md
@@ -1,6 +1,6 @@
-# Moke v1.0.13
+# Moke v1.0.14
 
-这是从 `v1.0.2` 升级到 `v1.0.13` 的累计版本，包含此前 `v1.0.3` 至 `v1.0.12` 的全部代码更改。
+这是从 `v1.0.2` 升级到 `v1.0.14` 的累计版本，包含此前 `v1.0.3` 至 `v1.0.13` 的全部代码更改。
 
 ## 内嵌阅读器
 
@@ -12,6 +12,7 @@
 - 保留进入和退出阅读器时的应用切换动画。
 - Readest 原生服务初始化失败时显示具体错误和重试入口，同时保留右下角调试面板按钮。
 - 修复 Android 原生整页导航与 Zustand 状态恢复的竞态：已开启调试面板时，进入 Readest 后右下角按钮不再因过期的 `mokeDebug=0` 而消失。
+- 修复 Android 内嵌阅读器启动上下文被 `next/script` 延后执行的问题；调试开关现会在客户端模块启动前同步注入，确保阅读页右下角调试按钮显示。
 - 修复 Windows 内嵌 Readest 创建应用配置目录时权限范围不匹配，导致 `settings.json` 无法保存的问题；仅允许在 `$APPCONFIG` 与 `$APPCACHE` 根目录执行 `mkdir`，未扩大文件写入、删除或重命名范围。
 - 为 Moke 嵌入模式补齐 LocalSend 状态初始化及全部 9 个命令注册，修复 `localsend_stop` 等命令在 Windows 上提示未找到的问题。
 - 调试面板不再记录 React/Next 启动脚本产生的已知 `<script>` 框架提示，并在读取持久化历史及同步日志时过滤同一条旧记录；其他真实 `console.error` 仍正常保留。
@@ -47,9 +48,9 @@
 
 | 平台 | 安装包 |
 |---|---|
-| Windows | `Moke_1.0.13_x64_en-US.msi` / `.exe` |
-| macOS | `Moke_1.0.13_aarch64.dmg` |
-| Linux | `Moke_1.0.13_amd64.AppImage` / `.deb` |
+| Windows | `Moke_1.0.14_x64_en-US.msi` / `.exe` |
+| macOS | `Moke_1.0.14_aarch64.dmg` |
+| Linux | `Moke_1.0.14_amd64.AppImage` / `.deb` |
 | Android | `moke-android-release.apk` |
 | iOS/iPadOS | `Moke.ipa`（自签名安装） |
 | OpenHarmony（鸿蒙） | `entry-default-unsigned.hap`（alpha，未签名，可能需要自签名安装） |
@@ -62,4 +63,4 @@
 
 遇到问题或建议请提交 [GitHub Issues](https://github.com/talebook/moke/issues)。安全漏洞请通过[私密报告](https://github.com/talebook/moke/security/advisories/new)提交。
 
-**Full Changelog**: https://github.com/talebook/moke/compare/v1.0.2...v1.0.13
+**Full Changelog**: https://github.com/talebook/moke/compare/v1.0.2...v1.0.14

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moke",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@9.15.9",


### PR DESCRIPTION
## Summary

- update embedded Readest to execute the Moke launch context synchronously during document head parsing
- prevent Android client modules from starting before `__MOKE_EMBEDDED` and `__MOKE_DEBUG_PANEL` are initialized
- add regression coverage and bump the cumulative package/release notes to v1.0.14

Readest dependency PR: https://github.com/hehetoshang/readest/pull/31

## Verification

- Moke tests: 350/350 passed
- Moke TypeScript check passed
- Moke ESLint passed with 23 pre-existing warnings and no errors
- Readest targeted Vitest: 9/9 passed
- Readest TypeScript check passed
- Readest Biome check passed
- production Readest export succeeded
- exported `reader.html` contains the direct bootstrap before `<body>` and no `__next_s` wrapper
