### PR TITLE
fix(security): harden extension API and WebSocket boundary

### DIFF
--- a/packages/moke-ext/DEVELOPMENT.md
+++ b/packages/moke-ext/DEVELOPMENT.md
@@ -5,7 +5,7 @@
 Moke 拓展是安装在 `%APPDATA%\com.moke.client\extensions\{name}\` 下的独立程序，
 通过主程序提供的 **本地 HTTP API**（REST + WebSocket）与主程序交互。
 
-拓展可以使用**任意编程语言**开发——只要它能发送 HTTP 请求。
+拓展可以使用**任意编程语言**开发——只要后端进程能发送 HTTP 请求。宿主凭据不会提供给浏览器 UI。
 
 ## 快速开始
 
@@ -69,9 +69,9 @@ my-extension/
 
 ## API 参考
 
-### REST API — `http://127.0.0.1:19555`
+### REST API — 会话级随机回环端口
 
-所有请求需携带：
+Moke 启动拓展后端时通过 `MOKE_API_PORT` 环境变量传入本次会话的端口。不要硬编码端口。所有请求需携带：
 ```
 X-Extension-Name: my-extension
 X-Extension-Token: {token}    // 启用拓展时由主程序分配
@@ -168,7 +168,9 @@ X-Extension-Token: {token}    // 启用拓展时由主程序分配
 
 失败时 `success` 为 `false`，并带 `error` 字段说明原因（如 `No active reader view`）。
 
-### WebSocket 事件 — `ws://127.0.0.1:19556`
+### WebSocket 事件 — 会话级随机回环端口
+
+端口由 `MOKE_WS_PORT` 环境变量传入拓展后端。不要硬编码端口。
 
 **连接流程:**
 
@@ -212,9 +214,7 @@ X-Extension-Token: {token}    // 启用拓展时由主程序分配
 
 ### 纯前端拓展
 
-最简单的类型，只有一个 `manifest.json` + `ui/index.html`。
-前端通过 fetch/WebSocket 调用主程序 API。
-适合：仪表盘、统计面板、简单工具。
+只有 `manifest.json` + `ui/index.html`，适合不需要宿主 API 的静态页面。浏览器 UI 不会收到宿主 token，也不能直接调用宿主 REST/WS；需要宿主数据时必须增加后端，由同源 UI 调用自己的后端，再由后端使用环境变量中的会话凭据访问宿主。
 
 ### 带后端的拓展
 
@@ -226,6 +226,13 @@ X-Extension-Token: {token}    // 启用拓展时由主程序分配
 
 不声明 `entry`，没有 UI。仅通过 WebSocket 订阅事件做后台处理。
 适合：自动同步标注、阅读数据上报、系统钩子。
+
+## 安全迁移（会话端口与凭据）
+
+- 已经从 `MOKE_API_PORT`、`MOKE_WS_PORT` 和 `MOKE_EXT_TOKEN` 读取配置的后端无需改调用格式；端口和 token 现在每次 Moke 启动都会更新。
+- 硬编码 `19555` / `19556` 的后端必须改读对应端口环境变量。
+- 旧版直接在 UI 中获取 token、连接宿主 REST/WS 的拓展必须迁移为「UI → 同源拓展后端 → 宿主」；不得用扩大 CORS 或把 token 返回给 UI 的方式兼容。
+- Moke 首次读取旧 `runtime.json` 时会忽略其中的 token、生成新会话 token，并立即重写文件移除明文凭据；启用状态和拓展端口保持不变。
 
 ## 分发
 
@@ -252,9 +259,9 @@ X-Extension-Token: {token}    // 启用拓展时由主程序分配
 
 ## 安全注意事项
 
-1. **不要硬编码 token**：token 由主程序在启用时分配，应通过环境变量或文件读取
+1. **token 仅限后端环境变量**：只从 `MOKE_EXT_TOKEN` 读取，不得写入文件、日志、HTML、浏览器响应或前端脚本
 2. **后端程序只用纯文件名**：manifest 中 `executable` 不能包含路径，防止路径穿越攻击
-3. **网络请求走主程序代理**：不要直接连接 Talebook 服务器，通过 API Server 代理以确保认证
+3. **端口使用环境变量**：从 `MOKE_API_PORT` / `MOKE_WS_PORT` 读取本次会话随机端口；浏览器 UI 只调用自己的同源后端
 4. **权限最小化**：只声明拓展真正需要的权限
 5. **iframe sandbox**：拓展 UI 运行在 `<iframe sandbox="allow-scripts allow-forms">` 中，能力受限
 
@@ -262,5 +269,5 @@ X-Extension-Token: {token}    // 启用拓展时由主程序分配
 
 1. 打开 Moke 开发者选项（关于页连点版本号 8 次）
 2. 开启调试面板（查看实时日志）
-3. 检查 API Server 是否运行: `curl http://127.0.0.1:19555/api/v1/info`
+3. 在拓展后端日志中确认已读取有效的 `MOKE_API_PORT` / `MOKE_WS_PORT`（不要记录 token）
 4. 检查拓展目录: `%APPDATA%\com.moke.client\extensions\`

--- a/packages/moke-ext/examples/reading-stats/README.md
+++ b/packages/moke-ext/examples/reading-stats/README.md
@@ -63,7 +63,7 @@ makensis installer.nsi
 ## 架构
 
 ```
-manifest.json → 主程序: 分配端口 19557+, 启动 server.exe (注入 MOKE_EXT_TOKEN)
-server.exe    → 静态文件服务 + /api/token 端点
-ui/index.html → fetch(/api/token) → WS(19556) 认证 → 订阅 reader:* 事件
+manifest.json → 主程序: 分配 UI 端口并启动 server.exe
+server.exe    → 从 MOKE_EXT_TOKEN / MOKE_WS_PORT 读取会话配置并订阅 reader:* 事件
+ui/index.html → 仅同源读取 server.exe 的 /api/stats；不会接触宿主 token
 ```

--- a/packages/moke-ext/examples/reading-stats/backend/src/main.rs
+++ b/packages/moke-ext/examples/reading-stats/backend/src/main.rs
@@ -1,8 +1,8 @@
 //! 阅读统计拓展 — 后端。
 //!
 //! 架构：
-//!   - 主线程： tiny_http 服务器，serve 静态文件 + /api/token + /api/stats
-//!   - 后台线程： WebSocket 客户端，连接宿主的 WS Server，订阅阅读事件并累计统计
+//!   - 主线程： tiny_http 服务器，serve 静态文件 + /api/stats
+//!   - 后台线程： WebSocket 客户端，使用进程环境中的会话凭据连接宿主
 //!   - 统计数据结构在 Arc<Mutex<>> 中共享，持久化到 stats.json
 //!
 //! 用法: server --ext-port PORT
@@ -10,7 +10,6 @@
 use std::collections::HashSet;
 use std::env;
 use std::fs;
-use std::net::TcpStream;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::thread;
@@ -118,19 +117,28 @@ fn json_response(data: serde_json::Value) -> Response<std::io::Cursor<Vec<u8>>> 
     let body = data.to_string();
     Response::from_string(body)
         .with_header(header("Content-Type", "application/json"))
-        .with_header(header("Access-Control-Allow-Origin", "*"))
+        .with_header(header("X-Content-Type-Options", "nosniff"))
+}
+
+fn has_expected_host(request: &tiny_http::Request, port: u16) -> bool {
+    let hosts: Vec<String> = request
+        .headers()
+        .iter()
+        .filter(|item| item.field.equiv("Host"))
+        .map(|item| item.value.to_string())
+        .collect();
+    expected_host_values(&hosts, port)
+}
+
+fn expected_host_values(hosts: &[String], port: u16) -> bool {
+    hosts == [format!("127.0.0.1:{port}")]
 }
 
 // ===========================================================================
 // 后台线程： WebSocket 客户端
 // ===========================================================================
 
-fn ws_client_loop(
-    stats: Arc<Mutex<Stats>>,
-    ws_port: u16,
-    token: String,
-    ext_name: String,
-) {
+fn ws_client_loop(stats: Arc<Mutex<Stats>>, ws_port: u16, token: String, ext_name: String) {
     let url = format!("ws://127.0.0.1:{ws_port}");
 
     loop {
@@ -217,7 +225,10 @@ fn handle_ws_event(stats: &Arc<Mutex<Stats>>, event: &str, data: &serde_json::Va
                 cover_url: data["cover_url"].as_str().unwrap_or("").into(),
                 language: data["language"].as_str().unwrap_or("").into(),
             });
-            eprintln!("[stats] 打开书籍: {}", s.current_book.as_ref().map(|b| &b.title[..]).unwrap_or("?"));
+            eprintln!(
+                "[stats] 打开书籍: {}",
+                s.current_book.as_ref().map(|b| &b.title[..]).unwrap_or("?")
+            );
         }
 
         "reader:book:closed" => {
@@ -227,7 +238,10 @@ fn handle_ws_event(stats: &Arc<Mutex<Stats>>, event: &str, data: &serde_json::Va
                 s.stop_reading();
                 s.current_book = None;
             }
-            eprintln!("[stats] 关闭书籍 (view_key={view_key}), 剩余活跃: {}", s.active_view_keys.len());
+            eprintln!(
+                "[stats] 关闭书籍 (view_key={view_key}), 剩余活跃: {}",
+                s.active_view_keys.len()
+            );
         }
 
         "reader:page:changed" => {
@@ -275,15 +289,21 @@ fn main() {
     }
 
     // 从环境变量读取宿主配置
-    let token = env::var("MOKE_EXT_TOKEN").unwrap_or_default();
-    let api_port: u16 = env::var("MOKE_API_PORT")
+    let token = env::var("MOKE_EXT_TOKEN")
         .ok()
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(19555);
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| {
+            eprintln!("错误: 缺少 MOKE_EXT_TOKEN 会话凭据");
+            std::process::exit(1);
+        });
     let ws_port: u16 = env::var("MOKE_WS_PORT")
         .ok()
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(19556);
+        .and_then(|value| value.parse().ok())
+        .filter(|port| *port > 0)
+        .unwrap_or_else(|| {
+            eprintln!("错误: 缺少有效的 MOKE_WS_PORT");
+            std::process::exit(1);
+        });
 
     // 加载已持久化的统计
     let stats = Arc::new(Mutex::new(load_stats()));
@@ -292,9 +312,8 @@ fn main() {
     {
         let stats = stats.clone();
         let ext_name = "reading-stats".to_string();
-        let ws_token = token.clone();
         thread::spawn(move || {
-            ws_client_loop(stats, ws_port, ws_token, ext_name);
+            ws_client_loop(stats, ws_port, token, ext_name);
         });
     }
 
@@ -304,27 +323,20 @@ fn main() {
         std::process::exit(1);
     });
 
-    eprintln!("阅读统计后端已启动:");
-    eprintln!("  HTTP: http://127.0.0.1:{port}");
-    eprintln!("  API 端口: {api_port}, WS 端口: {ws_port}");
+    eprintln!("阅读统计后端已启动: http://127.0.0.1:{port}");
 
     for request in server.incoming_requests() {
+        if !has_expected_host(&request, port) {
+            let _ = request.respond(
+                Response::from_string("Invalid Host")
+                    .with_status_code(403)
+                    .with_header(header("X-Content-Type-Options", "nosniff")),
+            );
+            continue;
+        }
         let url = request.url().to_string();
 
         match url.as_str() {
-            "/api/token" => {
-                let _ = request.respond(json_response(serde_json::json!({
-                    "token": token
-                })));
-                continue;
-            }
-            "/api/config" => {
-                let _ = request.respond(json_response(serde_json::json!({
-                    "api_port": api_port,
-                    "ws_port": ws_port,
-                })));
-                continue;
-            }
             "/api/stats" => {
                 let s = stats.lock().unwrap();
                 let _ = request.respond(json_response(serde_json::json!({
@@ -369,7 +381,7 @@ fn serve_static(request: tiny_http::Request, file_path: &std::path::Path) {
             let _ = request.respond(
                 Response::from_data(data)
                     .with_header(header("Content-Type", mime))
-                    .with_header(header("Access-Control-Allow-Origin", "*")),
+                    .with_header(header("X-Content-Type-Options", "nosniff")),
             );
         }
         Err(_) => {
@@ -438,6 +450,17 @@ mod tests {
         assert!(!is_path_traversal("index.html"));
         assert!(is_path_traversal("../secret.txt"));
         assert!(is_path_traversal(&urlencoding("%2e%2e%2f")));
+    }
+
+    #[test]
+    fn test_host_validation_rejects_rebinding_names() {
+        assert!(expected_host_values(&["127.0.0.1:19557".into()], 19557));
+        assert!(!expected_host_values(&["evil.example:19557".into()], 19557));
+        assert!(!expected_host_values(&["localhost:19557".into()], 19557));
+        assert!(!expected_host_values(
+            &["127.0.0.1:19557".into(), "evil.example:19557".into()],
+            19557,
+        ));
     }
 
     #[test]

--- a/packages/moke-ext/src/commands/dev.js
+++ b/packages/moke-ext/src/commands/dev.js
@@ -4,7 +4,6 @@ import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { createServer } from 'node:http';
 import { readFile } from 'node:fs/promises';
-import { lookup } from 'node:dns/promises';
 
 export default function dev(args) {
   const cwd = process.cwd();
@@ -40,22 +39,21 @@ export default function dev(args) {
   };
 
   const server = createServer(async (req, res) => {
+    if (req.headers.host !== `127.0.0.1:${port}`) {
+      res.writeHead(403, { 'Content-Type': 'text/plain', 'X-Content-Type-Options': 'nosniff' });
+      res.end('Invalid Host');
+      return;
+    }
+
     let url = req.url === '/' ? '/index.html' : req.url;
     // Prevent path traversal
     if (url.includes('..')) { res.writeHead(403); res.end(); return; }
 
     const filePath = join(uiDir, url);
 
-    // /api/token — return simulated token for dev
-    if (req.url === '/api/token') {
-      res.writeHead(200, { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' });
-      res.end(JSON.stringify({ token: 'dev-token-use-real-token-in-production' }));
-      return;
-    }
-
     try {
       const data = await readFile(filePath);
-      res.writeHead(200, { 'Content-Type': mime(url), 'Access-Control-Allow-Origin': '*' });
+      res.writeHead(200, { 'Content-Type': mime(url), 'X-Content-Type-Options': 'nosniff' });
       res.end(data);
     } catch {
       res.writeHead(404);
@@ -72,7 +70,6 @@ export default function dev(args) {
     console.log(`Moke extension dev server`);
     console.log(`  Extension: ${name}`);
     console.log(`  URL:       http://127.0.0.1:${port}`);
-    console.log(`  Token:     dev-token-use-real-token-in-production`);
     console.log();
     console.log('To test in Moke:');
     console.log(`  1. Copy this folder to %APPDATA%\\com.moke.client\\extensions\\${name}\\`);

--- a/packages/moke-ext/src/commands/init.js
+++ b/packages/moke-ext/src/commands/init.js
@@ -29,48 +29,12 @@ const INDEX_HTML = `<!DOCTYPE html>
     h1 { font-size: 1.3rem; margin-bottom: 8px; }
     p { font-size: 0.85rem; color: #8b806e; }
     .status { margin-top: 16px; font-size: 0.8rem; }
-    .connected { color: #065f46; }
-    .disconnected { color: #991b1b; }
   </style>
 </head>
 <body>
   <h1>%DISPLAY%</h1>
   <p>Moke extension — edit ui/index.html to get started.</p>
-  <div class="status" id="status">Connecting...</div>
-
-  <script>
-    const WS_PORT = 19556;
-    const EXT_NAME = '%NAME%';
-
-    async function connect() {
-      const status = document.getElementById('status');
-
-      // 1. Get token from backend
-      let token = '';
-      try { token = (await (await fetch('/api/token')).json()).token || ''; } catch {}
-
-      // 2. Connect WebSocket
-      const ws = new WebSocket('ws://127.0.0.1:' + WS_PORT);
-      ws.onopen = () => {
-        status.className = 'status connected';
-        status.textContent = 'Connected';
-        ws.send(JSON.stringify({
-          type: 'hello', extension: EXT_NAME, token,
-          events: ['reader:book:opened', 'reader:page:changed', 'reader:book:closed'],
-        }));
-      };
-      ws.onmessage = (msg) => {
-        const { event, data } = JSON.parse(msg.data);
-        status.textContent = event + ': ' + JSON.stringify(data).substring(0, 80);
-      };
-      ws.onclose = () => {
-        status.className = 'status disconnected';
-        status.textContent = 'Disconnected, retrying...';
-        setTimeout(connect, 5000);
-      };
-    }
-    connect();
-  </script>
+  <div class="status">UI ready. Add a backend for host API access.</div>
 </body>
 </html>`;
 

--- a/src-tauri/src/extensions/api_server.rs
+++ b/src-tauri/src/extensions/api_server.rs
@@ -3,8 +3,11 @@
 //! 基于 `tiny_http` 提供 REST 接口，供拓展（外部进程）调用。
 //! 监听 `127.0.0.1`（仅本地可达），通过 token 认证拓展身份。
 
+use super::security::ValidatedOrigin;
 use super::EnabledExtension;
 use std::collections::HashMap;
+use std::io::Read;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::mpsc::Sender;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
@@ -15,6 +18,12 @@ use tauri::Manager;
 pub(crate) const MAX_COMMAND_WAIT_MS: u64 = 30_000;
 /// 同时阻塞等待阅读器命令回执的请求上限，避免耗尽 API 请求线程。
 pub(crate) const MAX_CONCURRENT_COMMAND_WAITS: usize = 32;
+/// Maximum number of HTTP handlers, including handlers waiting for reader receipts.
+pub(crate) const MAX_CONCURRENT_REQUESTS: usize = 48;
+/// Requests larger than this are rejected before their bodies are read.
+pub(crate) const MAX_REQUEST_BODY_BYTES: usize = 1024 * 1024;
+/// Slow request bodies receive a deterministic timeout once the bounded read returns.
+const MAX_BODY_READ_TIME: Duration = Duration::from_secs(5);
 const RETIRED_COMMAND_TTL: Duration = Duration::from_secs(60);
 const INTERNAL_REQUEST_ID_PREFIX: &str = "moke-pending:";
 
@@ -33,6 +42,38 @@ impl ApiError {
             status: 400,
             code,
             message: message.into(),
+        }
+    }
+
+    fn unauthorized(message: impl Into<String>) -> Self {
+        Self {
+            status: 401,
+            code: "AUTH_FAILED",
+            message: message.into(),
+        }
+    }
+
+    fn forbidden(code: &'static str, message: impl Into<String>) -> Self {
+        Self {
+            status: 403,
+            code,
+            message: message.into(),
+        }
+    }
+
+    fn request_timeout(message: impl Into<String>) -> Self {
+        Self {
+            status: 408,
+            code: "REQUEST_TIMEOUT",
+            message: message.into(),
+        }
+    }
+
+    fn payload_too_large() -> Self {
+        Self {
+            status: 413,
+            code: "PAYLOAD_TOO_LARGE",
+            message: format!("请求体不能超过 {MAX_REQUEST_BODY_BYTES} 字节"),
         }
     }
 
@@ -273,31 +314,72 @@ pub struct ServerContext {
 // 启动
 // ---------------------------------------------------------------------------
 
-/// 在独立线程中启动 REST API Server。
-/// 如果首选端口被占用，自动尝试下一个端口（最多 10 次）。
-pub fn start(ctx: Arc<ServerContext>, start_port: u16) -> u16 {
-    let mut port = start_port;
-    let server = loop {
-        match tiny_http::Server::http(format!("127.0.0.1:{port}")) {
-            Ok(s) => break s,
-            Err(_e) if port < start_port + 10 => {
-                log::warn!(
-                    "API Server 端口 {port} 被占用，尝试 {next}",
-                    next = port + 1
-                );
-                port += 1;
-            }
-            Err(e) => panic!("无法启动 API Server (尝试了 {start_port}-{port}): {e}"),
-        }
-    };
+#[derive(Default)]
+struct RequestLimiter {
+    active: AtomicUsize,
+}
 
+struct RequestPermit {
+    limiter: Arc<RequestLimiter>,
+}
+
+impl RequestLimiter {
+    fn try_acquire(self: &Arc<Self>) -> Option<RequestPermit> {
+        let mut active = self.active.load(Ordering::Acquire);
+        loop {
+            if active >= MAX_CONCURRENT_REQUESTS {
+                return None;
+            }
+            match self.active.compare_exchange_weak(
+                active,
+                active + 1,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => {
+                    return Some(RequestPermit {
+                        limiter: self.clone(),
+                    })
+                }
+                Err(current) => active = current,
+            }
+        }
+    }
+}
+
+impl Drop for RequestPermit {
+    fn drop(&mut self) {
+        self.limiter.active.fetch_sub(1, Ordering::AcqRel);
+    }
+}
+
+/// 在独立线程中启动 REST API Server。`start_port == 0` 让操作系统为本次
+/// Moke 会话分配随机回环端口；非零值仅用于兼容测试和诊断。
+pub fn start(ctx: Arc<ServerContext>, start_port: u16) -> u16 {
+    let server = tiny_http::Server::http(format!("127.0.0.1:{start_port}"))
+        .unwrap_or_else(|e| panic!("无法启动 API Server: {e}"));
     let actual_port = server.server_addr().to_ip().unwrap().port();
+    let limiter = Arc::new(RequestLimiter::default());
     log::info!("拓展 API Server 已启动: http://127.0.0.1:{actual_port}");
 
     std::thread::spawn(move || {
         for request in server.incoming_requests() {
+            let Some(permit) = limiter.try_acquire() else {
+                respond_error(
+                    request,
+                    ApiError::too_many_requests(
+                        "TOO_MANY_REQUESTS",
+                        format!("并发请求已达上限（{MAX_CONCURRENT_REQUESTS}）"),
+                    ),
+                    None,
+                );
+                continue;
+            };
             let ctx = ctx.clone();
-            std::thread::spawn(move || handle_request(request, ctx));
+            std::thread::spawn(move || {
+                let _permit = permit;
+                handle_request(request, ctx, actual_port);
+            });
         }
     });
 
@@ -308,126 +390,296 @@ pub fn start(ctx: Arc<ServerContext>, start_port: u16) -> u16 {
 // 路由分发
 // ---------------------------------------------------------------------------
 
-fn handle_request(mut request: tiny_http::Request, ctx: Arc<ServerContext>) {
-    // 先提取所有需要的数据（immutable borrows），然后读取 body（mutable borrow）
-    let url = request.url().to_string();
-    let method = request.method().clone();
-    let ext_name = request
-        .headers()
-        .iter()
-        .find(|h| h.field.equiv("X-Extension-Name"))
-        .map(|h| h.value.to_string());
-    let ext_token = request
-        .headers()
-        .iter()
-        .find(|h| h.field.equiv("X-Extension-Token"))
-        .map(|h| h.value.to_string());
+fn header(name: &str, value: &str) -> tiny_http::Header {
+    tiny_http::Header::from_bytes(name.as_bytes(), value.as_bytes()).unwrap()
+}
 
-    // 读取请求体（需要 mutable borrow，必须在所有 immutable borrow 结束之后）
-    let body = {
-        let mut s = String::new();
-        let _ = request.as_reader().read_to_string(&mut s);
-        s
+fn single_header(request: &tiny_http::Request, name: &str) -> Result<Option<String>, ApiError> {
+    let values: Vec<String> = request
+        .headers()
+        .iter()
+        .filter(|item| item.field.as_str().as_str().eq_ignore_ascii_case(name))
+        .map(|item| item.value.to_string())
+        .collect();
+    match values.as_slice() {
+        [] => Ok(None),
+        [value] => Ok(Some(value.clone())),
+        _ => Err(ApiError::bad_request(
+            "DUPLICATE_HEADER",
+            format!("请求头 {name} 不能重复"),
+        )),
+    }
+}
+
+fn with_security_headers(
+    mut response: tiny_http::Response<std::io::Cursor<Vec<u8>>>,
+    cors_origin: Option<&str>,
+) -> tiny_http::Response<std::io::Cursor<Vec<u8>>> {
+    response.add_header(header("Content-Type", "application/json; charset=utf-8"));
+    response.add_header(header("X-Content-Type-Options", "nosniff"));
+    response.add_header(header("Cache-Control", "no-store"));
+    response.add_header(header("Connection", "close"));
+    if let Some(origin) = cors_origin {
+        response.add_header(header("Access-Control-Allow-Origin", origin));
+        response.add_header(header("Vary", "Origin"));
+    }
+    response
+}
+
+fn respond_json(request: tiny_http::Request, status: u16, body: String, cors_origin: Option<&str>) {
+    let response = with_security_headers(
+        tiny_http::Response::from_string(body).with_status_code(status),
+        cors_origin,
+    );
+    let _ = request.respond(response);
+}
+
+fn respond_error(request: tiny_http::Request, error: ApiError, cors_origin: Option<&str>) {
+    let body = serde_json::json!({
+        "code": error.code,
+        "error": error.message,
+    })
+    .to_string();
+    respond_json(request, error.status, body, cors_origin);
+}
+
+fn validate_requested_headers(value: Option<&str>) -> Result<(), ApiError> {
+    const ALLOWED: [&str; 3] = ["content-type", "x-extension-name", "x-extension-token"];
+    if let Some(value) = value {
+        for requested in value
+            .split(',')
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            if !ALLOWED
+                .iter()
+                .any(|allowed| requested.eq_ignore_ascii_case(allowed))
+            {
+                return Err(ApiError::forbidden(
+                    "CORS_HEADER_FORBIDDEN",
+                    format!("预检请求头「{requested}」不被允许"),
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_preflight(
+    request: &tiny_http::Request,
+    ctx: &ServerContext,
+    actual_port: u16,
+) -> Result<String, ApiError> {
+    let host = single_header(request, "Host")?;
+    if !super::security::validate_host(host.as_deref(), actual_port) {
+        return Err(ApiError::forbidden(
+            "INVALID_HOST",
+            "Host 必须是当前回环监听地址",
+        ));
+    }
+
+    let origin = single_header(request, "Origin")?;
+    let validated = {
+        let enabled = ctx.enabled.lock().unwrap();
+        super::security::validate_origin(origin.as_deref(), &enabled)
+    }
+    .map_err(|message| ApiError::forbidden("INVALID_ORIGIN", message))?;
+    let ValidatedOrigin::Extension { value, .. } = validated else {
+        return Err(ApiError::forbidden(
+            "INVALID_ORIGIN",
+            "浏览器预检请求必须携带受信拓展 Origin",
+        ));
     };
 
-    // 添加 CORS header（仅对本地拓展，实际不限来源）
-    let cors_header =
-        tiny_http::Header::from_bytes(&b"Access-Control-Allow-Origin"[..], &b"*"[..]).unwrap();
+    let requested_method =
+        single_header(request, "Access-Control-Request-Method")?.ok_or_else(|| {
+            ApiError::bad_request("INVALID_PREFLIGHT", "缺少 Access-Control-Request-Method 头")
+        })?;
+    if !["GET", "POST", "PUT", "DELETE"]
+        .iter()
+        .any(|allowed| requested_method.eq_ignore_ascii_case(allowed))
+    {
+        return Err(ApiError::forbidden(
+            "CORS_METHOD_FORBIDDEN",
+            "预检请求方法不被允许",
+        ));
+    }
+    let requested_headers = single_header(request, "Access-Control-Request-Headers")?;
+    validate_requested_headers(requested_headers.as_deref())?;
+    Ok(value)
+}
 
-    // 处理 CORS 预检请求
-    if method == tiny_http::Method::Options || url == "/" {
-        // for CORS preflight & health check
-        let response = tiny_http::Response::from_string("")
-            .with_header(cors_header)
-            .with_header(
-                tiny_http::Header::from_bytes(
-                    &b"Access-Control-Allow-Headers"[..],
-                    &b"X-Extension-Name, X-Extension-Token, Content-Type"[..],
-                )
-                .unwrap(),
-            )
-            .with_header(
-                tiny_http::Header::from_bytes(
-                    &b"Access-Control-Allow-Methods"[..],
-                    &b"GET, POST, PUT, DELETE, OPTIONS"[..],
-                )
-                .unwrap(),
-            );
-        let _ = request.respond(response);
+fn validate_body_length(request: &tiny_http::Request) -> Result<(), ApiError> {
+    if request
+        .body_length()
+        .is_some_and(|length| length > MAX_REQUEST_BODY_BYTES)
+    {
+        Err(ApiError::payload_too_large())
+    } else {
+        Ok(())
+    }
+}
+
+fn read_request_body(request: &mut tiny_http::Request) -> Result<String, ApiError> {
+    validate_body_length(request)?;
+
+    let started = Instant::now();
+    let mut bytes = Vec::new();
+    request
+        .as_reader()
+        .take((MAX_REQUEST_BODY_BYTES + 1) as u64)
+        .read_to_end(&mut bytes)
+        .map_err(|error| ApiError::bad_request("BODY_READ_FAILED", error.to_string()))?;
+    if bytes.len() > MAX_REQUEST_BODY_BYTES {
+        return Err(ApiError::payload_too_large());
+    }
+    if started.elapsed() > MAX_BODY_READ_TIME {
+        return Err(ApiError::request_timeout("读取请求体超时"));
+    }
+    String::from_utf8(bytes)
+        .map_err(|_| ApiError::bad_request("INVALID_BODY_ENCODING", "请求体必须是 UTF-8"))
+}
+
+fn handle_request(mut request: tiny_http::Request, ctx: Arc<ServerContext>, actual_port: u16) {
+    let url = request.url().to_string();
+    let method = request.method().clone();
+
+    if method == tiny_http::Method::Options {
+        match validate_preflight(&request, &ctx, actual_port) {
+            Ok(origin) => {
+                let mut response = with_security_headers(
+                    tiny_http::Response::from_string("").with_status_code(204),
+                    Some(&origin),
+                );
+                response.add_header(header(
+                    "Access-Control-Allow-Headers",
+                    "X-Extension-Name, X-Extension-Token, Content-Type",
+                ));
+                response.add_header(header(
+                    "Access-Control-Allow-Methods",
+                    "GET, POST, PUT, DELETE",
+                ));
+                response.add_header(header("Access-Control-Max-Age", "600"));
+                let _ = request.respond(response);
+            }
+            Err(error) => respond_error(request, error, None),
+        }
         return;
     }
 
-    // Token 认证
-    if let Err(e) = authenticate(&ctx, ext_name.as_deref(), ext_token.as_deref()) {
-        let response = tiny_http::Response::from_string(
-            serde_json::json!({"code": "AUTH_FAILED", "error": e}).to_string(),
-        )
-        .with_status_code(401)
-        .with_header(cors_header)
-        .with_header(
-            tiny_http::Header::from_bytes(&b"Content-Type"[..], &b"application/json"[..]).unwrap(),
+    // Host, Origin and token checks deliberately happen before any body read.
+    let host = match single_header(&request, "Host") {
+        Ok(value) => value,
+        Err(error) => {
+            respond_error(request, error, None);
+            return;
+        }
+    };
+    if !super::security::validate_host(host.as_deref(), actual_port) {
+        respond_error(
+            request,
+            ApiError::forbidden("INVALID_HOST", "Host 必须是当前回环监听地址"),
+            None,
         );
-        let _ = request.respond(response);
         return;
     }
 
+    let origin = match single_header(&request, "Origin") {
+        Ok(value) => value,
+        Err(error) => {
+            respond_error(request, error, None);
+            return;
+        }
+    };
+    let validated_origin = {
+        let enabled = ctx.enabled.lock().unwrap();
+        super::security::validate_origin(origin.as_deref(), &enabled)
+    };
+    let validated_origin = match validated_origin {
+        Ok(value) => value,
+        Err(message) => {
+            respond_error(
+                request,
+                ApiError::forbidden("INVALID_ORIGIN", message),
+                None,
+            );
+            return;
+        }
+    };
+    let cors_origin = match &validated_origin {
+        ValidatedOrigin::Backend => None,
+        ValidatedOrigin::Extension { value, .. } => Some(value.clone()),
+    };
+
+    // A declared oversized body is rejected before authentication and without
+    // touching the body stream. This also prevents attackers from using auth
+    // failures to tie up workers with large uploads.
+    if let Err(error) = validate_body_length(&request) {
+        respond_error(request, error, cors_origin.as_deref());
+        return;
+    }
+
+    let ext_name = match single_header(&request, "X-Extension-Name") {
+        Ok(value) => value,
+        Err(error) => {
+            respond_error(request, error, cors_origin.as_deref());
+            return;
+        }
+    };
+    if let ValidatedOrigin::Extension { name, .. } = &validated_origin {
+        if ext_name.as_deref() != Some(name.as_str()) {
+            respond_error(
+                request,
+                ApiError::forbidden("ORIGIN_EXTENSION_MISMATCH", "Origin 与拓展身份不匹配"),
+                cors_origin.as_deref(),
+            );
+            return;
+        }
+    }
+    let ext_token = match single_header(&request, "X-Extension-Token") {
+        Ok(value) => value,
+        Err(error) => {
+            respond_error(request, error, cors_origin.as_deref());
+            return;
+        }
+    };
+    if let Err(error) = authenticate(&ctx, ext_name.as_deref(), ext_token.as_deref()) {
+        respond_error(request, error, cors_origin.as_deref());
+        return;
+    }
     let ext_name = ext_name.unwrap();
 
-    // 路由
-    let result = match (&method, url.as_str()) {
-        // ---- 宿主信息 ----
-        (tiny_http::Method::Get, "/api/v1/info") => handle_info(&ctx, &ext_name),
-
-        // ---- 阅读器 ----
-        (_, u) if u.starts_with("/api/v1/reader/") => {
-            handle_reader(&ctx, &ext_name, &method, u, &body)
+    let body = match read_request_body(&mut request) {
+        Ok(body) => body,
+        Err(error) => {
+            respond_error(request, error, cors_origin.as_deref());
+            return;
         }
+    };
 
-        // ---- 拓展存储（列出所有 key） ----
+    let result = match (&method, url.as_str()) {
+        (tiny_http::Method::Get, "/api/v1/info") => handle_info(&ctx, &ext_name),
+        (_, path) if path.starts_with("/api/v1/reader/") => {
+            handle_reader(&ctx, &ext_name, &method, path, &body)
+        }
         (tiny_http::Method::Get, "/api/v1/extension/storage") => {
             handle_ext_storage_list(&ctx, &ext_name)
         }
-
-        // ---- 拓展自管理 ----
         (tiny_http::Method::Post, "/api/v1/extension/sidebar/add") => {
             handle_ext_sidebar_add(&ctx, &ext_name, &body)
         }
         (tiny_http::Method::Post, "/api/v1/extension/page/register") => {
             handle_ext_page_register(&ctx, &ext_name, &body)
         }
-        (_, u) if u.starts_with("/api/v1/extension/storage/") => {
-            handle_ext_storage(&ctx, &ext_name, &method, u, &body)
+        (_, path) if path.starts_with("/api/v1/extension/storage/") => {
+            handle_ext_storage(&ctx, &ext_name, &method, path, &body)
         }
-
-        // ---- 404 ----
         _ => Err(ApiError::not_found("未找到")),
     };
 
     match result {
-        Ok(body) => {
-            let response = tiny_http::Response::from_string(body)
-                .with_header(cors_header)
-                .with_header(
-                    tiny_http::Header::from_bytes(&b"Content-Type"[..], &b"application/json"[..])
-                        .unwrap(),
-                );
-            let _ = request.respond(response);
-        }
-        Err(error) => {
-            let body = serde_json::json!({
-                "code": error.code,
-                "error": error.message,
-            })
-            .to_string();
-            let response = tiny_http::Response::from_string(body)
-                .with_status_code(error.status)
-                .with_header(cors_header)
-                .with_header(
-                    tiny_http::Header::from_bytes(&b"Content-Type"[..], &b"application/json"[..])
-                        .unwrap(),
-                );
-            let _ = request.respond(response);
-        }
+        Ok(body) => respond_json(request, 200, body, cors_origin.as_deref()),
+        Err(error) => respond_error(request, error, cors_origin.as_deref()),
     }
 }
 
@@ -439,17 +691,17 @@ fn authenticate(
     ctx: &ServerContext,
     ext_name: Option<&str>,
     ext_token: Option<&str>,
-) -> Result<(), String> {
-    let name = ext_name.ok_or("缺少 X-Extension-Name 头".to_string())?;
-    let token = ext_token.ok_or("缺少 X-Extension-Token 头".to_string())?;
+) -> Result<(), ApiError> {
+    let name = ext_name.ok_or_else(|| ApiError::unauthorized("缺少 X-Extension-Name 头"))?;
+    let token = ext_token.ok_or_else(|| ApiError::unauthorized("缺少 X-Extension-Token 头"))?;
 
     let enabled = ctx.enabled.lock().unwrap();
     let ext = enabled
         .get(name)
-        .ok_or_else(|| format!("拓展「{name}」未启用或不存在"))?;
+        .ok_or_else(|| ApiError::unauthorized(format!("拓展「{name}」未启用或不存在")))?;
 
-    if ext.token != token {
-        return Err("token 无效".into());
+    if !super::security::token_matches(&ext.token, token) {
+        return Err(ApiError::unauthorized("token 无效"));
     }
 
     Ok(())
@@ -1139,5 +1391,44 @@ mod tests {
             invalid["result"],
             serde_json::json!({"command": "legacy", "value": 42})
         );
+    }
+
+    #[test]
+    fn cors_preflight_header_policy_matches_actual_api_headers() {
+        assert!(validate_requested_headers(Some(
+            "content-type, X-Extension-Name, x-extension-token",
+        ))
+        .is_ok());
+        let error = validate_requested_headers(Some("X-Extension-Name, X-Evil")).unwrap_err();
+        assert_eq!(error.status, 403);
+        assert_eq!(error.code, "CORS_HEADER_FORBIDDEN");
+    }
+
+    #[test]
+    fn body_and_concurrency_limits_have_stable_errors() {
+        let body_error = ApiError::payload_too_large();
+        assert_eq!(body_error.status, 413);
+        assert_eq!(body_error.code, "PAYLOAD_TOO_LARGE");
+
+        let limiter = Arc::new(RequestLimiter::default());
+        let permits: Vec<_> = (0..MAX_CONCURRENT_REQUESTS)
+            .map(|_| limiter.try_acquire().expect("capacity available"))
+            .collect();
+        assert!(limiter.try_acquire().is_none());
+        drop(permits);
+        assert!(limiter.try_acquire().is_some());
+    }
+
+    #[test]
+    fn oversized_and_authentication_errors_are_stable_without_echoing_credentials() {
+        let auth_error = ApiError::unauthorized("token 无效");
+        let body_error = ApiError::payload_too_large();
+        assert_eq!((auth_error.status, auth_error.code), (401, "AUTH_FAILED"));
+        assert_eq!(
+            (body_error.status, body_error.code),
+            (413, "PAYLOAD_TOO_LARGE")
+        );
+        assert!(!auth_error.message.contains("moke_ext_"));
+        assert!(!body_error.message.contains("moke_ext_"));
     }
 }

--- a/src-tauri/src/extensions/events.rs
+++ b/src-tauri/src/extensions/events.rs
@@ -1,15 +1,23 @@
 //! WebSocket 事件服务器 + Tauri event 桥接。
 //!
-//! 单线程事件循环：accept 新连接、接收认证/订阅、接收广播、发送消息。
-//! 支持事件重放：新客户端订阅时，立即回放最近一次该类型事件的缓存数据。
+//! 单线程事件循环负责广播与已认证客户端；握手在有并发上限和超时的
+//! 工作线程中完成，避免慢连接阻塞现有事件。支持最近事件重放。
 
+use super::security::ValidatedOrigin;
 use super::EnabledExtension;
 use std::collections::HashMap;
 use std::net::TcpListener;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::mpsc::{self, Sender};
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Duration;
+
+const WS_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(5);
+const MAX_WS_CLIENTS: usize = 32;
+const MAX_PENDING_WS_HANDSHAKES: usize = 8;
+const MAX_WS_MESSAGE_BYTES: usize = 64 * 1024;
+const MAX_WS_SUBSCRIPTIONS: usize = 64;
 
 // ---------------------------------------------------------------------------
 // 数据结构
@@ -31,17 +39,54 @@ struct Client {
     last_activity: std::time::Instant,
 }
 
+struct HandshakePermit {
+    pending: Arc<AtomicUsize>,
+}
+
+impl HandshakePermit {
+    fn try_acquire(pending: &Arc<AtomicUsize>) -> Option<Self> {
+        let mut count = pending.load(Ordering::Acquire);
+        loop {
+            if count >= MAX_PENDING_WS_HANDSHAKES {
+                return None;
+            }
+            match pending.compare_exchange_weak(
+                count,
+                count + 1,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => {
+                    return Some(Self {
+                        pending: pending.clone(),
+                    })
+                }
+                Err(current) => count = current,
+            }
+        }
+    }
+}
+
+impl Drop for HandshakePermit {
+    fn drop(&mut self) {
+        self.pending.fetch_sub(1, Ordering::AcqRel);
+    }
+}
+
 // ---------------------------------------------------------------------------
 // 公开接口
 // ---------------------------------------------------------------------------
 
 /// 启动 WebSocket 服务器，返回 (实际端口, 广播发送端)。
-/// 如果首选端口被占用，自动尝试下一个端口（最多 10 次）。
+/// `start_port == 0` 时由操作系统为本次会话分配随机回环端口。
 pub fn start(
     enabled: Arc<Mutex<HashMap<String, EnabledExtension>>>,
     start_port: u16,
 ) -> (u16, Sender<WsBroadcast>) {
     let (tx, rx) = mpsc::channel::<WsBroadcast>();
+    let (authenticated_tx, authenticated_rx) =
+        mpsc::sync_channel::<Client>(MAX_PENDING_WS_HANDSHAKES);
+    let pending_handshakes = Arc::new(AtomicUsize::new(0));
 
     let mut port = start_port;
     let listener = loop {
@@ -54,9 +99,7 @@ pub fn start(
             Err(e) => panic!("无法启动 WS Server (尝试了 {start_port}-{port}): {e}"),
         }
     };
-    listener
-        .set_nonblocking(true)
-        .expect("无法设置非阻塞模式");
+    listener.set_nonblocking(true).expect("无法设置非阻塞模式");
 
     let actual_port = listener.local_addr().unwrap().port();
     log::info!("拓展 WS Server 已启动: ws://127.0.0.1:{actual_port}");
@@ -75,35 +118,33 @@ pub fn start(
             match listener.accept() {
                 Ok((stream, addr)) => {
                     log::info!("WS 新连接: {addr}");
-
-                    let mut ws = match tungstenite::accept(stream) {
-                        Ok(w) => w,
-                        Err(e) => {
-                            log::warn!("WS 握手失败: {e}");
-                            continue;
-                        }
+                    if clients.len() + pending_handshakes.load(Ordering::Acquire) >= MAX_WS_CLIENTS
+                    {
+                        log::warn!("WS 客户端已达上限（{MAX_WS_CLIENTS}），拒绝新连接");
+                        drop(stream);
+                        continue;
+                    }
+                    let Some(permit) = HandshakePermit::try_acquire(&pending_handshakes) else {
+                        log::warn!(
+                            "WS 待认证连接已达上限（{MAX_PENDING_WS_HANDSHAKES}），拒绝新连接"
+                        );
+                        drop(stream);
+                        continue;
                     };
 
-                    // 读取认证和订阅消息（非阻塞超时）
-                    match authenticate_and_subscribe(&mut ws, &enabled) {
-                        Ok((name, subs)) => {
-                            log::info!("WS 认证成功: {name}, 订阅: {subs:?}");
-
-                            // 重放已缓存的事件
-                            replay_events(&mut ws, &subs, &last_events);
-
-                            clients.push(Client {
-                                ws,
-                                extension_name: name,
-                                subscriptions: subs,
-                                last_activity: std::time::Instant::now(),
-                            });
+                    let enabled = enabled.clone();
+                    let authenticated_tx = authenticated_tx.clone();
+                    thread::spawn(move || {
+                        let _permit = permit;
+                        match accept_and_authenticate(stream, &enabled, actual_port) {
+                            Ok(client) => {
+                                if authenticated_tx.try_send(client).is_err() {
+                                    log::warn!("WS 已认证连接队列已满，关闭连接");
+                                }
+                            }
+                            Err(error) => log::warn!("WS 连接认证失败: {error}"),
                         }
-                        Err(e) => {
-                            log::warn!("WS 认证失败: {e}");
-                            let _ = ws.close(None);
-                        }
-                    }
+                    });
                 }
                 Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
                     // 无新连接，继续处理
@@ -113,59 +154,73 @@ pub fn start(
                 }
             }
 
-            // 2. 处理广播（同时更新缓存）
+            // 2. 接入已完成握手的客户端。握手在受限线程中进行，慢速或
+            // 恶意握手不会阻塞事件广播和现有客户端心跳。
+            while let Ok(mut client) = authenticated_rx.try_recv() {
+                if clients.len() >= MAX_WS_CLIENTS {
+                    let _ = client.ws.close(None);
+                    continue;
+                }
+                log::info!(
+                    "WS 认证成功: {}, 订阅: {:?}",
+                    client.extension_name,
+                    client.subscriptions
+                );
+                replay_events(&mut client.ws, &client.subscriptions, &last_events);
+                clients.push(client);
+            }
+
+            // 3. 处理广播（同时更新缓存）
             while let Ok(msg) = rx.try_recv() {
                 let payload = build_payload(&msg);
                 last_events.insert(msg.event.clone(), payload.clone());
                 broadcast_to_clients(&mut clients, &msg.event, &payload);
             }
 
-            // 3. 处理客户端消息（pong、unsubscribe 等）并清理断线
-            clients.retain_mut(|client| {
-                match client.ws.read() {
-                    Ok(tungstenite::Message::Text(text)) => {
-                        client.last_activity = std::time::Instant::now();
-                        if text == "ping" {
-                            let _ = client.ws.send(tungstenite::Message::Text("pong".into()));
-                        }
-                        true
+            // 4. 处理客户端消息（pong、unsubscribe 等）并清理断线
+            clients.retain_mut(|client| match client.ws.read() {
+                Ok(tungstenite::Message::Text(text)) => {
+                    client.last_activity = std::time::Instant::now();
+                    if text == "ping" {
+                        let _ = client.ws.send(tungstenite::Message::Text("pong".into()));
                     }
-                    Ok(tungstenite::Message::Binary(_)) => {
-                        client.last_activity = std::time::Instant::now();
-                        true
-                    }
-                    Ok(tungstenite::Message::Ping(data)) => {
-                        client.last_activity = std::time::Instant::now();
-                        let _ = client.ws.send(tungstenite::Message::Pong(data));
-                        true
-                    }
-                    Ok(tungstenite::Message::Pong(_)) => {
-                        client.last_activity = std::time::Instant::now();
-                        true
-                    }
-                    Ok(tungstenite::Message::Close(_)) => {
-                        log::info!("WS 客户端断开: {}", client.extension_name);
-                        false
-                    }
-                    Err(tungstenite::Error::ConnectionClosed)
-                    | Err(tungstenite::Error::AlreadyClosed) => {
-                        log::info!("WS 连接关闭: {}", client.extension_name);
-                        false
-                    }
-                    Err(tungstenite::Error::Io(ref io))
-                        if io.kind() == std::io::ErrorKind::WouldBlock =>
-                    {
-                        true
-                    }
-                    Err(e) => {
-                        log::warn!("WS 错误 ({}): {e}", client.extension_name);
-                        false
-                    }
-                    _ => true,
+                    true
                 }
+                Ok(tungstenite::Message::Binary(_)) => {
+                    client.last_activity = std::time::Instant::now();
+                    true
+                }
+                Ok(tungstenite::Message::Ping(data)) => {
+                    client.last_activity = std::time::Instant::now();
+                    let _ = client.ws.send(tungstenite::Message::Pong(data));
+                    true
+                }
+                Ok(tungstenite::Message::Pong(_)) => {
+                    client.last_activity = std::time::Instant::now();
+                    true
+                }
+                Ok(tungstenite::Message::Close(_)) => {
+                    log::info!("WS 客户端断开: {}", client.extension_name);
+                    false
+                }
+                Err(tungstenite::Error::ConnectionClosed)
+                | Err(tungstenite::Error::AlreadyClosed) => {
+                    log::info!("WS 连接关闭: {}", client.extension_name);
+                    false
+                }
+                Err(tungstenite::Error::Io(ref io))
+                    if io.kind() == std::io::ErrorKind::WouldBlock =>
+                {
+                    true
+                }
+                Err(e) => {
+                    log::warn!("WS 错误 ({}): {e}", client.extension_name);
+                    false
+                }
+                _ => true,
             });
 
-            // 4. 心跳：定期 ping 客户端 + 清理超时连接
+            // 5. 心跳：定期 ping 客户端 + 清理超时连接
             tick = tick.wrapping_add(1);
             if tick % HEARTBEAT_INTERVAL == 0 {
                 let now = std::time::Instant::now();
@@ -182,17 +237,14 @@ pub fn start(
                     }
                     // 发送 WebSocket Ping，接收方自动回复 Pong
                     if let Err(e) = client.ws.send(tungstenite::Message::Ping(vec![])) {
-                        log::warn!(
-                            "[ext] WS ping 失败 ({}): {e}",
-                            client.extension_name
-                        );
+                        log::warn!("[ext] WS ping 失败 ({}): {e}", client.extension_name);
                         return false;
                     }
                     true
                 });
             }
 
-            // 5. 短暂休眠避免忙等
+            // 6. 短暂休眠避免忙等
             thread::sleep(Duration::from_millis(50));
         }
     });
@@ -204,9 +256,111 @@ pub fn start(
 // 认证与订阅
 // ---------------------------------------------------------------------------
 
+fn accept_and_authenticate(
+    stream: std::net::TcpStream,
+    enabled: &Arc<Mutex<HashMap<String, EnabledExtension>>>,
+    actual_port: u16,
+) -> Result<Client, String> {
+    stream
+        .set_read_timeout(Some(WS_HANDSHAKE_TIMEOUT))
+        .map_err(|error| format!("设置 WS 握手读取超时失败: {error}"))?;
+    stream
+        .set_write_timeout(Some(WS_HANDSHAKE_TIMEOUT))
+        .map_err(|error| format!("设置 WS 握手写入超时失败: {error}"))?;
+
+    let mut origin_extension = None;
+    let expected_host = super::security::expected_authority(actual_port);
+    let enabled_for_handshake = enabled.clone();
+    let config = tungstenite::protocol::WebSocketConfig {
+        write_buffer_size: 16 * 1024,
+        max_write_buffer_size: 128 * 1024,
+        max_message_size: Some(MAX_WS_MESSAGE_BYTES),
+        max_frame_size: Some(MAX_WS_MESSAGE_BYTES),
+        ..Default::default()
+    };
+    let mut ws = tungstenite::accept_hdr_with_config(
+        stream,
+        |request: &tungstenite::handshake::server::Request, response| {
+            let hosts: Vec<_> = request
+                .headers()
+                .get_all(tungstenite::http::header::HOST)
+                .iter()
+                .collect();
+            let host = hosts.first().and_then(|value| value.to_str().ok());
+            if hosts.len() != 1 || host != Some(expected_host.as_str()) {
+                return Err(handshake_error(
+                    tungstenite::http::StatusCode::FORBIDDEN,
+                    "INVALID_HOST",
+                    "Host 必须是当前回环监听地址",
+                ));
+            }
+
+            let origins: Vec<_> = request
+                .headers()
+                .get_all(tungstenite::http::header::ORIGIN)
+                .iter()
+                .collect();
+            if origins.len() > 1 {
+                return Err(handshake_error(
+                    tungstenite::http::StatusCode::BAD_REQUEST,
+                    "DUPLICATE_ORIGIN",
+                    "Origin 头不能重复",
+                ));
+            }
+            let origin = origins.first().and_then(|value| value.to_str().ok());
+            let validated = {
+                let enabled = enabled_for_handshake.lock().unwrap();
+                super::security::validate_origin(origin, &enabled)
+            }
+            .map_err(|message| {
+                handshake_error(
+                    tungstenite::http::StatusCode::FORBIDDEN,
+                    "INVALID_ORIGIN",
+                    message,
+                )
+            })?;
+            if let ValidatedOrigin::Extension { name, .. } = validated {
+                origin_extension = Some(name);
+            }
+            Ok(response)
+        },
+        Some(config),
+    )
+    .map_err(|error| format!("WS 握手失败: {error}"))?;
+
+    // 即使来源是受信拓展页面也必须持有 token；浏览器来源本身不是凭据。
+    let (extension_name, subscriptions) =
+        authenticate_and_subscribe(&mut ws, enabled, origin_extension.as_deref())?;
+    Ok(Client {
+        ws,
+        extension_name,
+        subscriptions,
+        last_activity: std::time::Instant::now(),
+    })
+}
+
+fn handshake_error(
+    status: tungstenite::http::StatusCode,
+    code: &'static str,
+    message: &str,
+) -> tungstenite::handshake::server::ErrorResponse {
+    tungstenite::http::Response::builder()
+        .status(status)
+        .header(
+            tungstenite::http::header::CONTENT_TYPE,
+            "application/json; charset=utf-8",
+        )
+        .header("X-Content-Type-Options", "nosniff")
+        .body(Some(
+            serde_json::json!({"code": code, "error": message}).to_string(),
+        ))
+        .expect("valid WS rejection response")
+}
+
 fn authenticate_and_subscribe(
     ws: &mut tungstenite::WebSocket<std::net::TcpStream>,
     enabled: &Arc<Mutex<HashMap<String, EnabledExtension>>>,
+    origin_extension: Option<&str>,
 ) -> Result<(String, Vec<String>), String> {
     // 显式设为阻塞模式 + 5 秒超时（Windows 上 set_read_timeout 不会自动从 nonblocking 切回）
     ws.get_mut()
@@ -246,25 +400,35 @@ fn authenticate_and_subscribe(
     let data: serde_json::Value =
         serde_json::from_str(&msg).map_err(|_| "握手 JSON 解析失败".to_string())?;
 
+    if data["type"].as_str() != Some("hello") {
+        return Err("握手 type 必须是 hello".into());
+    }
     let ext_name = data["extension"].as_str().unwrap_or("").to_string();
     let token = data["token"].as_str().unwrap_or("");
+    if ext_name.is_empty() || ext_name.len() > 64 {
+        return Err("拓展名称无效".into());
+    }
+    if origin_extension.is_some_and(|expected| expected != ext_name) {
+        return Err("Origin 与拓展身份不匹配".into());
+    }
 
     {
         let enabled_map = enabled.lock().unwrap();
         match enabled_map.get(&ext_name) {
-            Some(ext) if ext.token == token => { /* OK */ }
+            Some(ext) if super::security::token_matches(&ext.token, token) => { /* OK */ }
             _ => return Err("token 无效或拓展未启用".into()),
         }
     }
 
-    let subscriptions: Vec<String> = data["events"]
-        .as_array()
-        .map(|arr| {
-            arr.iter()
-                .filter_map(|v| v.as_str().map(String::from))
-                .collect()
-        })
-        .unwrap_or_default();
+    let events = data["events"].as_array().cloned().unwrap_or_default();
+    if events.len() > MAX_WS_SUBSCRIPTIONS {
+        return Err(format!("订阅事件不能超过 {MAX_WS_SUBSCRIPTIONS} 个"));
+    }
+    let subscriptions: Vec<String> = events
+        .into_iter()
+        .filter_map(|value| value.as_str().map(String::from))
+        .filter(|event| !event.is_empty() && event.len() <= 128)
+        .collect();
 
     // 设为非阻塞模式（set_read_timeout(None) = 无限阻塞，会卡死主循环！）
     ws.get_mut()
@@ -319,5 +483,22 @@ fn replay_events(
                 log::info!("WS 事件重放: {sub}");
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pending_handshake_limit_is_bounded_and_released() {
+        let pending = Arc::new(AtomicUsize::new(0));
+        let permits: Vec<_> = (0..MAX_PENDING_WS_HANDSHAKES)
+            .map(|_| HandshakePermit::try_acquire(&pending).unwrap())
+            .collect();
+        assert!(HandshakePermit::try_acquire(&pending).is_none());
+        drop(permits);
+        assert_eq!(pending.load(Ordering::Acquire), 0);
+        assert!(HandshakePermit::try_acquire(&pending).is_some());
     }
 }

--- a/src-tauri/src/extensions/lifecycle.rs
+++ b/src-tauri/src/extensions/lifecycle.rs
@@ -1,7 +1,8 @@
 //! 拓展生命周期管理：启用/禁用/卸载、后端进程启停、状态持久化。
 
-use super::{EnabledExtension, BackendConfig, Manifest};
+use super::{BackendConfig, EnabledExtension, Manifest};
 use std::collections::HashMap;
+use std::io::Write;
 use std::path::Path;
 use std::sync::atomic::{AtomicU16, Ordering};
 use std::sync::{Arc, Mutex};
@@ -47,7 +48,11 @@ pub fn allocate_port(next_port: &Arc<AtomicU16>, port_range_start: u16) -> u16 {
 pub fn reserve_after_port(next_port: &Arc<AtomicU16>, used_port: u16) {
     let next = used_port.saturating_add(1).clamp(PORT_MIN, PORT_MAX);
     let _ = next_port.fetch_update(Ordering::SeqCst, Ordering::SeqCst, |current| {
-        if current <= used_port { Some(next) } else { None }
+        if current <= used_port {
+            Some(next)
+        } else {
+            None
+        }
     });
 }
 
@@ -73,10 +78,7 @@ pub fn start_backend(
     let exe_path = ext_dir.join(&backend.executable);
 
     if !exe_path.exists() {
-        return Err(format!(
-            "后端可执行文件不存在: {}",
-            exe_path.display()
-        ));
+        return Err(format!("后端可执行文件不存在: {}", exe_path.display()));
     }
 
     // 构建参数，替换 {EXT_PORT} 占位符
@@ -92,7 +94,10 @@ pub fn start_backend(
         .current_dir(ext_dir)
         .env_clear()
         // 最基本的 Windows 运行环境
-        .env("SYSTEMROOT", std::env::var("SYSTEMROOT").unwrap_or_else(|_| "C:\\Windows".into()))
+        .env(
+            "SYSTEMROOT",
+            std::env::var("SYSTEMROOT").unwrap_or_else(|_| "C:\\Windows".into()),
+        )
         .env("PATH", std::env::var("PATH").unwrap_or_default())
         // 传递 token 和宿主服务端口，拓展后端可通过环境变量获取
         .env("MOKE_EXT_TOKEN", token)
@@ -122,11 +127,7 @@ pub fn start_backend(
         ));
     }
 
-    log::info!(
-        "启动拓展后端: {} (PID: {})",
-        exe_path.display(),
-        child.id()
-    );
+    log::info!("启动拓展后端: {} (PID: {})", exe_path.display(), child.id());
 
     Ok(child)
 }
@@ -143,8 +144,46 @@ struct RuntimeStateFile {
 
 #[derive(serde::Serialize, serde::Deserialize)]
 struct PersistedExtension {
-    token: String,
+    #[serde(default)]
     port: u16,
+}
+
+pub fn secure_extensions_directory(path: &Path) -> Result<(), String> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700))
+            .map_err(|error| format!("限制拓展目录权限失败: {error}"))?;
+    }
+    Ok(())
+}
+
+fn write_private_file(path: &Path, contents: &[u8]) -> Result<(), String> {
+    let mut options = std::fs::OpenOptions::new();
+    options.create(true).truncate(true).write(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let mut file = options
+        .open(path)
+        .map_err(|error| format!("写入临时状态文件失败: {error}"))?;
+    file.write_all(contents)
+        .map_err(|error| format!("写入临时状态文件失败: {error}"))?;
+    file.sync_all()
+        .map_err(|error| format!("同步临时状态文件失败: {error}"))?;
+    Ok(())
+}
+
+fn restrict_file_permissions(path: &Path) -> Result<(), String> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
+            .map_err(|error| format!("限制运行时状态文件权限失败: {error}"))?;
+    }
+    Ok(())
 }
 
 /// 将当前已启用的拓展状态写入文件。
@@ -156,32 +195,27 @@ pub fn save_runtime_state(
 
     let persisted: HashMap<String, PersistedExtension> = enabled
         .iter()
-        .map(|(name, ext)| {
-            (
-                name.clone(),
-                PersistedExtension {
-                    token: ext.token.clone(),
-                    port: ext.port,
-                },
-            )
-        })
+        .map(|(name, ext)| (name.clone(), PersistedExtension { port: ext.port }))
         .collect();
 
-    let state = RuntimeStateFile {
-        enabled: persisted,
-    };
+    let state = RuntimeStateFile { enabled: persisted };
 
-    let json = serde_json::to_string_pretty(&state)
-        .map_err(|e| format!("序列化运行时状态失败: {e}"))?;
+    let json =
+        serde_json::to_string_pretty(&state).map_err(|e| format!("序列化运行时状态失败: {e}"))?;
 
     let path = extensions_dir.join(RUNTIME_STATE_FILE);
 
-    // 先写临时文件，再原子替换（防写入过程中断电导致文件损坏）
+    // 先以仅当前用户可读写的权限写临时文件，再原子替换。旧版本
+    // runtime.json 中的 token 会在这次保存后被迁移移除。
     let tmp_path = extensions_dir.join("runtime.tmp");
-    std::fs::write(&tmp_path, &json)
-        .map_err(|e| format!("写入临时状态文件失败: {e}"))?;
-    std::fs::rename(&tmp_path, &path)
-        .map_err(|e| format!("替换状态文件失败: {e}"))?;
+    write_private_file(&tmp_path, json.as_bytes())?;
+    #[cfg(target_os = "windows")]
+    if path.exists() {
+        // std::fs::rename does not replace an existing destination on Windows.
+        std::fs::remove_file(&path).map_err(|e| format!("移除旧状态文件失败: {e}"))?;
+    }
+    std::fs::rename(&tmp_path, &path).map_err(|e| format!("替换状态文件失败: {e}"))?;
+    restrict_file_permissions(&path)?;
 
     Ok(())
 }
@@ -237,10 +271,20 @@ pub fn restore_runtime_state_inner(
             }
         };
 
+        // Tokens are session credentials: rotate on every Moke start and pass
+        // the new value only to the extension backend environment.
+        let session_token = generate_token();
         let backend_child = if let Some(entry) = &manifest.entry {
             if let Some(backend) = &entry.backend {
                 let ext_dir = extensions_dir.join(&name);
-                match start_backend(&ext_dir, backend, persisted.port, &persisted.token, api_port, ws_port) {
+                match start_backend(
+                    &ext_dir,
+                    backend,
+                    persisted.port,
+                    &session_token,
+                    api_port,
+                    ws_port,
+                ) {
                     Ok(child) => Some(child),
                     Err(e) => {
                         log::warn!("恢复拓展「{name}」后端失败: {e}");
@@ -261,7 +305,7 @@ pub fn restore_runtime_state_inner(
         enabled.insert(
             name.clone(),
             EnabledExtension {
-                token: persisted.token,
+                token: session_token,
                 port: persisted.port,
                 backend: Mutex::new(backend_child),
             },
@@ -271,4 +315,83 @@ pub fn restore_runtime_state_inner(
     }
 
     restored_ports
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_extensions_dir(label: &str) -> std::path::PathBuf {
+        let path = std::env::temp_dir().join(format!(
+            "moke-extension-lifecycle-{label}-{}",
+            Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&path).unwrap();
+        path
+    }
+
+    #[test]
+    fn runtime_state_never_serializes_session_tokens() {
+        let directory = temp_extensions_dir("no-token");
+        let enabled = Arc::new(Mutex::new(HashMap::from([(
+            "sample".into(),
+            EnabledExtension {
+                token: "must-not-be-persisted".into(),
+                port: 24001,
+                backend: Mutex::new(None),
+            },
+        )])));
+
+        save_runtime_state(&directory, &enabled).unwrap();
+        let raw = std::fs::read_to_string(directory.join(RUNTIME_STATE_FILE)).unwrap();
+        assert!(!raw.contains("must-not-be-persisted"));
+        assert!(!raw.contains("\"token\""));
+        assert!(raw.contains("24001"));
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = std::fs::metadata(directory.join(RUNTIME_STATE_FILE))
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777;
+            assert_eq!(mode, 0o600);
+        }
+        let _ = std::fs::remove_dir_all(directory);
+    }
+
+    #[test]
+    fn legacy_plaintext_token_is_ignored_and_rotated_on_restore() {
+        let directory = temp_extensions_dir("legacy-token");
+        std::fs::create_dir_all(directory.join("legacy")).unwrap();
+        std::fs::write(
+            directory.join("legacy/manifest.json"),
+            r#"{
+                "name":"legacy",
+                "version":"1.0.0",
+                "display_name":"Legacy"
+            }"#,
+        )
+        .unwrap();
+        std::fs::write(
+            directory.join(RUNTIME_STATE_FILE),
+            r#"{"enabled":{"legacy":{"token":"legacy-plaintext-secret","port":0}}}"#,
+        )
+        .unwrap();
+        let enabled = Arc::new(Mutex::new(HashMap::new()));
+
+        restore_runtime_state_inner(&directory, &enabled, 31001, 31002);
+        let restored = enabled.lock().unwrap();
+        let token = &restored.get("legacy").unwrap().token;
+        assert!(token.starts_with("moke_ext_"));
+        assert_ne!(token, "legacy-plaintext-secret");
+        drop(restored);
+
+        save_runtime_state(&directory, &enabled).unwrap();
+        let migrated = std::fs::read_to_string(directory.join(RUNTIME_STATE_FILE)).unwrap();
+        assert!(!migrated.contains("legacy-plaintext-secret"));
+        assert!(!migrated.contains("\"token\""));
+        let _ = std::fs::remove_dir_all(directory);
+    }
 }

--- a/src-tauri/src/extensions/mod.rs
+++ b/src-tauri/src/extensions/mod.rs
@@ -7,6 +7,7 @@ mod discovery;
 mod events;
 mod lifecycle;
 mod permissions;
+mod security;
 mod storage;
 
 use std::collections::HashMap;
@@ -602,8 +603,12 @@ fn ext_moke_list_offline_books(app: AppHandle) -> Result<Vec<MokeOfflineBookInfo
 // ---------------------------------------------------------------------------
 
 /// 常量
-const API_SERVER_PORT: u16 = 19555;
-const WS_SERVER_PORT: u16 = 19556;
+// Host transports use OS-assigned ports so a stale fixed endpoint is never a
+// cross-session capability. Extension backends receive the actual values only
+// through their sanitized process environment.
+const API_SERVER_PORT: u16 = 0;
+const WS_SERVER_PORT: u16 = 0;
+const EXTENSION_PORT_START: u16 = 19557;
 
 /// 创建 `ExtensionRuntime` 并注入到 Tauri app state。
 /// 同时启动 API Server（REST + WebSocket）。
@@ -619,6 +624,8 @@ pub fn init(app: &AppHandle) {
 
     if let Err(e) = std::fs::create_dir_all(&extensions_dir) {
         log::error!("无法创建拓展目录「{}」: {e}", extensions_dir.display());
+    } else if let Err(e) = lifecycle::secure_extensions_directory(&extensions_dir) {
+        log::warn!("{e}");
     }
 
     let enabled = Arc::new(Mutex::new(HashMap::new()));
@@ -638,8 +645,9 @@ pub fn init(app: &AppHandle) {
     });
     let api_port = api_server::start(api_ctx, API_SERVER_PORT);
 
-    // 3. 拓展端口从 server 之后开始，避免冲突
-    let port_range_start = u16::max(api_port, ws_port) + 1;
+    // 3. 拓展 UI/backend 端口仍使用兼容范围；随机宿主端口由操作系统
+    // 独占，不会与随后启动的拓展后端重复绑定。
+    let port_range_start = EXTENSION_PORT_START;
 
     // 4. 最后恢复上次的启用状态
     let next_port = Arc::new(AtomicU16::new(port_range_start));
@@ -649,6 +657,11 @@ pub fn init(app: &AppHandle) {
         let restored_ports = lifecycle::restore_runtime_state_inner(&runtime_state, &enabled_clone, api_port, ws_port);
         if let Some(max_port) = restored_ports.into_iter().max() {
             lifecycle::reserve_after_port(&next_port, max_port);
+        }
+        // Rewrite legacy runtime.json files immediately so persisted plaintext
+        // tokens are removed even if the user never toggles an extension.
+        if let Err(error) = lifecycle::save_runtime_state(&runtime_state, &enabled_clone) {
+            log::warn!("迁移拓展运行时状态失败: {error}");
         }
     }
 

--- a/src-tauri/src/extensions/security.rs
+++ b/src-tauri/src/extensions/security.rs
@@ -1,0 +1,169 @@
+//! Shared loopback transport security checks for the extension HTTP and WS servers.
+//!
+//! Binding to `127.0.0.1` is not by itself a browser security boundary: a DNS
+//! rebinding page can still address the listener. Both transports therefore
+//! require the literal loopback authority and only recognize browser origins
+//! belonging to a currently enabled extension UI.
+
+use super::EnabledExtension;
+use std::collections::HashMap;
+
+pub(crate) const LOOPBACK_HOST: &str = "127.0.0.1";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ValidatedOrigin {
+    /// Native extension backends do not send an Origin header. They still have
+    /// to authenticate with their session token at the application layer.
+    Backend,
+    /// Browser requests are accepted only from an enabled extension's exact
+    /// loopback UI origin. The extension name is used to prevent one extension
+    /// origin from exercising another extension's token.
+    Extension { value: String, name: String },
+}
+
+pub(crate) fn expected_authority(port: u16) -> String {
+    format!("{LOOPBACK_HOST}:{port}")
+}
+
+pub(crate) fn validate_host(host: Option<&str>, port: u16) -> bool {
+    host.is_some_and(|value| value.trim() == expected_authority(port))
+}
+
+pub(crate) fn extension_origin(port: u16) -> Option<String> {
+    (port > 0).then(|| format!("http://{}", expected_authority(port)))
+}
+
+pub(crate) fn validate_origin(
+    origin: Option<&str>,
+    enabled: &HashMap<String, EnabledExtension>,
+) -> Result<ValidatedOrigin, &'static str> {
+    let Some(origin) = origin else {
+        return Ok(ValidatedOrigin::Backend);
+    };
+
+    // Be deliberately strict: browser-generated origins use this exact form.
+    // In particular, `localhost`, DNS names resolving to loopback, `null`, user
+    // info, paths, and trailing slashes are not equivalent authorities.
+    let mut matched_name: Option<String> = None;
+    for (name, extension) in enabled {
+        if extension_origin(extension.port).as_deref() == Some(origin) {
+            // Duplicate runtime ports must fail closed rather than make the
+            // browser identity depend on HashMap iteration order.
+            if matched_name.is_some() {
+                return Err("拓展来源端口不唯一");
+            }
+            matched_name = Some(name.clone());
+        }
+    }
+
+    matched_name
+        .map(|name| ValidatedOrigin::Extension {
+            value: origin.to_string(),
+            name,
+        })
+        .ok_or("不允许的 Origin")
+}
+
+/// Compare bearer-style session credentials without an early byte mismatch.
+pub(crate) fn token_matches(expected: &str, supplied: &str) -> bool {
+    let expected = expected.as_bytes();
+    let supplied = supplied.as_bytes();
+    let mut difference = expected.len() ^ supplied.len();
+    let max_len = expected.len().max(supplied.len());
+
+    for index in 0..max_len {
+        let left = expected.get(index).copied().unwrap_or(0);
+        let right = supplied.get(index).copied().unwrap_or(0);
+        difference |= usize::from(left ^ right);
+    }
+
+    difference == 0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    fn enabled_extensions() -> HashMap<String, EnabledExtension> {
+        HashMap::from([
+            (
+                "reader-tools".into(),
+                EnabledExtension {
+                    token: "session-a".into(),
+                    port: 24001,
+                    backend: Mutex::new(None),
+                },
+            ),
+            (
+                "headless".into(),
+                EnabledExtension {
+                    token: "session-b".into(),
+                    port: 0,
+                    backend: Mutex::new(None),
+                },
+            ),
+        ])
+    }
+
+    #[test]
+    fn host_must_be_the_literal_listener_authority() {
+        assert!(validate_host(Some("127.0.0.1:19555"), 19555));
+        assert!(!validate_host(Some("localhost:19555"), 19555));
+        assert!(!validate_host(Some("books.example:19555"), 19555));
+        assert!(!validate_host(Some("127.0.0.1:19556"), 19555));
+        assert!(!validate_host(None, 19555));
+    }
+
+    #[test]
+    fn origin_is_absent_for_backends_or_exact_for_extension_ui() {
+        let enabled = enabled_extensions();
+        assert_eq!(
+            validate_origin(None, &enabled),
+            Ok(ValidatedOrigin::Backend)
+        );
+        assert_eq!(
+            validate_origin(Some("http://127.0.0.1:24001"), &enabled),
+            Ok(ValidatedOrigin::Extension {
+                value: "http://127.0.0.1:24001".into(),
+                name: "reader-tools".into(),
+            })
+        );
+
+        for malicious in [
+            "null",
+            "http://localhost:24001",
+            "http://evil.example:24001",
+            "http://127.0.0.1:24002",
+            "http://127.0.0.1:24001/",
+            "https://127.0.0.1:24001",
+        ] {
+            assert!(
+                validate_origin(Some(malicious), &enabled).is_err(),
+                "{malicious}"
+            );
+        }
+    }
+
+    #[test]
+    fn duplicate_origin_ports_fail_closed() {
+        let mut enabled = enabled_extensions();
+        enabled.insert(
+            "duplicate".into(),
+            EnabledExtension {
+                token: "session-c".into(),
+                port: 24001,
+                backend: Mutex::new(None),
+            },
+        );
+        assert!(validate_origin(Some("http://127.0.0.1:24001"), &enabled).is_err());
+    }
+
+    #[test]
+    fn token_comparison_handles_equal_different_and_length_mismatch() {
+        assert!(token_matches("moke_ext_abc", "moke_ext_abc"));
+        assert!(!token_matches("moke_ext_abc", "moke_ext_abd"));
+        assert!(!token_matches("moke_ext_abc", "moke_ext_abc0"));
+        assert!(!token_matches("", "x"));
+    }
+}

--- a/tests/moke-ext-transport-security.test.mjs
+++ b/tests/moke-ext-transport-security.test.mjs
@@ -1,0 +1,66 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+const read = (path) => readFileSync(join(root, path), 'utf8');
+
+test('extension SDK and example never expose the host session token to browser UI', () => {
+  const browserFacingSources = [
+    'packages/moke-ext/src/commands/init.js',
+    'packages/moke-ext/src/commands/dev.js',
+    'packages/moke-ext/examples/reading-stats/backend/src/main.rs',
+    'packages/moke-ext/examples/reading-stats/ui/index.html',
+  ];
+
+  for (const path of browserFacingSources) {
+    const source = read(path);
+    assert.doesNotMatch(source, /\/api\/token/, `${path} must not expose a token route`);
+    assert.doesNotMatch(
+      source,
+      /Access-Control-Allow-Origin[^\n]*["']\*["']/,
+      `${path} must not grant wildcard CORS`,
+    );
+  }
+
+  const exampleBackend = read('packages/moke-ext/examples/reading-stats/backend/src/main.rs');
+  assert.match(exampleBackend, /env::var\("MOKE_EXT_TOKEN"\)/);
+  assert.match(exampleBackend, /ws_client_loop\(stats, ws_port, token, ext_name\)/);
+});
+
+test('host transport uses session ports and concrete validated CORS origins', () => {
+  const extensionRuntime = read('src-tauri/src/extensions/mod.rs');
+  assert.match(extensionRuntime, /const API_SERVER_PORT: u16 = 0;/);
+  assert.match(extensionRuntime, /const WS_SERVER_PORT: u16 = 0;/);
+
+  const apiServer = read('src-tauri/src/extensions/api_server.rs');
+  assert.doesNotMatch(apiServer, /Access-Control-Allow-Origin"[^\n]*"\*"/);
+  assert.match(apiServer, /Access-Control-Allow-Origin", origin/);
+  const authCall = apiServer.indexOf('authenticate(&ctx');
+  const bodyReadCall = apiServer.indexOf('read_request_body(&mut request)');
+  assert.ok(authCall < bodyReadCall, 'authentication must precede request body reads');
+  const earlyBodyLimit = apiServer.lastIndexOf('validate_body_length(&request)', authCall);
+  assert.ok(
+    earlyBodyLimit >= 0 && earlyBodyLimit < authCall,
+    'declared oversized bodies must be rejected before authentication',
+  );
+  assert.match(apiServer, /MAX_CONCURRENT_REQUESTS/);
+  assert.match(apiServer, /MAX_REQUEST_BODY_BYTES/);
+
+  const events = read('src-tauri/src/extensions/events.rs');
+  assert.match(events, /accept_hdr_with_config/);
+  assert.match(events, /security::validate_origin/);
+  assert.match(events, /expected_authority\(actual_port\)/);
+  assert.match(events, /MAX_WS_CLIENTS/);
+  assert.match(events, /MAX_WS_MESSAGE_BYTES/);
+});
+
+test('runtime persistence stores enablement metadata but no token field', () => {
+  const lifecycle = read('src-tauri/src/extensions/lifecycle.rs');
+  const persisted = lifecycle.match(/struct PersistedExtension \{([\s\S]*?)\n\}/)?.[1] ?? '';
+  assert.doesNotMatch(persisted, /token/);
+  assert.match(lifecycle, /let session_token = generate_token\(\)/);
+  assert.match(lifecycle, /Permissions::from_mode\(0o600\)/);
+});


### PR DESCRIPTION
## Summary

- bind extension REST/WS services to OS-assigned session ports and enforce the exact literal loopback `Host` plus enabled-extension `Origin` on both transports
- replace wildcard CORS with validated origin reflection and keep preflight/actual request policies aligned
- reject declared oversized bodies before authentication/body reads, cap REST handlers and WS handshakes/clients/messages, and return stable errors/timeouts
- rotate extension tokens each session, remove tokens from `runtime.json`, migrate legacy state immediately, and restrict runtime state permissions on Unix
- remove browser-visible token endpoints and wildcard CORS from `moke-ext` scaffolding/dev server/reading-stats; document the backend-proxy migration

## Compatibility / migration

Backends already using `MOKE_API_PORT`, `MOKE_WS_PORT`, and `MOKE_EXT_TOKEN` keep the same request format. Extensions that hardcode `19555`/`19556` must read the injected ports. Browser UIs that previously obtained a token must move host access into their same-origin extension backend. Legacy `runtime.json` enablement/port state is retained while its persisted token is ignored, rotated, and removed.

## Tests

- `cargo test extensions:: --lib` (39 passed)
- `cargo test` in `packages/moke-ext/examples/reading-stats/backend` (4 passed)
- `node --test --experimental-strip-types tests/moke-ext-build.test.mjs tests/moke-ext-transport-security.test.mjs` (4 passed)
- Node syntax checks for `moke-ext` init/dev commands

Full `pnpm test`/`pnpm lint` could not run in this checkout because `node_modules` is absent; targeted dependency-free Node tests passed.
