### PR TITLE
fix: 支持连接非标准端口的 Talebook 服务器

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "moke",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@9.15.9",

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -57,8 +57,8 @@
     {
       "identifier": "http:default",
       "allow": [
-        { "url": "http://**" },
-        { "url": "https://**" }
+        { "url": "http://**:**" },
+        { "url": "https://**:**" }
       ]
     },
     "os:default",

--- a/src-tauri/capabilities/reader-mobile.json
+++ b/src-tauri/capabilities/reader-mobile.json
@@ -83,8 +83,8 @@
     {
       "identifier": "http:default",
       "allow": [
-        { "url": "http://**" },
-        { "url": "https://**" }
+        { "url": "http://**:**" },
+        { "url": "https://**:**" }
       ]
     },
     "dialog:default",

--- a/src-tauri/capabilities/reader.json
+++ b/src-tauri/capabilities/reader.json
@@ -85,8 +85,8 @@
     {
       "identifier": "http:default",
       "allow": [
-        { "url": "http://**" },
-        { "url": "https://**" }
+        { "url": "http://**:**" },
+        { "url": "https://**:**" }
       ]
     },
     "dialog:default",

--- a/tests/capabilities-scope.test.mjs
+++ b/tests/capabilities-scope.test.mjs
@@ -362,7 +362,7 @@ test('OHOS dev capability differs only by its development server origins', () =>
   ]);
 });
 
-test('HTTP access remains scheme-scoped for user-configured Talebook servers', () => {
+test('HTTP access remains scheme-scoped and allows arbitrary server ports', () => {
   for (const file of [
     'src-tauri/capabilities/default.json',
     'src-tauri/capabilities/reader.json',
@@ -370,6 +370,6 @@ test('HTTP access remains scheme-scoped for user-configured Talebook servers', (
   ]) {
     const permission = findPermission(readCapability(file), 'http:default');
     const urls = permission.allow.map((entry) => entry.url).sort();
-    assert.deepEqual(urls, ['http://**', 'https://**']);
+    assert.deepEqual(urls, ['http://**:**', 'https://**:**']);
   }
 });


### PR DESCRIPTION
## 变更

- 为 HTTP/HTTPS Tauri scope 增加任意端口匹配
- 同步主窗口、桌面阅读器和移动阅读器 capability
- 更新 capability 回归测试，锁定非标准端口支持
- 准备稳定版 `v1.1.1`

## 验证

- `pnpm test`（355 项通过）
- `pnpm lint`（0 error，23 个既有 warning）
- `pnpm typecheck`
- capability JSON 解析及 `git diff --check`

Closes #101
