### PR TITLE
TB-136: 「关于」页面加入赞助名单（首批：金海先生 ¥20、千成 ¥10）

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,11 +1,12 @@
 'use client';
 
 import { useState, useRef } from 'react';
-import { ArrowLeft, BookOpen, Coffee, ExternalLink, HeartHandshake, Info, Sparkles, X } from 'lucide-react';
+import { ArrowLeft, BookOpen, Coffee, Crown, ExternalLink, HeartHandshake, Info, Sparkles, X } from 'lucide-react';
 import { DesktopLayout } from '@/components/layout/DesktopLayout';
 import { useDeveloperStore } from '@/lib/store/developer';
 import { APP_VERSION } from '@/lib/app-version';
 import { requestAnimatedBack } from '@/lib/native-back';
+import { sponsors } from './sponsors';
 
 interface Contributor {
   id: string;
@@ -224,6 +225,25 @@ export default function AboutPage() {
                 </div>
               ))}
             </div>
+          </section>
+
+          <section className="rounded-[32px] app-glass p-6 transition-all duration-300 hover:bg-white/70">
+            <div className="flex items-center gap-2 mb-4 text-foreground">
+              <Crown className="w-5 h-5 text-amber-500" />
+              <h3 className="text-lg font-semibold">赞助名单</h3>
+            </div>
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+              {sponsors.map((s) => (
+                <div
+                  key={s.id}
+                  className="flex items-center justify-between gap-3 rounded-2xl border border-border/60 bg-background/50 backdrop-blur-xs px-4 py-3 transition-all duration-300 hover:bg-muted/80 hover:shadow-md"
+                >
+                  <span className="text-sm font-semibold text-foreground truncate">{s.name}</span>
+                  <span className="shrink-0 rounded-full bg-primary/10 px-2.5 py-0.5 text-xs font-medium text-primary">{s.amount}</span>
+                </div>
+              ))}
+            </div>
+            <p className="mt-3 text-xs text-muted-foreground">感谢每一位赞助者的支持与鼓励，名单将持续更新 💛</p>
           </section>
         </div>
       </div>

--- a/src/app/about/sponsors.ts
+++ b/src/app/about/sponsors.ts
@@ -1,0 +1,25 @@
+/**
+ * 赞助名单数据（「关于」页「赞助名单」区域）。
+ *
+ * 后续新增赞助者时，只需在数组末尾追加一项，无需改动页面模板：
+ *
+ * ```ts
+ * { id: 'zhangsan', name: '张三', amount: '¥50' },
+ * ```
+ *
+ * - `id`：唯一标识，用于 React key，不可重复；
+ * - `name`：展示名称（可包含称谓，如「金海先生」）；
+ * - `amount`：赞助金额，直接使用展示原文（如「¥20」）。
+ *
+ * 建议按赞助时间先后排列。
+ */
+export interface Sponsor {
+  id: string;
+  name: string;
+  amount: string;
+}
+
+export const sponsors: Sponsor[] = [
+  { id: 'jinhai', name: '金海先生', amount: '¥20' },
+  { id: 'qiancheng', name: '千成', amount: '¥10' },
+];

--- a/tests/about-sponsors.test.mjs
+++ b/tests/about-sponsors.test.mjs
@@ -1,0 +1,41 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { sponsors } from '../src/app/about/sponsors.ts';
+
+const root = path.resolve(import.meta.dirname, '..');
+const pageSource = readFileSync(path.join(root, 'src', 'app', 'about', 'page.tsx'), 'utf8');
+
+test('赞助名单首批包含金海先生与千成', () => {
+  assert.deepEqual(
+    sponsors.map(({ name, amount }) => ({ name, amount })),
+    [
+      { name: '金海先生', amount: '¥20' },
+      { name: '千成', amount: '¥10' },
+    ],
+  );
+});
+
+test('赞助名单字段完整且 id 唯一，便于后续追加', () => {
+  assert.ok(sponsors.length > 0, '名单不应为空');
+  for (const s of sponsors) {
+    assert.equal(typeof s.id, 'string');
+    assert.ok(s.id.length > 0, 'id 不能为空');
+    assert.equal(typeof s.name, 'string');
+    assert.ok(s.name.length > 0, 'name 不能为空');
+    assert.equal(typeof s.amount, 'string');
+    assert.match(s.amount, /^¥\s*\d+(\.\d+)?$/, '金额应形如 ¥20');
+  }
+  assert.equal(new Set(sponsors.map((s) => s.id)).size, sponsors.length, 'id 应唯一');
+});
+
+test('关于页渲染独立数据文件中的赞助名单，模板不写死姓名', () => {
+  assert.match(pageSource, /赞助名单/);
+  assert.match(pageSource, /from\s+['"]\.\/sponsors['"]/);
+  assert.match(pageSource, /sponsors\.map/);
+  // 具体赞助者应只存在于数据文件中，追加新赞助者无需改动页面模板
+  assert.doesNotMatch(pageSource, /金海先生/);
+  assert.doesNotMatch(pageSource, /千成/);
+});


### PR DESCRIPTION
## 变更

- 「关于」页新增**赞助名单**区域：位于「贡献者」下方，沿用页面 app-glass 卡片风格，桌面端与移动端均正常显示（网格自适应 `1/2/3` 列）
- 首批赞助者：金海先生 ¥20、千成 ¥10
- 名单数据独立存放于 `src/app/about/sponsors.ts`（`Sponsor[]` 数组），后续追加赞助者只需在数组末尾添加一项，无需改动页面模板
- 新增回归测试 `tests/about-sponsors.test.mjs`：校验首批名单内容、字段完整性与 `id` 唯一性，并防止具体姓名写死进页面模板

## 截图

桌面端（1280×900）：

![desktop](https://raw.githubusercontent.com/talebook/moke/tmp/tb-136-screenshots/docs/screenshots/about-desktop.png)

移动端（390×844）：

![mobile](https://raw.githubusercontent.com/talebook/moke/tmp/tb-136-screenshots/docs/screenshots/about-mobile.png)

## 验证

- `pnpm test`：383 项通过（新增 3 项；`reader-only-build` 因本环境未初始化 readest 子模块而失败，与本次变更无关，基线同样失败）
- `pnpm lint`：0 error（仅 23 个既有 warning）
- `pnpm typecheck` 通过
- Playwright 渲染验证：桌面与移动视口下赞助名单正常渲染、位于贡献者区域之后、无横向溢出
- `git diff --check` 通过

Closes TB-136
