### PR TITLE
perf(reader): 并行准备启动上下文，缩短进入 Readest 前等待

### DIFF
--- a/src/app/detail/page.tsx
+++ b/src/app/detail/page.tsx
@@ -452,15 +452,14 @@ function DetailContent() {
         loadRecord,
         loadProgress: async () => targetAnnotation
           ? annotationReaderProgress(targetAnnotation, book.id)
-          : fetchReadingProgress(book.id).catch(() => null),
+          : fetchReadingProgress(book.id),
         loadPlatform: getMokeRuntimePlatform,
         beforeSingleWebviewOpen: async (record) => {
           if (!record?.filePath) return;
-          try {
-            await recordBookRead(request, serverUrl, book.id, READ_RECORD_NAV_TIMEOUT_MS);
-          } catch (error) {
-            console.warn('Read record could not be saved before navigation:', error);
-          }
+          await recordBookRead(request, serverUrl, book.id, READ_RECORD_NAV_TIMEOUT_MS);
+        },
+        onBeforeSingleWebviewOpenError: (error) => {
+          console.warn('Read record could not be saved before navigation:', error);
         },
       });
       const { record, platform: currentPlatform } = prepared;

--- a/src/app/detail/page.tsx
+++ b/src/app/detail/page.tsx
@@ -25,7 +25,7 @@ import {
   readStateShelfState,
   shouldLoadReadingStateFallback,
 } from '@/lib/book-detail-core';
-import { openAndRecordBookRead, recordAndOpenBookRead, recordBookRead, READ_RECORD_NAV_TIMEOUT_MS } from '@/lib/book-read';
+import { openAndRecordBookRead, prepareEmbeddedBookOpen, recordBookRead, READ_RECORD_NAV_TIMEOUT_MS } from '@/lib/book-read';
 import {
   getOfflineDownloadSnapshot,
   removeOfflineDownloadSnapshot,
@@ -415,93 +415,108 @@ function DetailContent() {
     };
 
     try {
-      const record = offlineMode && offlineRecord?.format === selectedFormat
+      const loadRecord = async () => offlineMode && offlineRecord?.format === selectedFormat
         ? offlineRecord
-        : await getOfflineBook(activeServerUrl, id!, selectedFormat);
-      if (record?.filePath && process.env.NEXT_PUBLIC_APP_PLATFORM === 'tauri') {
-        if (offlineMode) {
-          await openOfflineBook(record, router.push);
+        : getOfflineBook(activeServerUrl, id!, selectedFormat);
+      if (offlineMode) {
+        const record = await loadRecord();
+        if (!record?.filePath || process.env.NEXT_PUBLIC_APP_PLATFORM !== 'tauri') {
+          setMessage('无法打开书籍：未找到本地文件或当前环境不支持。');
           return;
         }
-        // 通过统一的 open_reader 命令打开阅读器：阅读器作为打包资源随应用一起
-        // 发布（合为一个应用），并在自己的独立窗口中打开书籍。后续更换阅读器
-        // 只需替换打包资源，无需改动这里的调用方式。
-        let restoreProgress = targetAnnotation
+        await openOfflineBook(record, router.push);
+        return;
+      }
+
+      const useSystemReader = useSettingsStore.getState().readerPreference === 'system'
+        && !targetAnnotation;
+      if (useSystemReader) {
+        const record = await loadRecord();
+        if (!record?.filePath || process.env.NEXT_PUBLIC_APP_PLATFORM !== 'tauri') {
+          setMessage('无法打开书籍：未找到本地文件或当前环境不支持。');
+          return;
+        }
+        await openAndRecordBookRead({
+          open: () => openBookWithSystemDefault(record.id),
+          onOpened: () => setOpeningReader(false),
+          record: () => recordBookRead(request, serverUrl, book.id),
+          onRecordError: (error) => {
+            console.warn('Book opened in the system app, but the read record could not be saved:', error);
+            setMessage('书籍已打开，但阅读记录同步失败。');
+          },
+        });
+        return;
+      }
+
+      const prepared = await prepareEmbeddedBookOpen({
+        loadRecord,
+        loadProgress: async () => targetAnnotation
           ? annotationReaderProgress(targetAnnotation, book.id)
-          : await fetchReadingProgress(book.id).catch(() => null);
-        if (targetAnnotation && restoreProgress) {
-          annotationNavigationId = beginAnnotationLocateNavigation(serverUrl, book.id);
-          restoreProgress = {
-            ...restoreProgress,
-            moke_navigation_id: annotationNavigationId,
-            moke_navigation_kind: 'annotation-locate',
-          };
-        }
-        const currentPlatform = await getMokeRuntimePlatform();
+          : fetchReadingProgress(book.id).catch(() => null),
+        loadPlatform: getMokeRuntimePlatform,
+        beforeSingleWebviewOpen: async (record) => {
+          if (!record?.filePath) return;
+          try {
+            await recordBookRead(request, serverUrl, book.id, READ_RECORD_NAV_TIMEOUT_MS);
+          } catch (error) {
+            console.warn('Read record could not be saved before navigation:', error);
+          }
+        },
+      });
+      const { record, platform: currentPlatform } = prepared;
+      if (!record?.filePath || process.env.NEXT_PUBLIC_APP_PLATFORM !== 'tauri') {
+        setMessage('无法打开书籍：未找到本地文件或当前环境不支持。');
+        return;
+      }
+      // 通过统一的 open_reader 命令打开阅读器：阅读器作为打包资源随应用一起
+      // 发布（合为一个应用），并在自己的独立窗口中打开书籍。后续更换阅读器
+      // 只需替换打包资源，无需改动这里的调用方式。
+      let restoreProgress = prepared.restoreProgress;
+      if (targetAnnotation && restoreProgress) {
+        annotationNavigationId = beginAnnotationLocateNavigation(serverUrl, book.id);
+        restoreProgress = {
+          ...restoreProgress,
+          moke_navigation_id: annotationNavigationId,
+          moke_navigation_kind: 'annotation-locate',
+        };
+      }
 
-        if (useSettingsStore.getState().readerPreference === 'system' && !targetAnnotation) {
-          await openAndRecordBookRead({
-            open: () => openBookWithSystemDefault(record.id),
-            onOpened: () => setOpeningReader(false),
-            record: () => recordBookRead(request, serverUrl, book.id),
-            onRecordError: (error) => {
-              console.warn('Book opened in the system app, but the read record could not be saved:', error);
-              setMessage('书籍已打开，但阅读记录同步失败。');
-            },
-          });
-          return;
-        }
+      if (isSingleWebviewRuntime(currentPlatform)) {
+        const href = buildEmbeddedReaderUrl({
+          filePath: record.filePath,
+          eink: useSettingsStore.getState().eink,
+          debugPanel: getDebugPanelLaunchState(),
+          mokeBookId: String(book.id),
+          restoreProgress,
+          // The explicit navigation id lets the reader skip only startup and
+          // annotation relocations; genuine page turns still sync directly.
+          serverUrl: useServerStore.getState().serverUrl,
+        });
+        await openEmbeddedReaderBook(href, router.push, currentPlatform);
+        return;
+      }
 
-        if (isSingleWebviewRuntime(currentPlatform)) {
-          const href = buildEmbeddedReaderUrl({
+      await openAndRecordBookRead({
+        open: async () => {
+          const { invoke } = await import('@tauri-apps/api/core');
+          await invoke('open_reader', {
             filePath: record.filePath,
             eink: useSettingsStore.getState().eink,
             debugPanel: getDebugPanelLaunchState(),
             mokeBookId: String(book.id),
             restoreProgress,
-            // The explicit navigation id lets the reader skip only startup and
-            // annotation relocations; genuine page turns still sync directly.
-            serverUrl: useServerStore.getState().serverUrl,
           });
-
-          // Navigation replaces this WebView and destroys the current JS
-          // context, so dispatch and await the bounded record request first.
-          // Use a short timeout: the record is best-effort and must not hold
-          // up opening the reader for long.
-          await recordAndOpenBookRead({
-            record: () => recordBookRead(request, serverUrl, book.id, READ_RECORD_NAV_TIMEOUT_MS),
-            open: () => openEmbeddedReaderBook(href, router.push, currentPlatform),
-            onRecordError: (error) => {
-              console.warn('Read record could not be saved before navigation:', error);
-            },
-          });
-          return;
-        }
-
-        await openAndRecordBookRead({
-          open: async () => {
-            const { invoke } = await import('@tauri-apps/api/core');
-            await invoke('open_reader', {
-              filePath: record.filePath,
-              eink: useSettingsStore.getState().eink,
-              debugPanel: getDebugPanelLaunchState(),
-              mokeBookId: String(book.id),
-              restoreProgress,
-            });
-          },
-          // The independent reader window is already usable. Release the
-          // visible loading state now, while openingReaderRef continues to
-          // block duplicate opens until the record request settles.
-          onOpened: () => setOpeningReader(false),
-          record: () => recordBookRead(request, serverUrl, book.id),
-          onRecordError: (error) => {
-            console.warn('Reader opened, but the read record could not be saved:', error);
-            setMessage('书籍已打开，但阅读记录同步失败。');
-          },
-        });
-      } else {
-        setMessage('无法打开书籍：未找到本地文件或当前环境不支持。');
-      }
+        },
+        // The independent reader window is already usable. Release the
+        // visible loading state now, while openingReaderRef continues to
+        // block duplicate opens until the record request settles.
+        onOpened: () => setOpeningReader(false),
+        record: () => recordBookRead(request, serverUrl, book.id),
+        onRecordError: (error) => {
+          console.warn('Reader opened, but the read record could not be saved:', error);
+          setMessage('书籍已打开，但阅读记录同步失败。');
+        },
+      });
     } catch (e) {
       if (annotationNavigationId) clearAnnotationLocateProgressSuppression(annotationNavigationId);
       console.error('Failed to open book:', e);

--- a/src/lib/book-read.ts
+++ b/src/lib/book-read.ts
@@ -169,26 +169,35 @@ export async function recordBookRead(
  * read-history request starts as soon as the local record and runtime are
  * known, instead of waiting for the unrelated progress fetch. The returned
  * preparation still waits for that best-effort write before a full-document
- * navigation destroys the Moke WebView.
+ * navigation destroys the Moke WebView, but a write failure never blocks the
+ * book from opening. Starting all three jobs means a missing local record can
+ * still spend one progress request and platform probe; that rare failure-path
+ * cost is the deliberate trade-off for removing their latency on valid opens.
  */
 export async function prepareEmbeddedBookOpen<TRecord, TProgress>({
   loadRecord,
   loadProgress,
   loadPlatform,
   beforeSingleWebviewOpen,
+  onBeforeSingleWebviewOpenError,
 }: {
   loadRecord: () => Promise<TRecord>;
   loadProgress: () => Promise<TProgress>;
   loadPlatform: () => Promise<string>;
   beforeSingleWebviewOpen?: (record: TRecord, platform: string) => Promise<void>;
+  onBeforeSingleWebviewOpenError?: (error: unknown) => void;
 }): Promise<{ record: TRecord; restoreProgress: TProgress; platform: string }> {
   const recordPromise = Promise.resolve().then(loadRecord);
   const progressPromise = Promise.resolve().then(loadProgress);
   const platformPromise = Promise.resolve().then(loadPlatform);
   const beforeOpenPromise = beforeSingleWebviewOpen
-    ? Promise.all([recordPromise, platformPromise]).then(([record, platform]) => {
-        if (!isSingleWebviewRuntime(platform)) return undefined;
-        return beforeSingleWebviewOpen(record, platform);
+    ? Promise.all([recordPromise, platformPromise]).then(async ([record, platform]) => {
+        if (!isSingleWebviewRuntime(platform)) return;
+        try {
+          await beforeSingleWebviewOpen(record, platform);
+        } catch (error) {
+          onBeforeSingleWebviewOpenError?.(error);
+        }
       })
     : Promise.resolve();
 

--- a/src/lib/book-read.ts
+++ b/src/lib/book-read.ts
@@ -1,3 +1,5 @@
+import { isSingleWebviewRuntime } from './moke-reader.ts';
+
 type RequestLike = (url: string, init?: RequestInit) => Promise<Response>;
 const READ_RECORD_TIMEOUT_MS = 10_000;
 /**
@@ -162,6 +164,43 @@ export async function recordBookRead(
   }
 }
 
+/**
+ * Start the independent reader-launch prerequisites together. On mobile the
+ * read-history request starts as soon as the local record and runtime are
+ * known, instead of waiting for the unrelated progress fetch. The returned
+ * preparation still waits for that best-effort write before a full-document
+ * navigation destroys the Moke WebView.
+ */
+export async function prepareEmbeddedBookOpen<TRecord, TProgress>({
+  loadRecord,
+  loadProgress,
+  loadPlatform,
+  beforeSingleWebviewOpen,
+}: {
+  loadRecord: () => Promise<TRecord>;
+  loadProgress: () => Promise<TProgress>;
+  loadPlatform: () => Promise<string>;
+  beforeSingleWebviewOpen?: (record: TRecord, platform: string) => Promise<void>;
+}): Promise<{ record: TRecord; restoreProgress: TProgress; platform: string }> {
+  const recordPromise = Promise.resolve().then(loadRecord);
+  const progressPromise = Promise.resolve().then(loadProgress);
+  const platformPromise = Promise.resolve().then(loadPlatform);
+  const beforeOpenPromise = beforeSingleWebviewOpen
+    ? Promise.all([recordPromise, platformPromise]).then(([record, platform]) => {
+        if (!isSingleWebviewRuntime(platform)) return undefined;
+        return beforeSingleWebviewOpen(record, platform);
+      })
+    : Promise.resolve();
+
+  const [record, restoreProgress, platform] = await Promise.all([
+    recordPromise,
+    progressPromise,
+    platformPromise,
+    beforeOpenPromise,
+  ]);
+  return { record, restoreProgress, platform };
+}
+
 export async function openAndRecordBookRead({
   open,
   record,
@@ -180,22 +219,4 @@ export async function openAndRecordBookRead({
   } catch (error) {
     onRecordError?.(error);
   }
-}
-
-/** Record first when opening replaces the current WebView and destroys this page. */
-export async function recordAndOpenBookRead({
-  record,
-  open,
-  onRecordError,
-}: {
-  record: () => Promise<void>;
-  open: () => Promise<void>;
-  onRecordError?: (error: unknown) => void;
-}): Promise<void> {
-  try {
-    await record();
-  } catch (error) {
-    onRecordError?.(error);
-  }
-  await open();
 }

--- a/src/lib/open-offline-book.ts
+++ b/src/lib/open-offline-book.ts
@@ -4,7 +4,6 @@ import type { OfflineBookRecord } from '@/lib/offline-books';
 import { getDebugPanelLaunchState } from '@/lib/store/developer';
 import { useSettingsStore } from '@/lib/store/settings';
 import { fetchReadingProgress } from '@/lib/reading-progress';
-import { prepareEmbeddedBookOpen } from '@/lib/book-read';
 import {
   buildEmbeddedReaderUrl,
   getMokeRuntimePlatform,
@@ -25,27 +24,21 @@ export async function openOfflineBook(
     return;
   }
 
-  const prepared = await prepareEmbeddedBookOpen({
-    loadRecord: async () => record,
-    loadProgress: async () => {
-      try {
-        return await fetchReadingProgress(record.bookId);
-      } catch {
-        // Opening a local book must remain available while the server is offline.
-        return null;
-      }
-    },
-    loadPlatform: getMokeRuntimePlatform,
-  });
+  // Progress recovery and the immutable runtime probe are independent. Offline
+  // library opens intentionally do not write Talebook read history: there may
+  // be no active authenticated server session, and the saved record can belong
+  // to a server other than the currently connected one.
+  const [restoreProgress, platform] = await Promise.all([
+    fetchReadingProgress(record.bookId),
+    getMokeRuntimePlatform(),
+  ]);
   const common = {
     filePath: record.filePath,
     eink: useSettingsStore.getState().eink,
     debugPanel: getDebugPanelLaunchState(),
-    mokeBookId: prepared.record.bookId,
-    restoreProgress: prepared.restoreProgress,
+    mokeBookId: record.bookId,
+    restoreProgress,
   };
-
-  const platform = prepared.platform;
 
   if (isSingleWebviewRuntime(platform)) {
     await openEmbeddedReaderBook(

--- a/src/lib/open-offline-book.ts
+++ b/src/lib/open-offline-book.ts
@@ -4,6 +4,7 @@ import type { OfflineBookRecord } from '@/lib/offline-books';
 import { getDebugPanelLaunchState } from '@/lib/store/developer';
 import { useSettingsStore } from '@/lib/store/settings';
 import { fetchReadingProgress } from '@/lib/reading-progress';
+import { prepareEmbeddedBookOpen } from '@/lib/book-read';
 import {
   buildEmbeddedReaderUrl,
   getMokeRuntimePlatform,
@@ -24,21 +25,27 @@ export async function openOfflineBook(
     return;
   }
 
-  let restoreProgress = null;
-  try {
-    restoreProgress = await fetchReadingProgress(record.bookId);
-  } catch {
-    // Opening a local book must remain available while the server is offline.
-  }
-
-  const platform = await getMokeRuntimePlatform();
+  const prepared = await prepareEmbeddedBookOpen({
+    loadRecord: async () => record,
+    loadProgress: async () => {
+      try {
+        return await fetchReadingProgress(record.bookId);
+      } catch {
+        // Opening a local book must remain available while the server is offline.
+        return null;
+      }
+    },
+    loadPlatform: getMokeRuntimePlatform,
+  });
   const common = {
     filePath: record.filePath,
     eink: useSettingsStore.getState().eink,
     debugPanel: getDebugPanelLaunchState(),
-    mokeBookId: record.bookId,
-    restoreProgress,
+    mokeBookId: prepared.record.bookId,
+    restoreProgress: prepared.restoreProgress,
   };
+
+  const platform = prepared.platform;
 
   if (isSingleWebviewRuntime(platform)) {
     await openEmbeddedReaderBook(

--- a/tests/book-read.test.mjs
+++ b/tests/book-read.test.mjs
@@ -3,9 +3,17 @@ import assert from 'node:assert/strict';
 
 import {
   openAndRecordBookRead,
-  recordAndOpenBookRead,
+  prepareEmbeddedBookOpen,
   recordBookRead,
 } from '../src/lib/book-read.ts';
+
+function deferred() {
+  let resolve;
+  const promise = new Promise((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
 
 function fakeResponse({
   body = '',
@@ -22,6 +30,76 @@ function fakeResponse({
     arrayBuffer: async () => encoded.buffer,
   };
 }
+
+test('内嵌阅读器并行准备本地记录、进度与平台，移动端记录不等待进度', async () => {
+  const events = [];
+  const record = deferred();
+  const progress = deferred();
+  const platform = deferred();
+  const beforeOpen = deferred();
+
+  const pending = prepareEmbeddedBookOpen({
+    loadRecord: async () => {
+      events.push('record:start');
+      return record.promise;
+    },
+    loadProgress: async () => {
+      events.push('progress:start');
+      return progress.promise;
+    },
+    loadPlatform: async () => {
+      events.push('platform:start');
+      return platform.promise;
+    },
+    beforeSingleWebviewOpen: async (loadedRecord, loadedPlatform) => {
+      events.push(`before:${loadedRecord.id}:${loadedPlatform}`);
+      await beforeOpen.promise;
+    },
+  });
+
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.deepEqual(events, ['record:start', 'progress:start', 'platform:start']);
+
+  record.resolve({ id: 'book-1' });
+  platform.resolve('android');
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.deepEqual(events, [
+    'record:start',
+    'progress:start',
+    'platform:start',
+    'before:book-1:android',
+  ]);
+
+  progress.resolve({ location: 'chapter-2' });
+  let settled = false;
+  void pending.then(() => { settled = true; });
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(settled, false, '全文档导航前仍需等待已开始的阅读记录请求');
+
+  beforeOpen.resolve();
+  assert.deepEqual(await pending, {
+    record: { id: 'book-1' },
+    restoreProgress: { location: 'chapter-2' },
+    platform: 'android',
+  });
+});
+
+test('桌面内嵌阅读器跳过导航前记录，但仍并行收集启动上下文', async () => {
+  let beforeOpenCalls = 0;
+  const result = await prepareEmbeddedBookOpen({
+    loadRecord: async () => ({ id: 'book-2' }),
+    loadProgress: async () => null,
+    loadPlatform: async () => 'windows',
+    beforeSingleWebviewOpen: async () => { beforeOpenCalls += 1; },
+  });
+
+  assert.equal(beforeOpenCalls, 0);
+  assert.deepEqual(result, {
+    record: { id: 'book-2' },
+    restoreProgress: null,
+    platform: 'windows',
+  });
+});
 
 test('阅读器成功打开后通过 Talebook 阅读路由持久化一次记录', async () => {
   const events = [];
@@ -79,24 +157,6 @@ test('桌面阅读器打开后立即释放 UI 状态再同步记录', async () =
   });
 
   assert.deepEqual(events, ['opened', 'unlocked', 'recorded']);
-});
-
-test('单 WebView 在导航前记录，记录失败仍继续打开阅读器', async () => {
-  const events = [];
-  const errors = [];
-
-  await recordAndOpenBookRead({
-    record: async () => {
-      events.push('recorded');
-      throw new Error('network failed');
-    },
-    open: async () => events.push('opened'),
-    onRecordError: (error) => errors.push(error),
-  });
-
-  assert.deepEqual(events, ['recorded', 'opened']);
-  assert.equal(errors.length, 1);
-  assert.match(errors[0].message, /network failed/);
 });
 
 test('会话失效被重定向到登录页时不误报记录成功', async () => {

--- a/tests/book-read.test.mjs
+++ b/tests/book-read.test.mjs
@@ -101,6 +101,25 @@ test('桌面内嵌阅读器跳过导航前记录，但仍并行收集启动上�
   });
 });
 
+test('移动端导航前记录失败不会阻止阅读器准备完成', async () => {
+  const errors = [];
+  const result = await prepareEmbeddedBookOpen({
+    loadRecord: async () => ({ id: 'book-3' }),
+    loadProgress: async () => ({ location: 'chapter-3' }),
+    loadPlatform: async () => 'android',
+    beforeSingleWebviewOpen: async () => { throw new Error('record failed'); },
+    onBeforeSingleWebviewOpenError: (error) => errors.push(error),
+  });
+
+  assert.deepEqual(result, {
+    record: { id: 'book-3' },
+    restoreProgress: { location: 'chapter-3' },
+    platform: 'android',
+  });
+  assert.equal(errors.length, 1);
+  assert.match(errors[0].message, /record failed/);
+});
+
 test('阅读器成功打开后通过 Talebook 阅读路由持久化一次记录', async () => {
   const events = [];
   const requests = [];


### PR DESCRIPTION
## 背景与取证

关联任务：Multica **TB-137**（`678d483b-24eb-43a6-b3b7-a955de85418a`）。

Moke 当前打开已下载书籍的链路为：

1. 详情页读取本地下载记录（IndexedDB/原生索引）；
2. 请求 Talebook 阅读进度；
3. IPC 探测运行平台；
4. 单 WebView 平台再等待 `/read/{id}` 阅读记录请求，然后通过受限的 `moke_navigate` 进入 `/readest/reader`；桌面则调用 `open_reader` 创建 Readest WebView 窗口；
5. Readest 从 URL/初始化脚本接收文件路径、书籍 ID、墨水屏和恢复进度，桌面进度由主窗口事件监听保存，移动端由 Readest 直接保存；返回移动端 Moke 时走现有跨文档退出动画。

代码检查确认 Moke 侧的本地记录、进度请求和平台探测彼此独立，却在点击后串行等待；移动端阅读记录又排在三者之后。系统默认阅读器路径甚至先做了不需要的进度请求和平台探测。这部分会直接增加“点击阅读 → 发起开窗/导航”的等待，Readest 文档自身的初始化耗时则由 Readest 侧任务继续处理。

## 修改

- 新增可测试的启动准备编排：本地记录、阅读进度、平台探测同时开始。
- Android/iOS/OHOS 的导航前阅读记录在“本地文件存在 + 平台已确认”后立即开始，与仍在途的进度请求重叠；仍保留原 3 秒边界及失败后继续导航语义。
- 桌面保持“窗口成功打开后再记阅读记录”，不提前增加阅读次数。
- 系统默认阅读器路径跳过无用的进度请求和平台 IPC。
- 离线入口也并行读取恢复进度和平台，不改变离线失败降级。
- 删除已被新编排替代的串行辅助函数，并补充移动端/桌面并发时序回归测试。
- Readest 子模块更新至 [Readest #33](https://github.com/hehetoshang/readest/pull/33) 当前最终提交 `cf41c5ae5682ac6a85dcd3fb77eb7911ce8ab300`，带入 reader-only webpack/懒加载优化，以及 EPUB 单次授权源解析、sidecar I/O 并发、首个恢复页后写入导航缓存和 DebugLogPanel hydration 根因修复。
- 根据评审将导航前阅读记录失败的“best effort、不阻塞打开”语义固化在编排层，并移除冗余异常包装；离线入口继续不写远端阅读记录，因为可能没有当前服务器的有效认证会话。

未改动 URL 校验、Tauri capability、文件授权范围、Talebook 请求目标、登录 cookie、阅读进度结构或动画规则。

## 合并顺序

1. 先合并 [Readest #33](https://github.com/hehetoshang/readest/pull/33)。
2. 再合并本 PR。

本 PR 当前指向 #33 的 head SHA `cf41c5ae5682ac6a85dcd3fb77eb7911ce8ab300`；若 #33 采用 squash/rebase 导致最终 SHA 改写，必须在本 PR 合并前再次把子模块同步到 Readest `master` 上的最终提交。

## 量化对比

本机环境：Linux x64、Node v22.22.3（无桌面显示服务/移动设备，不能把该结果冒充原生首帧数据）。使用相同 Promise 阶段注入固定耗时，11 次取中位数：本地记录 40ms、进度 180ms、平台 15ms、移动端阅读记录 160ms。

| 指标 | 优化前串行模型 | 优化后实际编排 | 变化 |
|---|---:|---:|---:|
| 点击后 Moke 启动准备耗时中位数 | 395.8ms | 200.7ms | **-49.3%** |

关键路径从 `本地 + 进度 + 平台 + 阅读记录` 改为 `max(进度, max(本地, 平台) + 阅读记录)`；桌面从三项求和改为三项最大值。系统阅读器额外减少 1 次进度 HTTP 与 1 次平台 IPC。

此数据只量化本 PR 修改的 Moke 点击后准备链路，不代表 Readest 首个可读页耗时。原生端建议统一按以下口径复测：同一设备、同一本已下载书、同一网络，冷启动与连续 5 次热启动分开；记录点击“阅读”到 Moke 发出导航/`open_reader`、Readest 首次非空绘制、正文可交互三个时间点，并报告 P50/P95。

## 验证

- `pnpm test`：386/386 通过
- `pnpm typecheck`：通过
- `pnpm lint`：0 error，23 条仓库既有 warning
- `pnpm build`：通过（仅有仓库既有 Next 配置 warning）
- `pnpm build:reader && pnpm copy:reader`：通过，确认 Moke 能构建并打包更新后的 Readest reader-only 产物
- Readest 启动、临时书籍、进度桥、返回路径及本次懒加载定向测试：12 文件 / 52 用例通过
- Moke 定向回归覆盖：三个前置任务同时启动；移动端阅读记录不等待进度且记录失败仍打开；桌面不提前记录。

## 剩余风险

当前执行环境没有 Windows WebView2/Android/iOS/OHOS 设备，无法验证原生首个可读页、掉帧和白屏时长；请按上述口径做真机复测。Readest 书籍解析与真实 WebView 首次绘制仍属于真机剩余风险。

