### PR TITLE
fix(TB-138): 防止并发更新检查重复下载

### DIFF
--- a/src/lib/store/update.ts
+++ b/src/lib/store/update.ts
@@ -249,14 +249,16 @@ export function createUpdateStore(overrides: Partial<UpdateStoreDependencies> = 
                 set({ totalBytes: contentLength });
                 break;
               case 'Progress': {
-                bytesDownloaded = Math.max(bytesDownloaded + event.data.chunkLength, bytesDownloaded);
-                const progressPercent = contentLength
-                  ? Math.min(Math.round((bytesDownloaded / contentLength) * 100), 100)
+                bytesDownloaded += event.data.chunkLength;
+                const nextBytes = bytesDownloaded;
+                const nextPercent = contentLength
+                  ? Math.min(Math.round((nextBytes / contentLength) * 100), 100)
                   : 0;
-                set({
-                  downloadedBytes: Math.max(get().downloadedBytes, bytesDownloaded),
-                  progressPercent: Math.max(get().progressPercent, progressPercent),
-                });
+                // Keep shared progress monotonic if callbacks arrive out of order.
+                set((current) => ({
+                  downloadedBytes: Math.max(current.downloadedBytes, nextBytes),
+                  progressPercent: Math.max(current.progressPercent, nextPercent),
+                }));
                 break;
               }
               case 'Finished':
@@ -355,14 +357,16 @@ export function createUpdateStore(overrides: Partial<UpdateStoreDependencies> = 
               set({ totalBytes: contentLength });
               break;
             case 'Progress': {
-              bytesDownloaded = Math.max(bytesDownloaded + event.data.chunkLength, bytesDownloaded);
-              const progressPercent = contentLength
-                ? Math.min(Math.round((bytesDownloaded / contentLength) * 100), 100)
+              bytesDownloaded += event.data.chunkLength;
+              const nextBytes = bytesDownloaded;
+              const nextPercent = contentLength
+                ? Math.min(Math.round((nextBytes / contentLength) * 100), 100)
                 : 0;
-              set({
-                downloadedBytes: Math.max(get().downloadedBytes, bytesDownloaded),
-                progressPercent: Math.max(get().progressPercent, progressPercent),
-              });
+              // Keep shared progress monotonic if callbacks arrive out of order.
+              set((current) => ({
+                downloadedBytes: Math.max(current.downloadedBytes, nextBytes),
+                progressPercent: Math.max(current.progressPercent, nextPercent),
+              }));
               break;
             }
             case 'Finished':

--- a/src/lib/store/update.ts
+++ b/src/lib/store/update.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+// Keep this relative .ts import directly loadable by Node's strip-types test runner.
 import { copyTextToClipboard } from '../clipboard.ts';
 
 // ponytail: state machine mirrors cc-haha but without DesktopHost abstraction
@@ -119,101 +120,117 @@ export function createUpdateStore(overrides: Partial<UpdateStoreDependencies> = 
   let checkInFlight: Promise<void> | null = null;
 
   return create<UpdateStore>((set, get) => ({
-  status: 'idle',
-  availableVersion: null,
-  releaseNotes: null,
-  progressPercent: 0,
-  downloadedBytes: 0,
-  totalBytes: null,
-  error: null,
-  checkedAt: null,
-  shouldPrompt: false,
-  platform: null,
+    status: 'idle',
+    availableVersion: null,
+    releaseNotes: null,
+    progressPercent: 0,
+    downloadedBytes: 0,
+    totalBytes: null,
+    error: null,
+    checkedAt: null,
+    shouldPrompt: false,
+    platform: null,
 
-  initialize: async () => {
-    if (startupDone || process.env.NEXT_PUBLIC_APP_PLATFORM !== 'tauri') return;
-    // Claim initialization before platform detection so concurrent mounts cannot
-    // schedule more than one automatic update check.
-    startupDone = true;
+    initialize: async () => {
+      if (startupDone || process.env.NEXT_PUBLIC_APP_PLATFORM !== 'tauri') return;
+      // Claim initialization before platform detection so concurrent mounts cannot
+      // schedule more than one automatic update check.
+      startupDone = true;
 
-    // OHOS/移动端单 WebView 构建里没有注册 updater 插件，且 plugin-updater
-    // 官方不支持移动端，需要运行时平台检测区分。
-    const runtimePlatform = await dependencies.resolvePlatform();
-    set({ platform: runtimePlatform });
+      // OHOS/移动端单 WebView 构建里没有注册 updater 插件，且 plugin-updater
+      // 官方不支持移动端，需要运行时平台检测区分。
+      const runtimePlatform = await dependencies.resolvePlatform();
+      set({ platform: runtimePlatform });
 
-    // 移动端不自动检查（避免启动即弹浏览器），由用户在设置页点击跳转 release。
-    if (runtimePlatform === 'mobile') return;
+      // 移动端不自动检查（避免启动即弹浏览器），由用户在设置页点击跳转 release。
+      if (runtimePlatform === 'mobile') return;
 
-    await dependencies.sleep(5000);
-    try { await get().checkForUpdates(); } catch { /* silent */ }
-  },
+      await dependencies.sleep(5000);
+      // A manual check may have completed during the startup delay.
+      if (get().checkedAt !== null) return;
+      try { await get().checkForUpdates(); } catch { /* silent */ }
+    },
 
-  checkForUpdates: () => {
-    if (checkInFlight) return checkInFlight;
+    checkForUpdates: () => {
+      if (checkInFlight) return checkInFlight;
+      // Keep an already downloaded package for installation instead of checking
+      // and downloading the same release again.
+      if (pending && downloaded && get().status === 'downloaded') return Promise.resolve();
 
-    // Defer the implementation to a microtask so checkInFlight is assigned
-    // before platform detection or any other asynchronous work can begin.
-    const flight = Promise.resolve().then(async () => {
-      // 平台未缓存时先检测（initialize 尚未完成时点击也能正确跳转）。
-      let platform = get().platform;
-      if (!platform) {
-        platform = await dependencies.resolvePlatform();
-        set({ platform });
-      }
-      // 移动端：没有内置 updater，复制下载链接让用户去浏览器手动下载。
-      if (platform === 'mobile') {
-        await get().copyReleaseUrl();
-        return;
-      }
-
-      const updater = await dependencies.importUpdater();
-      if (!updater) return;
-      if (downloading) return;
-
-      set({ status: 'checking', error: null });
-
-      try {
-        // Close previous pending update
-        if (pending) {
-          try { await pending.close(); } catch { /* best effort */ }
-          pending = null;
-          downloaded = false;
+      // Defer the implementation to a microtask so checkInFlight is assigned
+      // before platform detection or any other asynchronous work can begin.
+      const flight = Promise.resolve().then(async () => {
+        // 平台未缓存时先检测（initialize 尚未完成时点击也能正确跳转）。
+        let platform = get().platform;
+        if (!platform) {
+          platform = await dependencies.resolvePlatform();
+          set({ platform });
         }
-
-        const update = await updater.check();
-        if (!update) {
-          writeDismissed(null);
-          set({
-            status: 'up-to-date',
-            availableVersion: null,
-            releaseNotes: null,
-            checkedAt: Date.now(),
-            error: null,
-            shouldPrompt: false,
-          });
+        // 移动端：没有内置 updater，复制下载链接让用户去浏览器手动下载。
+        if (platform === 'mobile') {
+          await get().copyReleaseUrl();
           return;
         }
 
-        // Ignore if not newer than current
-        const current = update.currentVersion;
-        if (current && !isNewer(update.version, current)) {
-          try { await update.close(); } catch { /* best effort */ }
-          writeDismissed(null);
-          set({
-            status: 'up-to-date',
-            availableVersion: null,
-            releaseNotes: null,
-            checkedAt: Date.now(),
-            error: null,
-            shouldPrompt: false,
-          });
-          return;
-        }
+        const updater = await dependencies.importUpdater();
+        if (!updater) return;
+        if (downloading) return;
 
-        pending = update;
+        set({ status: 'checking', error: null });
 
-        // Already dismissed this version → don't prompt, don't download
-        if (readDismissed() === update.version) {
+        try {
+          // Close previous pending update
+          if (pending) {
+            try { await pending.close(); } catch { /* best effort */ }
+            pending = null;
+            downloaded = false;
+          }
+
+          const update = await updater.check();
+          if (!update) {
+            writeDismissed(null);
+            set({
+              status: 'up-to-date',
+              availableVersion: null,
+              releaseNotes: null,
+              checkedAt: Date.now(),
+              error: null,
+              shouldPrompt: false,
+            });
+            return;
+          }
+
+          // Ignore if not newer than current
+          const current = update.currentVersion;
+          if (current && !isNewer(update.version, current)) {
+            try { await update.close(); } catch { /* best effort */ }
+            writeDismissed(null);
+            set({
+              status: 'up-to-date',
+              availableVersion: null,
+              releaseNotes: null,
+              checkedAt: Date.now(),
+              error: null,
+              shouldPrompt: false,
+            });
+            return;
+          }
+
+          pending = update;
+
+          // Already dismissed this version → don't prompt, don't download
+          if (readDismissed() === update.version) {
+            set({
+              status: 'available',
+              availableVersion: update.version,
+              releaseNotes: update.body ?? null,
+              checkedAt: Date.now(),
+              error: null,
+              shouldPrompt: false,
+            });
+            return;
+          }
+
           set({
             status: 'available',
             availableVersion: update.version,
@@ -222,27 +239,135 @@ export function createUpdateStore(overrides: Partial<UpdateStoreDependencies> = 
             error: null,
             shouldPrompt: false,
           });
-          return;
+
+          // Auto-download (don't install yet — user decides when to restart)
+          downloading = true;
+          set({ status: 'downloading', progressPercent: 0, downloadedBytes: 0, totalBytes: null });
+
+          let contentLength: number | null = null;
+          let bytesDownloaded = 0;
+
+          try {
+            await update.download((event) => {
+              switch (event.event) {
+                case 'Started':
+                  contentLength = event.data.contentLength ?? null;
+                  set({ totalBytes: contentLength });
+                  break;
+                case 'Progress': {
+                  bytesDownloaded += event.data.chunkLength;
+                  const nextBytes = bytesDownloaded;
+                  const nextPercent = contentLength
+                    ? Math.min(Math.round((nextBytes / contentLength) * 100), 100)
+                    : 0;
+                  // Keep shared progress monotonic if callbacks arrive out of order.
+                  set((current) => ({
+                    downloadedBytes: Math.max(current.downloadedBytes, nextBytes),
+                    progressPercent: Math.max(current.progressPercent, nextPercent),
+                  }));
+                  break;
+                }
+                case 'Finished':
+                  set({ progressPercent: 100 });
+                  break;
+              }
+            });
+
+            downloaded = true;
+            set({
+              status: 'downloaded',
+              progressPercent: 100,
+              shouldPrompt: true,
+              error: null,
+            });
+          } catch (e) {
+            set({
+              status: 'available',
+              error: e instanceof Error ? e.message : String(e),
+              shouldPrompt: true,
+            });
+          } finally {
+            downloading = false;
+          }
+        } catch (e) {
+          set({
+            status: 'error',
+            error: e instanceof Error ? e.message : String(e),
+            checkedAt: Date.now(),
+          });
         }
-
+      }).catch((e) => {
         set({
-          status: 'available',
-          availableVersion: update.version,
-          releaseNotes: update.body ?? null,
+          status: 'error',
+          error: e instanceof Error ? e.message : String(e),
           checkedAt: Date.now(),
-          error: null,
-          shouldPrompt: false,
         });
+      }).finally(() => {
+        if (checkInFlight === flight) checkInFlight = null;
+      });
 
-        // Auto-download (don't install yet — user decides when to restart)
-        downloading = true;
-        set({ status: 'downloading', progressPercent: 0, downloadedBytes: 0, totalBytes: null });
+      checkInFlight = flight;
+      return flight;
+    },
 
-        let contentLength: number | null = null;
-        let bytesDownloaded = 0;
+    installUpdate: async () => {
+      if (downloading) return;
 
-        try {
-          await update.download((event) => {
+      // 平台未缓存时先检测，避免移动端误走内置 updater。
+      let platform = get().platform;
+      if (!platform) {
+        platform = await dependencies.resolvePlatform();
+        set({ platform });
+      }
+      // 移动端：复制下载链接，由用户去浏览器手动下载安装（没有内置安装流程）。
+      if (platform === 'mobile') {
+        await get().copyReleaseUrl();
+        return;
+      }
+
+      // ponytail: fake update skips real Tauri calls, just simulates restart
+      if (fake) {
+        writeDismissed(null);
+        set({ status: 'installing', shouldPrompt: false });
+        await new Promise((r) => setTimeout(r, 1000));
+        set({ status: 'restarting' });
+
+        if (watchdog) clearTimeout(watchdog);
+        watchdog = setTimeout(() => {
+          set({ status: 'downloaded', error: '重启未能自动启动（模拟），请手动重启应用以完成更新。', shouldPrompt: true });
+        }, 15_000);
+
+        // Don't actually relaunch — restore after 3s for re-testing
+        await new Promise((r) => setTimeout(r, 3000));
+        if (watchdog) { clearTimeout(watchdog); watchdog = null; }
+        fake = false;
+        set({ status: 'idle', availableVersion: null, releaseNotes: null, shouldPrompt: false, error: null, progressPercent: 0, checkedAt: null });
+        (await import('@/lib/toast')).useToast.getState().show('虚假更新流程已走完，状态已重置。', 'info');
+        return;
+      }
+
+      const updater = await dependencies.importUpdater();
+      const process = await dependencies.importProcess();
+      if (!updater || !process) return;
+
+      if (!pending) {
+        await get().checkForUpdates();
+        if (!pending) return;
+      }
+      // Re-check after the awaits above so a check-triggered download that
+      // started in the meantime cannot be duplicated by the install path.
+      if (downloading) return;
+
+      try {
+        // Download if not yet downloaded
+        if (!downloaded) {
+          downloading = true;
+          set({ status: 'downloading', progressPercent: 0, downloadedBytes: 0, totalBytes: null });
+
+          let contentLength: number | null = null;
+          let bytesDownloaded = 0;
+
+          await pending.download((event) => {
             switch (event.event) {
               case 'Started':
                 contentLength = event.data.contentLength ?? null;
@@ -267,181 +392,73 @@ export function createUpdateStore(overrides: Partial<UpdateStoreDependencies> = 
             }
           });
 
+          downloading = false;
           downloaded = true;
+        }
+
+        writeDismissed(null);
+
+        set({ status: 'installing', shouldPrompt: false, error: null });
+
+        await pending.install();
+
+        set({ status: 'restarting', progressPercent: 100 });
+
+        // Watchdog: if still here after 15s, relaunch didn't work
+        if (watchdog) clearTimeout(watchdog);
+        watchdog = setTimeout(() => {
           set({
             status: 'downloaded',
-            progressPercent: 100,
-            shouldPrompt: true,
-            error: null,
-          });
-        } catch (e) {
-          set({
-            status: 'available',
-            error: e instanceof Error ? e.message : String(e),
+            error: '重启未能自动启动，请手动重启应用以完成更新。',
             shouldPrompt: true,
           });
-        } finally {
-          downloading = false;
-        }
+        }, 15_000);
+
+        await process.relaunch();
       } catch (e) {
-        set({
-          status: 'error',
-          error: e instanceof Error ? e.message : String(e),
-          checkedAt: Date.now(),
-        });
-      }
-    }).finally(() => {
-      if (checkInFlight === flight) checkInFlight = null;
-    });
-
-    checkInFlight = flight;
-    return flight;
-  },
-
-  installUpdate: async () => {
-    // 平台未缓存时先检测，避免移动端误走内置 updater。
-    let platform = get().platform;
-    if (!platform) {
-      platform = await dependencies.resolvePlatform();
-      set({ platform });
-    }
-    // 移动端：复制下载链接，由用户去浏览器手动下载安装（没有内置安装流程）。
-    if (platform === 'mobile') {
-      await get().copyReleaseUrl();
-      return;
-    }
-
-    // ponytail: fake update skips real Tauri calls, just simulates restart
-    if (fake) {
-      writeDismissed(null);
-      set({ status: 'installing', shouldPrompt: false });
-      await new Promise((r) => setTimeout(r, 1000));
-      set({ status: 'restarting' });
-
-      if (watchdog) clearTimeout(watchdog);
-      watchdog = setTimeout(() => {
-        set({ status: 'downloaded', error: '重启未能自动启动（模拟），请手动重启应用以完成更新。', shouldPrompt: true });
-      }, 15_000);
-
-      // Don't actually relaunch — restore after 3s for re-testing
-      await new Promise((r) => setTimeout(r, 3000));
-      if (watchdog) { clearTimeout(watchdog); watchdog = null; }
-      fake = false;
-      set({ status: 'idle', availableVersion: null, releaseNotes: null, shouldPrompt: false, error: null, progressPercent: 0, checkedAt: null });
-      (await import('@/lib/toast')).useToast.getState().show('虚假更新流程已走完，状态已重置。', 'info');
-      return;
-    }
-
-    const updater = await dependencies.importUpdater();
-    const process = await dependencies.importProcess();
-    if (!updater || !process) return;
-
-    if (!pending) {
-      await get().checkForUpdates();
-      if (!pending) return;
-    }
-
-    try {
-      // Download if not yet downloaded
-      if (!downloaded) {
-        downloading = true;
-        set({ status: 'downloading', progressPercent: 0, downloadedBytes: 0, totalBytes: null });
-
-        let contentLength: number | null = null;
-        let bytesDownloaded = 0;
-
-        await pending.download((event) => {
-          switch (event.event) {
-            case 'Started':
-              contentLength = event.data.contentLength ?? null;
-              set({ totalBytes: contentLength });
-              break;
-            case 'Progress': {
-              bytesDownloaded += event.data.chunkLength;
-              const nextBytes = bytesDownloaded;
-              const nextPercent = contentLength
-                ? Math.min(Math.round((nextBytes / contentLength) * 100), 100)
-                : 0;
-              // Keep shared progress monotonic if callbacks arrive out of order.
-              set((current) => ({
-                downloadedBytes: Math.max(current.downloadedBytes, nextBytes),
-                progressPercent: Math.max(current.progressPercent, nextPercent),
-              }));
-              break;
-            }
-            case 'Finished':
-              set({ progressPercent: 100 });
-              break;
-          }
-        });
-
         downloading = false;
-        downloaded = true;
-      }
-
-      writeDismissed(null);
-
-      set({ status: 'installing', shouldPrompt: false, error: null });
-
-      await pending.install();
-
-      set({ status: 'restarting', progressPercent: 100 });
-
-      // Watchdog: if still here after 15s, relaunch didn't work
-      if (watchdog) clearTimeout(watchdog);
-      watchdog = setTimeout(() => {
+        if (watchdog) { clearTimeout(watchdog); watchdog = null; }
         set({
-          status: 'downloaded',
-          error: '重启未能自动启动，请手动重启应用以完成更新。',
+          status: downloaded ? 'downloaded' : 'available',
+          error: e instanceof Error ? e.message : String(e),
           shouldPrompt: true,
         });
-      }, 15_000);
+      }
+    },
 
-      await process.relaunch();
-    } catch (e) {
-      downloading = false;
-      if (watchdog) { clearTimeout(watchdog); watchdog = null; }
-      set({
-        status: downloaded ? 'downloaded' : 'available',
-        error: e instanceof Error ? e.message : String(e),
-        shouldPrompt: true,
-      });
-    }
-  },
+    copyReleaseUrl: async () => {
+      const copied = await copyTextToClipboard(RELEASE_URL);
+      const toast = (await import('@/lib/toast')).useToast.getState();
+      if (copied) {
+        toast.show('已复制下载链接，请在浏览器中打开并下载安装。', 'info');
+      } else {
+        toast.show(`复制失败，请手动访问 ${RELEASE_URL}`, 'error');
+      }
+    },
 
-  copyReleaseUrl: async () => {
-    const copied = await copyTextToClipboard(RELEASE_URL);
-    const toast = (await import('@/lib/toast')).useToast.getState();
-    if (copied) {
-      toast.show('已复制下载链接，请在浏览器中打开并下载安装。', 'info');
-    } else {
-      toast.show(`复制失败，请手动访问 ${RELEASE_URL}`, 'error');
-    }
-  },
+    dismissPrompt: () => {
+      writeDismissed(get().availableVersion);
+      set({ shouldPrompt: false });
+    },
 
-  dismissPrompt: () => {
-    writeDismissed(get().availableVersion);
-    set({ shouldPrompt: false });
-  },
+    simulateUpdate: async () => {
+      fake = true;
+      writeDismissed(null);
 
-  simulateUpdate: async () => {
-    fake = true;
-    writeDismissed(null);
+      set({ status: 'checking', error: null });
+      await new Promise((r) => setTimeout(r, 800));
 
-    set({ status: 'checking', error: null });
-    await new Promise((r) => setTimeout(r, 800));
+      set({ status: 'available', availableVersion: 'v9.9.9-test', releaseNotes: '🧪 虚假更新测试\n\n这个更新是假的，用于验证更新流程的 UI 交互是否正常。', checkedAt: Date.now(), error: null });
+      await new Promise((r) => setTimeout(r, 600));
 
-    set({ status: 'available', availableVersion: 'v9.9.9-test', releaseNotes: '🧪 虚假更新测试\n\n这个更新是假的，用于验证更新流程的 UI 交互是否正常。', checkedAt: Date.now(), error: null });
-    await new Promise((r) => setTimeout(r, 600));
+      set({ status: 'downloading', progressPercent: 0, downloadedBytes: 0, totalBytes: 1024 * 1024 * 50 });
+      for (let p = 0; p <= 100; p += 10) {
+        await new Promise((r) => setTimeout(r, 250));
+        set({ progressPercent: p, downloadedBytes: (1024 * 1024 * 50) * p / 100 });
+      }
 
-    set({ status: 'downloading', progressPercent: 0, downloadedBytes: 0, totalBytes: 1024 * 1024 * 50 });
-    for (let p = 0; p <= 100; p += 10) {
-      await new Promise((r) => setTimeout(r, 250));
-      set({ progressPercent: p, downloadedBytes: (1024 * 1024 * 50) * p / 100 });
-    }
-
-    set({ status: 'downloaded', progressPercent: 100, shouldPrompt: true });
-  },
+      set({ status: 'downloaded', progressPercent: 100, shouldPrompt: true });
+    },
   }));
 }
 

--- a/src/lib/store/update.ts
+++ b/src/lib/store/update.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import { copyTextToClipboard } from '@/lib/clipboard';
+import { copyTextToClipboard } from '../clipboard.ts';
 
 // ponytail: state machine mirrors cc-haha but without DesktopHost abstraction
 // (Moke is Tauri-only). Proxy settings skipped — add when LAN users need them.
@@ -69,18 +69,16 @@ interface UpdateStore {
   simulateUpdate: () => Promise<void>;
 }
 
-// ponytail: flag to skip real Tauri APIs when simulating
-let fake = false;
-
 type UpdaterMod = typeof import('@tauri-apps/plugin-updater');
 type ProcessMod = typeof import('@tauri-apps/plugin-process');
 type UpdateObj = NonNullable<Awaited<ReturnType<UpdaterMod['check']>>>;
 
-let pending: UpdateObj | null = null;
-let downloading = false;
-let downloaded = false;
-let watchdog: ReturnType<typeof setTimeout> | null = null;
-let startupDone = false;
+export interface UpdateStoreDependencies {
+  importUpdater: () => Promise<UpdaterMod | null>;
+  importProcess: () => Promise<ProcessMod | null>;
+  resolvePlatform: () => Promise<'desktop' | 'mobile'>;
+  sleep: (delayMs: number) => Promise<void>;
+}
 
 async function importUpdater(): Promise<UpdaterMod | null> {
   try { return await import('@tauri-apps/plugin-updater'); } catch { return null; }
@@ -102,7 +100,25 @@ async function resolvePlatform(): Promise<'desktop' | 'mobile'> {
   }
 }
 
-export const useUpdateStore = create<UpdateStore>((set, get) => ({
+const defaultDependencies: UpdateStoreDependencies = {
+  importUpdater,
+  importProcess,
+  resolvePlatform,
+  sleep: (delayMs) => new Promise((resolve) => setTimeout(resolve, delayMs)),
+};
+
+export function createUpdateStore(overrides: Partial<UpdateStoreDependencies> = {}) {
+  const dependencies = { ...defaultDependencies, ...overrides };
+  // ponytail: flag to skip real Tauri APIs when simulating
+  let fake = false;
+  let pending: UpdateObj | null = null;
+  let downloading = false;
+  let downloaded = false;
+  let watchdog: ReturnType<typeof setTimeout> | null = null;
+  let startupDone = false;
+  let checkInFlight: Promise<void> | null = null;
+
+  return create<UpdateStore>((set, get) => ({
   status: 'idle',
   availableVersion: null,
   releaseNotes: null,
@@ -116,80 +132,99 @@ export const useUpdateStore = create<UpdateStore>((set, get) => ({
 
   initialize: async () => {
     if (startupDone || process.env.NEXT_PUBLIC_APP_PLATFORM !== 'tauri') return;
+    // Claim initialization before platform detection so concurrent mounts cannot
+    // schedule more than one automatic update check.
+    startupDone = true;
+
     // OHOS/移动端单 WebView 构建里没有注册 updater 插件，且 plugin-updater
     // 官方不支持移动端，需要运行时平台检测区分。
-    const runtimePlatform = await resolvePlatform();
+    const runtimePlatform = await dependencies.resolvePlatform();
     set({ platform: runtimePlatform });
-    startupDone = true;
 
     // 移动端不自动检查（避免启动即弹浏览器），由用户在设置页点击跳转 release。
     if (runtimePlatform === 'mobile') return;
 
-    await new Promise((r) => setTimeout(r, 5000));
+    await dependencies.sleep(5000);
     try { await get().checkForUpdates(); } catch { /* silent */ }
   },
 
-  checkForUpdates: async () => {
-    // 平台未缓存时先检测（initialize 尚未完成时点击也能正确跳转）。
-    let platform = get().platform;
-    if (!platform) {
-      platform = await resolvePlatform();
-      set({ platform });
-    }
-    // 移动端：没有内置 updater，复制下载链接让用户去浏览器手动下载。
-    if (platform === 'mobile') {
-      await get().copyReleaseUrl();
-      return;
-    }
+  checkForUpdates: () => {
+    if (checkInFlight) return checkInFlight;
 
-    const updater = await importUpdater();
-    if (!updater) return;
-    if (downloading) return;
-
-    set({ status: 'checking', error: null });
-
-    try {
-      // Close previous pending update
-      if (pending) {
-        try { await pending.close(); } catch { /* best effort */ }
-        pending = null;
-        downloaded = false;
+    // Defer the implementation to a microtask so checkInFlight is assigned
+    // before platform detection or any other asynchronous work can begin.
+    const flight = Promise.resolve().then(async () => {
+      // 平台未缓存时先检测（initialize 尚未完成时点击也能正确跳转）。
+      let platform = get().platform;
+      if (!platform) {
+        platform = await dependencies.resolvePlatform();
+        set({ platform });
       }
-
-      const update = await updater.check();
-      if (!update) {
-        writeDismissed(null);
-        set({
-          status: 'up-to-date',
-          availableVersion: null,
-          releaseNotes: null,
-          checkedAt: Date.now(),
-          error: null,
-          shouldPrompt: false,
-        });
+      // 移动端：没有内置 updater，复制下载链接让用户去浏览器手动下载。
+      if (platform === 'mobile') {
+        await get().copyReleaseUrl();
         return;
       }
 
-      // Ignore if not newer than current
-      const current = update.currentVersion;
-      if (current && !isNewer(update.version, current)) {
-        try { await update.close(); } catch { /* best effort */ }
-        writeDismissed(null);
-        set({
-          status: 'up-to-date',
-          availableVersion: null,
-          releaseNotes: null,
-          checkedAt: Date.now(),
-          error: null,
-          shouldPrompt: false,
-        });
-        return;
-      }
+      const updater = await dependencies.importUpdater();
+      if (!updater) return;
+      if (downloading) return;
 
-      pending = update;
+      set({ status: 'checking', error: null });
 
-      // Already dismissed this version → don't prompt, don't download
-      if (readDismissed() === update.version) {
+      try {
+        // Close previous pending update
+        if (pending) {
+          try { await pending.close(); } catch { /* best effort */ }
+          pending = null;
+          downloaded = false;
+        }
+
+        const update = await updater.check();
+        if (!update) {
+          writeDismissed(null);
+          set({
+            status: 'up-to-date',
+            availableVersion: null,
+            releaseNotes: null,
+            checkedAt: Date.now(),
+            error: null,
+            shouldPrompt: false,
+          });
+          return;
+        }
+
+        // Ignore if not newer than current
+        const current = update.currentVersion;
+        if (current && !isNewer(update.version, current)) {
+          try { await update.close(); } catch { /* best effort */ }
+          writeDismissed(null);
+          set({
+            status: 'up-to-date',
+            availableVersion: null,
+            releaseNotes: null,
+            checkedAt: Date.now(),
+            error: null,
+            shouldPrompt: false,
+          });
+          return;
+        }
+
+        pending = update;
+
+        // Already dismissed this version → don't prompt, don't download
+        if (readDismissed() === update.version) {
+          set({
+            status: 'available',
+            availableVersion: update.version,
+            releaseNotes: update.body ?? null,
+            checkedAt: Date.now(),
+            error: null,
+            shouldPrompt: false,
+          });
+          return;
+        }
+
         set({
           status: 'available',
           availableVersion: update.version,
@@ -198,77 +233,74 @@ export const useUpdateStore = create<UpdateStore>((set, get) => ({
           error: null,
           shouldPrompt: false,
         });
-        return;
-      }
 
-      set({
-        status: 'available',
-        availableVersion: update.version,
-        releaseNotes: update.body ?? null,
-        checkedAt: Date.now(),
-        error: null,
-        shouldPrompt: false,
-      });
+        // Auto-download (don't install yet — user decides when to restart)
+        downloading = true;
+        set({ status: 'downloading', progressPercent: 0, downloadedBytes: 0, totalBytes: null });
 
-      // Auto-download (don't install yet — user decides when to restart)
-      downloading = true;
-      set({ status: 'downloading', progressPercent: 0, downloadedBytes: 0, totalBytes: null });
+        let contentLength: number | null = null;
+        let bytesDownloaded = 0;
 
-      let contentLength: number | null = null;
-      let bytesDownloaded = 0;
-
-      try {
-        await update.download((event) => {
-          switch (event.event) {
-            case 'Started':
-              contentLength = event.data.contentLength ?? null;
-              set({ totalBytes: contentLength });
-              break;
-            case 'Progress':
-              bytesDownloaded += event.data.chunkLength;
-              set({
-                downloadedBytes: bytesDownloaded,
-                progressPercent: contentLength
+        try {
+          await update.download((event) => {
+            switch (event.event) {
+              case 'Started':
+                contentLength = event.data.contentLength ?? null;
+                set({ totalBytes: contentLength });
+                break;
+              case 'Progress': {
+                bytesDownloaded = Math.max(bytesDownloaded + event.data.chunkLength, bytesDownloaded);
+                const progressPercent = contentLength
                   ? Math.min(Math.round((bytesDownloaded / contentLength) * 100), 100)
-                  : 0,
-              });
-              break;
-            case 'Finished':
-              set({ progressPercent: 100 });
-              break;
-          }
-        });
+                  : 0;
+                set({
+                  downloadedBytes: Math.max(get().downloadedBytes, bytesDownloaded),
+                  progressPercent: Math.max(get().progressPercent, progressPercent),
+                });
+                break;
+              }
+              case 'Finished':
+                set({ progressPercent: 100 });
+                break;
+            }
+          });
 
-        downloaded = true;
-        set({
-          status: 'downloaded',
-          progressPercent: 100,
-          shouldPrompt: true,
-          error: null,
-        });
+          downloaded = true;
+          set({
+            status: 'downloaded',
+            progressPercent: 100,
+            shouldPrompt: true,
+            error: null,
+          });
+        } catch (e) {
+          set({
+            status: 'available',
+            error: e instanceof Error ? e.message : String(e),
+            shouldPrompt: true,
+          });
+        } finally {
+          downloading = false;
+        }
       } catch (e) {
         set({
-          status: 'available',
+          status: 'error',
           error: e instanceof Error ? e.message : String(e),
-          shouldPrompt: true,
+          checkedAt: Date.now(),
         });
-      } finally {
-        downloading = false;
       }
-    } catch (e) {
-      set({
-        status: 'error',
-        error: e instanceof Error ? e.message : String(e),
-        checkedAt: Date.now(),
-      });
-    }
+    }).finally(() => {
+      if (checkInFlight === flight) checkInFlight = null;
+    });
+
+    checkInFlight = flight;
+    return flight;
   },
 
   installUpdate: async () => {
     // 平台未缓存时先检测，避免移动端误走内置 updater。
     let platform = get().platform;
     if (!platform) {
-      platform = await resolvePlatform();
+      platform = await dependencies.resolvePlatform();
       set({ platform });
     }
     // 移动端：复制下载链接，由用户去浏览器手动下载安装（没有内置安装流程）。
@@ -298,8 +330,8 @@ export const useUpdateStore = create<UpdateStore>((set, get) => ({
       return;
     }
 
-    const updater = await importUpdater();
-    const process = await importProcess();
+    const updater = await dependencies.importUpdater();
+    const process = await dependencies.importProcess();
     if (!updater || !process) return;
 
     if (!pending) {
@@ -322,15 +354,17 @@ export const useUpdateStore = create<UpdateStore>((set, get) => ({
               contentLength = event.data.contentLength ?? null;
               set({ totalBytes: contentLength });
               break;
-            case 'Progress':
-              bytesDownloaded += event.data.chunkLength;
+            case 'Progress': {
+              bytesDownloaded = Math.max(bytesDownloaded + event.data.chunkLength, bytesDownloaded);
+              const progressPercent = contentLength
+                ? Math.min(Math.round((bytesDownloaded / contentLength) * 100), 100)
+                : 0;
               set({
-                downloadedBytes: bytesDownloaded,
-                progressPercent: contentLength
-                  ? Math.min(Math.round((bytesDownloaded / contentLength) * 100), 100)
-                  : 0,
+                downloadedBytes: Math.max(get().downloadedBytes, bytesDownloaded),
+                progressPercent: Math.max(get().progressPercent, progressPercent),
               });
               break;
+            }
             case 'Finished':
               set({ progressPercent: 100 });
               break;
@@ -404,4 +438,7 @@ export const useUpdateStore = create<UpdateStore>((set, get) => ({
 
     set({ status: 'downloaded', progressPercent: 100, shouldPrompt: true });
   },
-}));
+  }));
+}
+
+export const useUpdateStore = createUpdateStore();

--- a/src/lib/store/update.ts
+++ b/src/lib/store/update.ts
@@ -73,6 +73,40 @@ interface UpdateStore {
 type UpdaterMod = typeof import('@tauri-apps/plugin-updater');
 type ProcessMod = typeof import('@tauri-apps/plugin-process');
 type UpdateObj = NonNullable<Awaited<ReturnType<UpdaterMod['check']>>>;
+type DownloadEvent = Parameters<NonNullable<Parameters<UpdateObj['download']>[0]>>[0];
+type UpdateStoreSetter = (
+  partial: Partial<UpdateStore> | ((state: UpdateStore) => Partial<UpdateStore>),
+) => void;
+
+function createDownloadHandler(set: UpdateStoreSetter) {
+  let contentLength: number | null = null;
+  let bytesDownloaded = 0;
+
+  return (event: DownloadEvent) => {
+    switch (event.event) {
+      case 'Started':
+        contentLength = event.data.contentLength ?? null;
+        set({ totalBytes: contentLength });
+        break;
+      case 'Progress': {
+        bytesDownloaded += event.data.chunkLength;
+        const nextBytes = bytesDownloaded;
+        const nextPercent = contentLength
+          ? Math.min(Math.round((nextBytes / contentLength) * 100), 100)
+          : 0;
+        // Keep shared progress monotonic if callbacks arrive out of order.
+        set((current) => ({
+          downloadedBytes: Math.max(current.downloadedBytes, nextBytes),
+          progressPercent: Math.max(current.progressPercent, nextPercent),
+        }));
+        break;
+      }
+      case 'Finished':
+        set({ progressPercent: 100 });
+        break;
+    }
+  };
+}
 
 export interface UpdateStoreDependencies {
   importUpdater: () => Promise<UpdaterMod | null>;
@@ -113,11 +147,34 @@ export function createUpdateStore(overrides: Partial<UpdateStoreDependencies> = 
   // ponytail: flag to skip real Tauri APIs when simulating
   let fake = false;
   let pending: UpdateObj | null = null;
-  let downloading = false;
+  let downloadInFlight: Promise<void> | null = null;
   let downloaded = false;
   let watchdog: ReturnType<typeof setTimeout> | null = null;
   let startupDone = false;
   let checkInFlight: Promise<void> | null = null;
+
+  const downloadUpdate = (update: UpdateObj, set: UpdateStoreSetter): Promise<void> => {
+    if (downloadInFlight) return downloadInFlight;
+
+    const flight = Promise.resolve().then(async () => {
+      set({ status: 'downloading', progressPercent: 0, downloadedBytes: 0, totalBytes: null });
+      await update.download(createDownloadHandler(set));
+      if (pending === update) {
+        downloaded = true;
+        set({
+          status: 'downloaded',
+          progressPercent: 100,
+          shouldPrompt: true,
+          error: null,
+        });
+      }
+    }).finally(() => {
+      if (downloadInFlight === flight) downloadInFlight = null;
+    });
+
+    downloadInFlight = flight;
+    return flight;
+  };
 
   return create<UpdateStore>((set, get) => ({
     status: 'idle',
@@ -137,25 +194,27 @@ export function createUpdateStore(overrides: Partial<UpdateStoreDependencies> = 
       // schedule more than one automatic update check.
       startupDone = true;
 
-      // OHOS/移动端单 WebView 构建里没有注册 updater 插件，且 plugin-updater
-      // 官方不支持移动端，需要运行时平台检测区分。
-      const runtimePlatform = await dependencies.resolvePlatform();
-      set({ platform: runtimePlatform });
+      try {
+        // OHOS/移动端单 WebView 构建里没有注册 updater 插件，且 plugin-updater
+        // 官方不支持移动端，需要运行时平台检测区分。
+        const runtimePlatform = await dependencies.resolvePlatform();
+        set({ platform: runtimePlatform });
 
-      // 移动端不自动检查（避免启动即弹浏览器），由用户在设置页点击跳转 release。
-      if (runtimePlatform === 'mobile') return;
+        // 移动端不自动检查（避免启动即弹浏览器），由用户在设置页点击跳转 release。
+        if (runtimePlatform === 'mobile') return;
 
-      await dependencies.sleep(5000);
-      // A manual check may have completed during the startup delay.
-      if (get().checkedAt !== null) return;
-      try { await get().checkForUpdates(); } catch { /* silent */ }
+        await dependencies.sleep(5000);
+        // A manual check may have completed during the startup delay.
+        if (get().checkedAt !== null) return;
+        await get().checkForUpdates();
+      } catch {
+        // Allow a later mount to retry if startup preparation itself failed.
+        startupDone = false;
+      }
     },
 
     checkForUpdates: () => {
       if (checkInFlight) return checkInFlight;
-      // Keep an already downloaded package for installation instead of checking
-      // and downloading the same release again.
-      if (pending && downloaded && get().status === 'downloaded') return Promise.resolve();
 
       // Defer the implementation to a microtask so checkInFlight is assigned
       // before platform detection or any other asynchronous work can begin.
@@ -174,20 +233,26 @@ export function createUpdateStore(overrides: Partial<UpdateStoreDependencies> = 
 
         const updater = await dependencies.importUpdater();
         if (!updater) return;
-        if (downloading) return;
+
+        // A download started by installUpdate owns pending until it settles.
+        if (downloadInFlight) {
+          try { await downloadInFlight; } catch { /* a fresh check may retry */ }
+        }
 
         set({ status: 'checking', error: null });
 
         try {
-          // Close previous pending update
-          if (pending) {
-            try { await pending.close(); } catch { /* best effort */ }
-            pending = null;
-            downloaded = false;
-          }
-
+          const previousPending = pending;
+          const previousDownloaded = downloaded;
           const update = await updater.check();
           if (!update) {
+            if (previousPending) {
+              try { await previousPending.close(); } catch { /* best effort */ }
+            }
+            if (pending === previousPending) {
+              pending = null;
+              downloaded = false;
+            }
             writeDismissed(null);
             set({
               status: 'up-to-date',
@@ -204,6 +269,13 @@ export function createUpdateStore(overrides: Partial<UpdateStoreDependencies> = 
           const current = update.currentVersion;
           if (current && !isNewer(update.version, current)) {
             try { await update.close(); } catch { /* best effort */ }
+            if (previousPending && previousPending !== update) {
+              try { await previousPending.close(); } catch { /* best effort */ }
+            }
+            if (pending === previousPending) {
+              pending = null;
+              downloaded = false;
+            }
             writeDismissed(null);
             set({
               status: 'up-to-date',
@@ -216,21 +288,30 @@ export function createUpdateStore(overrides: Partial<UpdateStoreDependencies> = 
             return;
           }
 
-          pending = update;
-
-          // Already dismissed this version → don't prompt, don't download
-          if (readDismissed() === update.version) {
+          // Always perform updater.check(), but reuse an already downloaded package
+          // when the server still reports the same version.
+          if (previousPending && previousDownloaded && previousPending.version === update.version) {
+            if (previousPending !== update) {
+              try { await update.close(); } catch { /* best effort */ }
+            }
             set({
-              status: 'available',
+              status: 'downloaded',
               availableVersion: update.version,
-              releaseNotes: update.body ?? null,
+              releaseNotes: update.body ?? previousPending.body ?? null,
               checkedAt: Date.now(),
               error: null,
-              shouldPrompt: false,
+              shouldPrompt: readDismissed() !== update.version,
             });
             return;
           }
 
+          if (previousPending && previousPending !== update) {
+            try { await previousPending.close(); } catch { /* best effort */ }
+          }
+          pending = update;
+          downloaded = false;
+
+          const dismissed = readDismissed() === update.version;
           set({
             status: 'available',
             availableVersion: update.version,
@@ -240,54 +321,18 @@ export function createUpdateStore(overrides: Partial<UpdateStoreDependencies> = 
             shouldPrompt: false,
           });
 
+          // Already dismissed this version → don't prompt, don't download
+          if (dismissed) return;
+
           // Auto-download (don't install yet — user decides when to restart)
-          downloading = true;
-          set({ status: 'downloading', progressPercent: 0, downloadedBytes: 0, totalBytes: null });
-
-          let contentLength: number | null = null;
-          let bytesDownloaded = 0;
-
           try {
-            await update.download((event) => {
-              switch (event.event) {
-                case 'Started':
-                  contentLength = event.data.contentLength ?? null;
-                  set({ totalBytes: contentLength });
-                  break;
-                case 'Progress': {
-                  bytesDownloaded += event.data.chunkLength;
-                  const nextBytes = bytesDownloaded;
-                  const nextPercent = contentLength
-                    ? Math.min(Math.round((nextBytes / contentLength) * 100), 100)
-                    : 0;
-                  // Keep shared progress monotonic if callbacks arrive out of order.
-                  set((current) => ({
-                    downloadedBytes: Math.max(current.downloadedBytes, nextBytes),
-                    progressPercent: Math.max(current.progressPercent, nextPercent),
-                  }));
-                  break;
-                }
-                case 'Finished':
-                  set({ progressPercent: 100 });
-                  break;
-              }
-            });
-
-            downloaded = true;
-            set({
-              status: 'downloaded',
-              progressPercent: 100,
-              shouldPrompt: true,
-              error: null,
-            });
+            await downloadUpdate(update, set);
           } catch (e) {
             set({
               status: 'available',
               error: e instanceof Error ? e.message : String(e),
               shouldPrompt: true,
             });
-          } finally {
-            downloading = false;
           }
         } catch (e) {
           set({
@@ -311,8 +356,6 @@ export function createUpdateStore(overrides: Partial<UpdateStoreDependencies> = 
     },
 
     installUpdate: async () => {
-      if (downloading) return;
-
       // 平台未缓存时先检测，避免移动端误走内置 updater。
       let platform = get().platform;
       if (!platform) {
@@ -350,57 +393,30 @@ export function createUpdateStore(overrides: Partial<UpdateStoreDependencies> = 
       const process = await dependencies.importProcess();
       if (!updater || !process) return;
 
-      if (!pending) {
-        await get().checkForUpdates();
-        if (!pending) return;
-      }
-      // Re-check after the awaits above so a check-triggered download that
-      // started in the meantime cannot be duplicated by the install path.
-      if (downloading) return;
-
       try {
-        // Download if not yet downloaded
-        if (!downloaded) {
-          downloading = true;
-          set({ status: 'downloading', progressPercent: 0, downloadedBytes: 0, totalBytes: null });
-
-          let contentLength: number | null = null;
-          let bytesDownloaded = 0;
-
-          await pending.download((event) => {
-            switch (event.event) {
-              case 'Started':
-                contentLength = event.data.contentLength ?? null;
-                set({ totalBytes: contentLength });
-                break;
-              case 'Progress': {
-                bytesDownloaded += event.data.chunkLength;
-                const nextBytes = bytesDownloaded;
-                const nextPercent = contentLength
-                  ? Math.min(Math.round((nextBytes / contentLength) * 100), 100)
-                  : 0;
-                // Keep shared progress monotonic if callbacks arrive out of order.
-                set((current) => ({
-                  downloadedBytes: Math.max(current.downloadedBytes, nextBytes),
-                  progressPercent: Math.max(current.progressPercent, nextPercent),
-                }));
-                break;
-              }
-              case 'Finished':
-                set({ progressPercent: 100 });
-                break;
-            }
-          });
-
-          downloading = false;
-          downloaded = true;
+        // Preserve an install click made during automatic download. If that
+        // download fails, continue below and retry it through the same helper.
+        if (downloadInFlight) {
+          try { await downloadInFlight; } catch { /* retry below */ }
         }
+
+        if (!pending) {
+          await get().checkForUpdates();
+          if (!pending) return;
+        }
+
+        if (downloadInFlight) {
+          try { await downloadInFlight; } catch { /* retry below */ }
+        }
+
+        const updateToInstall = pending;
+        if (!downloaded) await downloadUpdate(updateToInstall, set);
 
         writeDismissed(null);
 
         set({ status: 'installing', shouldPrompt: false, error: null });
 
-        await pending.install();
+        await updateToInstall.install();
 
         set({ status: 'restarting', progressPercent: 100 });
 
@@ -416,7 +432,6 @@ export function createUpdateStore(overrides: Partial<UpdateStoreDependencies> = 
 
         await process.relaunch();
       } catch (e) {
-        downloading = false;
         if (watchdog) { clearTimeout(watchdog); watchdog = null; }
         set({
           status: downloaded ? 'downloaded' : 'available',

--- a/tests/update-store.test.mjs
+++ b/tests/update-store.test.mjs
@@ -13,8 +13,8 @@ function deferred() {
   return { promise, resolve, reject };
 }
 
-async function flushPromises() {
-  for (let index = 0; index < 8; index += 1) await Promise.resolve();
+function settleAsyncWork() {
+  return new Promise((resolve) => setImmediate(resolve));
 }
 
 function makeUpdate(download) {
@@ -66,7 +66,7 @@ test('并发 checkForUpdates 共享同一次检查和下载，且进度不倒退
   const first = store.getState().checkForUpdates();
   const second = store.getState().checkForUpdates();
   assert.equal(first, second);
-  await flushPromises();
+  await settleAsyncWork();
   assert.equal(checkCalls, 1);
 
   checking.resolve();
@@ -113,16 +113,16 @@ test('自动检查与手动检查重叠时共享 single-flight，initialize 也�
   try {
     const firstInitialize = store.getState().initialize();
     const secondInitialize = store.getState().initialize();
-    await flushPromises();
+    await settleAsyncWork();
     assert.equal(platformCalls, 1);
     assert.equal(sleepCalls, 1);
 
     const manualCheck = store.getState().checkForUpdates();
-    await flushPromises();
+    await settleAsyncWork();
     assert.equal(checkCalls, 1);
 
     startupDelay.resolve();
-    await flushPromises();
+    await settleAsyncWork();
     assert.equal(checkCalls, 1);
 
     checking.resolve();
@@ -136,6 +136,92 @@ test('自动检查与手动检查重叠时共享 single-flight，initialize 也�
       process.env.NEXT_PUBLIC_APP_PLATFORM = previousPlatform;
     }
   }
+});
+
+test('手动检查在启动延时内完成后跳过后续自动检查', async () => {
+  const previousPlatform = process.env.NEXT_PUBLIC_APP_PLATFORM;
+  process.env.NEXT_PUBLIC_APP_PLATFORM = 'tauri';
+  const startupDelay = deferred();
+  let checkCalls = 0;
+  let downloadCalls = 0;
+  const update = makeUpdate(async () => { downloadCalls += 1; });
+  const store = createUpdateStore({
+    resolvePlatform: async () => 'desktop',
+    sleep: async () => { await startupDelay.promise; },
+    importUpdater: async () => ({
+      check: async () => {
+        checkCalls += 1;
+        return update;
+      },
+    }),
+  });
+
+  try {
+    const initialization = store.getState().initialize();
+    await settleAsyncWork();
+
+    await store.getState().checkForUpdates();
+    assert.equal(checkCalls, 1);
+    assert.equal(downloadCalls, 1);
+    assert.equal(store.getState().status, 'downloaded');
+
+    startupDelay.resolve();
+    await initialization;
+    assert.equal(checkCalls, 1);
+    assert.equal(downloadCalls, 1);
+  } finally {
+    if (previousPlatform === undefined) {
+      delete process.env.NEXT_PUBLIC_APP_PLATFORM;
+    } else {
+      process.env.NEXT_PUBLIC_APP_PLATFORM = previousPlatform;
+    }
+  }
+});
+
+test('已下载的更新在后续手动检查中复用', async () => {
+  let checkCalls = 0;
+  let downloadCalls = 0;
+  let closeCalls = 0;
+  const update = {
+    ...makeUpdate(async () => { downloadCalls += 1; }),
+    close: async () => { closeCalls += 1; },
+  };
+  const store = createDesktopStore(async () => ({
+    check: async () => {
+      checkCalls += 1;
+      return update;
+    },
+  }));
+
+  await store.getState().checkForUpdates();
+  await store.getState().checkForUpdates();
+
+  assert.equal(checkCalls, 1);
+  assert.equal(downloadCalls, 1);
+  assert.equal(closeCalls, 0);
+  assert.equal(store.getState().status, 'downloaded');
+});
+
+test('自动下载进行中调用 installUpdate 不会并发下载同一更新', async () => {
+  const downloadStarted = deferred();
+  const finishDownload = deferred();
+  let downloadCalls = 0;
+  const update = makeUpdate(async () => {
+    downloadCalls += 1;
+    downloadStarted.resolve();
+    await finishDownload.promise;
+  });
+  const store = createDesktopStore(async () => ({ check: async () => update }));
+
+  const automaticDownload = store.getState().checkForUpdates();
+  await downloadStarted.promise;
+  await store.getState().installUpdate();
+  assert.equal(downloadCalls, 1);
+
+  finishDownload.resolve();
+  await automaticDownload;
+  assert.equal(downloadCalls, 1);
+  assert.equal(store.getState().status, 'downloaded');
 });
 
 test('无更新时会释放 single-flight，后续检查仍会执行', async () => {

--- a/tests/update-store.test.mjs
+++ b/tests/update-store.test.mjs
@@ -1,0 +1,202 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createUpdateStore } from '../src/lib/store/update.ts';
+
+function deferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+async function flushPromises() {
+  for (let index = 0; index < 8; index += 1) await Promise.resolve();
+}
+
+function makeUpdate(download) {
+  return {
+    version: '1.2.0',
+    currentVersion: '1.1.0',
+    body: 'release notes',
+    download,
+    close: async () => {},
+    install: async () => {},
+  };
+}
+
+function createDesktopStore(importUpdater, sleep = async () => {}) {
+  return createUpdateStore({
+    importUpdater,
+    resolvePlatform: async () => 'desktop',
+    sleep,
+  });
+}
+
+test('并发 checkForUpdates 共享同一次检查和下载，且进度不倒退', async () => {
+  const checking = deferred();
+  let checkCalls = 0;
+  let downloadCalls = 0;
+  const update = makeUpdate(async (onEvent) => {
+    downloadCalls += 1;
+    onEvent({ event: 'Started', data: { contentLength: 100 } });
+    onEvent({ event: 'Progress', data: { chunkLength: 60 } });
+    // Even a changed total must not make a later progress callback move backwards.
+    onEvent({ event: 'Started', data: { contentLength: 200 } });
+    onEvent({ event: 'Progress', data: { chunkLength: 10 } });
+    onEvent({ event: 'Finished', data: {} });
+  });
+  const store = createDesktopStore(async () => ({
+    check: async () => {
+      checkCalls += 1;
+      await checking.promise;
+      return update;
+    },
+  }));
+  const observedProgress = [];
+  store.subscribe((state, previous) => {
+    if (state.progressPercent !== previous.progressPercent) {
+      observedProgress.push(state.progressPercent);
+    }
+  });
+
+  const first = store.getState().checkForUpdates();
+  const second = store.getState().checkForUpdates();
+  assert.equal(first, second);
+  await flushPromises();
+  assert.equal(checkCalls, 1);
+
+  checking.resolve();
+  await Promise.all([first, second]);
+
+  assert.equal(checkCalls, 1);
+  assert.equal(downloadCalls, 1);
+  assert.equal(store.getState().status, 'downloaded');
+  assert.ok(
+    observedProgress.every((value, index) => index === 0 || value >= observedProgress[index - 1]),
+    `progress moved backwards: ${observedProgress.join(', ')}`,
+  );
+});
+
+test('自动检查与手动检查重叠时共享 single-flight，initialize 也只安排一次', async () => {
+  const previousPlatform = process.env.NEXT_PUBLIC_APP_PLATFORM;
+  process.env.NEXT_PUBLIC_APP_PLATFORM = 'tauri';
+  const startupDelay = deferred();
+  const checking = deferred();
+  let platformCalls = 0;
+  let sleepCalls = 0;
+  let checkCalls = 0;
+  let downloadCalls = 0;
+  const update = makeUpdate(async () => { downloadCalls += 1; });
+  const store = createUpdateStore({
+    resolvePlatform: async () => {
+      platformCalls += 1;
+      return 'desktop';
+    },
+    sleep: async (delayMs) => {
+      sleepCalls += 1;
+      assert.equal(delayMs, 5000);
+      await startupDelay.promise;
+    },
+    importUpdater: async () => ({
+      check: async () => {
+        checkCalls += 1;
+        await checking.promise;
+        return update;
+      },
+    }),
+  });
+
+  try {
+    const firstInitialize = store.getState().initialize();
+    const secondInitialize = store.getState().initialize();
+    await flushPromises();
+    assert.equal(platformCalls, 1);
+    assert.equal(sleepCalls, 1);
+
+    const manualCheck = store.getState().checkForUpdates();
+    await flushPromises();
+    assert.equal(checkCalls, 1);
+
+    startupDelay.resolve();
+    await flushPromises();
+    assert.equal(checkCalls, 1);
+
+    checking.resolve();
+    await Promise.all([firstInitialize, secondInitialize, manualCheck]);
+    assert.equal(checkCalls, 1);
+    assert.equal(downloadCalls, 1);
+  } finally {
+    if (previousPlatform === undefined) {
+      delete process.env.NEXT_PUBLIC_APP_PLATFORM;
+    } else {
+      process.env.NEXT_PUBLIC_APP_PLATFORM = previousPlatform;
+    }
+  }
+});
+
+test('无更新时会释放 single-flight，后续检查仍会执行', async () => {
+  let checkCalls = 0;
+  const store = createDesktopStore(async () => ({
+    check: async () => {
+      checkCalls += 1;
+      return null;
+    },
+  }));
+
+  await store.getState().checkForUpdates();
+  await store.getState().checkForUpdates();
+
+  assert.equal(checkCalls, 2);
+  assert.equal(store.getState().status, 'up-to-date');
+});
+
+test('检查异常会释放 single-flight，后续手动重试可成功下载', async () => {
+  let checkCalls = 0;
+  let downloadCalls = 0;
+  const update = makeUpdate(async () => { downloadCalls += 1; });
+  const store = createDesktopStore(async () => ({
+    check: async () => {
+      checkCalls += 1;
+      if (checkCalls === 1) throw new Error('check failed');
+      return update;
+    },
+  }));
+
+  await store.getState().checkForUpdates();
+  assert.equal(store.getState().status, 'error');
+  assert.match(store.getState().error, /check failed/);
+
+  await store.getState().checkForUpdates();
+  assert.equal(checkCalls, 2);
+  assert.equal(downloadCalls, 1);
+  assert.equal(store.getState().status, 'downloaded');
+  assert.equal(store.getState().error, null);
+});
+
+test('下载异常后可重新检查并重试下载', async () => {
+  let checkCalls = 0;
+  let downloadCalls = 0;
+  const store = createDesktopStore(async () => ({
+    check: async () => {
+      checkCalls += 1;
+      return makeUpdate(async () => {
+        downloadCalls += 1;
+        if (downloadCalls === 1) throw new Error('download failed');
+      });
+    },
+  }));
+
+  await store.getState().checkForUpdates();
+  assert.equal(store.getState().status, 'available');
+  assert.match(store.getState().error, /download failed/);
+
+  await store.getState().checkForUpdates();
+  assert.equal(checkCalls, 2);
+  assert.equal(downloadCalls, 2);
+  assert.equal(store.getState().status, 'downloaded');
+  assert.equal(store.getState().error, null);
+});

--- a/tests/update-store.test.mjs
+++ b/tests/update-store.test.mjs
@@ -17,7 +17,27 @@ function settleAsyncWork() {
   return new Promise((resolve) => setImmediate(resolve));
 }
 
-function makeUpdate(download) {
+function useMemoryLocalStorage() {
+  const previous = Object.getOwnPropertyDescriptor(globalThis, 'localStorage');
+  const values = new Map();
+  Object.defineProperty(globalThis, 'localStorage', {
+    configurable: true,
+    value: {
+      getItem: (key) => values.get(key) ?? null,
+      setItem: (key, value) => values.set(key, String(value)),
+      removeItem: (key) => values.delete(key),
+    },
+  });
+  return () => {
+    if (previous) {
+      Object.defineProperty(globalThis, 'localStorage', previous);
+    } else {
+      delete globalThis.localStorage;
+    }
+  };
+}
+
+function makeUpdate(download, overrides = {}) {
   return {
     version: '1.2.0',
     currentVersion: '1.1.0',
@@ -25,6 +45,7 @@ function makeUpdate(download) {
     download,
     close: async () => {},
     install: async () => {},
+    ...overrides,
   };
 }
 
@@ -178,50 +199,161 @@ test('手动检查在启动延时内完成后跳过后续自动检查', async ()
   }
 });
 
-test('已下载的更新在后续手动检查中复用', async () => {
+test('后续检查仍查询 updater，但同版本复用已下载包', async () => {
   let checkCalls = 0;
   let downloadCalls = 0;
-  let closeCalls = 0;
-  const update = {
-    ...makeUpdate(async () => { downloadCalls += 1; }),
-    close: async () => { closeCalls += 1; },
-  };
+  let firstCloseCalls = 0;
+  let duplicateCloseCalls = 0;
+  const firstUpdate = makeUpdate(
+    async () => { downloadCalls += 1; },
+    { close: async () => { firstCloseCalls += 1; } },
+  );
+  const duplicateUpdate = makeUpdate(
+    async () => { downloadCalls += 1; },
+    { close: async () => { duplicateCloseCalls += 1; } },
+  );
   const store = createDesktopStore(async () => ({
     check: async () => {
       checkCalls += 1;
-      return update;
+      return checkCalls === 1 ? firstUpdate : duplicateUpdate;
+    },
+  }));
+  const restoreLocalStorage = useMemoryLocalStorage();
+
+  try {
+    await store.getState().checkForUpdates();
+    store.getState().dismissPrompt();
+    store.setState({ checkedAt: 1 });
+    await store.getState().checkForUpdates();
+
+    assert.equal(checkCalls, 2);
+    assert.equal(downloadCalls, 1);
+    assert.equal(firstCloseCalls, 0);
+    assert.equal(duplicateCloseCalls, 1);
+    assert.equal(store.getState().status, 'downloaded');
+    assert.equal(store.getState().shouldPrompt, false);
+    assert.ok(store.getState().checkedAt > 1);
+  } finally {
+    restoreLocalStorage();
+  }
+});
+
+test('已下载后检查到更新版本会关闭旧包并下载新包', async () => {
+  let checkCalls = 0;
+  let firstDownloadCalls = 0;
+  let nextDownloadCalls = 0;
+  let firstCloseCalls = 0;
+  const firstUpdate = makeUpdate(
+    async () => { firstDownloadCalls += 1; },
+    { close: async () => { firstCloseCalls += 1; } },
+  );
+  const nextUpdate = makeUpdate(
+    async () => { nextDownloadCalls += 1; },
+    { version: '1.3.0' },
+  );
+  const store = createDesktopStore(async () => ({
+    check: async () => {
+      checkCalls += 1;
+      return checkCalls === 1 ? firstUpdate : nextUpdate;
     },
   }));
 
   await store.getState().checkForUpdates();
   await store.getState().checkForUpdates();
 
-  assert.equal(checkCalls, 1);
-  assert.equal(downloadCalls, 1);
-  assert.equal(closeCalls, 0);
+  assert.equal(checkCalls, 2);
+  assert.equal(firstDownloadCalls, 1);
+  assert.equal(nextDownloadCalls, 1);
+  assert.equal(firstCloseCalls, 1);
+  assert.equal(store.getState().availableVersion, '1.3.0');
   assert.equal(store.getState().status, 'downloaded');
 });
 
-test('自动下载进行中调用 installUpdate 不会并发下载同一更新', async () => {
+test('自动下载进行中调用 installUpdate 会等待下载后继续安装', async () => {
   const downloadStarted = deferred();
   const finishDownload = deferred();
   let downloadCalls = 0;
-  const update = makeUpdate(async () => {
-    downloadCalls += 1;
-    downloadStarted.resolve();
-    await finishDownload.promise;
+  let installCalls = 0;
+  let relaunchCalls = 0;
+  const update = makeUpdate(
+    async () => {
+      downloadCalls += 1;
+      downloadStarted.resolve();
+      await finishDownload.promise;
+    },
+    { install: async () => { installCalls += 1; } },
+  );
+  const store = createUpdateStore({
+    importUpdater: async () => ({ check: async () => update }),
+    importProcess: async () => ({
+      relaunch: async () => {
+        relaunchCalls += 1;
+        throw new Error('test relaunch');
+      },
+    }),
+    resolvePlatform: async () => 'desktop',
+    sleep: async () => {},
   });
-  const store = createDesktopStore(async () => ({ check: async () => update }));
 
   const automaticDownload = store.getState().checkForUpdates();
   await downloadStarted.promise;
-  await store.getState().installUpdate();
+  let installationSettled = false;
+  const installation = store.getState().installUpdate().then(() => {
+    installationSettled = true;
+  });
+  await settleAsyncWork();
+
   assert.equal(downloadCalls, 1);
+  assert.equal(installCalls, 0);
+  assert.equal(installationSettled, false);
 
   finishDownload.resolve();
-  await automaticDownload;
+  await Promise.all([automaticDownload, installation]);
   assert.equal(downloadCalls, 1);
+  assert.equal(installCalls, 1);
+  assert.equal(relaunchCalls, 1);
   assert.equal(store.getState().status, 'downloaded');
+  assert.match(store.getState().error, /test relaunch/);
+});
+
+test('initialize 准备失败后允许后续调用重试', async () => {
+  const previousPlatform = process.env.NEXT_PUBLIC_APP_PLATFORM;
+  process.env.NEXT_PUBLIC_APP_PLATFORM = 'tauri';
+  let platformCalls = 0;
+  let sleepCalls = 0;
+  let checkCalls = 0;
+  const store = createUpdateStore({
+    resolvePlatform: async () => {
+      platformCalls += 1;
+      return 'desktop';
+    },
+    sleep: async () => {
+      sleepCalls += 1;
+      if (sleepCalls === 1) throw new Error('startup sleep failed');
+    },
+    importUpdater: async () => ({
+      check: async () => {
+        checkCalls += 1;
+        return null;
+      },
+    }),
+  });
+
+  try {
+    await store.getState().initialize();
+    await store.getState().initialize();
+
+    assert.equal(platformCalls, 2);
+    assert.equal(sleepCalls, 2);
+    assert.equal(checkCalls, 1);
+    assert.equal(store.getState().status, 'up-to-date');
+  } finally {
+    if (previousPlatform === undefined) {
+      delete process.env.NEXT_PUBLIC_APP_PLATFORM;
+    } else {
+      process.env.NEXT_PUBLIC_APP_PLATFORM = previousPlatform;
+    }
+  }
 });
 
 test('无更新时会释放 single-flight，后续检查仍会执行', async () => {


### PR DESCRIPTION
## 变更

- 在任何异步操作开始前占用更新检查 single-flight，并在成功、无更新或异常后统一释放，避免自动检查与手动检查重复调用 `updater.check()` / `update.download()`
- 提前设置初始化保护；若启动延时内已完成手动检查，则跳过后续自动检查，且启动准备异常后允许重新初始化
- 后续手动检查仍执行 `updater.check()`：同版本复用已下载包，新版本则关闭旧包并下载新包
- 用共享 download promise 协调自动下载与安装：安装点击会等待进行中的下载并继续安装，不会静默丢失或重复下载
- 抽取统一的下载进度回调，集中维护字节数、百分比和单调递增保护
- 保留移动端 release 链接、下载失败重试和安装重启流程
- 增加更新 store 自动化测试，覆盖并发与顺序检查、同版本复用、新版本发现、安装等待、初始化异常重试、无更新释放及检查/下载异常重试

## 验证

- `pnpm test`（394 tests passed）
- `pnpm typecheck`
- `pnpm lint`（通过，仅有仓库既有 warnings）
- `pnpm build`

关联 Multica 任务：TB-138 (`30873fa8-8d8e-484d-8cc8-9eb7b2f1b14b`)