### PR TITLE
fix: 自动续传被截断的书籍响应正文

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -16,7 +16,9 @@ import {
 } from '@/lib/api-core';
 import {
   classifyOfflineRangeResponse,
+  createOfflineTransferRecoveryState,
   hasEpubCentralDirectory,
+  nextOfflineTransferRecovery,
   parseContentRange,
 } from '@/lib/offline-book-core';
 import {
@@ -38,6 +40,23 @@ function isRequestCancelled(error: unknown): boolean {
 
 function binaryTransferErrorDetail(error: unknown): string {
   return error instanceof Error ? `${error.name}: ${error.message}` : String(error);
+}
+
+async function waitForTransferRetry(delayMs: number, signal?: AbortSignal): Promise<void> {
+  if (signal?.aborted) throw new DOMException('The operation was aborted', 'AbortError');
+  if (delayMs <= 0) return;
+
+  await new Promise<void>((resolve, reject) => {
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(new DOMException('The operation was aborted', 'AbortError'));
+    };
+    const timer = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, delayMs);
+    signal?.addEventListener('abort', onAbort, { once: true });
+  });
 }
 
 function logBinaryTransferFailure(
@@ -527,8 +546,6 @@ export async function streamBookDownload(
   const { serverUrl } = (await import('@/lib/store/server')).useServerStore.getState();
   const url = `${serverUrl}/api/book/${bookId}.${format}`;
   const requestedOffset = Math.max(0, options.resumeFrom || 0);
-  const headers = new Headers();
-  if (requestedOffset > 0) headers.set('Range', `bytes=${requestedOffset}-`);
 
   const fetchDownload = (requestHeaders: Headers) => request(
     url,
@@ -544,30 +561,54 @@ export async function streamBookDownload(
     },
     requestHeaders.has('Range') ? { expectedStatuses: [416] } : undefined,
   );
-  let response = await fetchDownload(headers);
-  let contentRange = parseContentRange(response.headers.get('content-range'));
-  let rangeMode = classifyOfflineRangeResponse(requestedOffset, response.status, contentRange);
-  if (!response.ok && rangeMode !== 'retry-full') throw new Error(`http.${response.status}`);
-  if (rangeMode === 'retry-full') {
-    if (response.status === 416) {
-      await drainResponseBodyQuietly(response);
-    } else {
-      await cancelResponseBodyQuietly(response);
+
+  const openDownloadResponse = async (offset: number, ifRange?: string) => {
+    const requestHeaders = new Headers();
+    if (offset > 0) {
+      requestHeaders.set('Range', `bytes=${offset}-`);
+      if (ifRange) requestHeaders.set('If-Range', ifRange);
     }
-    await options.onRangeReset?.();
-    response = await fetchDownload(new Headers());
-    if (!response.ok) throw new Error(`http.${response.status}`);
-    contentRange = parseContentRange(response.headers.get('content-range'));
-    rangeMode = classifyOfflineRangeResponse(0, response.status, contentRange);
-  }
-  if (rangeMode === 'invalid') throw new Error('book.download.range.invalid');
-  const resumed = rangeMode === 'resume';
-  let received = resumed ? requestedOffset : 0;
-  if (rangeMode === 'restart') await options.onRangeReset?.();
-  const responseLength = Number(response.headers.get('content-length') || 0);
-  const total = contentRange?.total ?? (responseLength > 0 ? received + responseLength : null);
-  const sourceSignature = response.headers.get('etag') || response.headers.get('last-modified') || undefined;
-  const reader = response.body?.getReader();
+
+    let response = await fetchDownload(requestHeaders);
+    let contentRange = parseContentRange(response.headers.get('content-range'));
+    let rangeMode = classifyOfflineRangeResponse(offset, response.status, contentRange);
+    if (!response.ok && rangeMode !== 'retry-full') throw new Error(`http.${response.status}`);
+    if (rangeMode === 'retry-full') {
+      if (response.status === 416) {
+        await drainResponseBodyQuietly(response);
+      } else {
+        await cancelResponseBodyQuietly(response);
+      }
+      await options.onRangeReset?.();
+      response = await fetchDownload(new Headers());
+      if (!response.ok) throw new Error(`http.${response.status}`);
+      contentRange = parseContentRange(response.headers.get('content-range'));
+      rangeMode = classifyOfflineRangeResponse(0, response.status, contentRange);
+    }
+    if (rangeMode === 'invalid') throw new Error('book.download.range.invalid');
+    if (rangeMode === 'restart') await options.onRangeReset?.();
+
+    const resumed = rangeMode === 'resume';
+    const received = resumed ? offset : 0;
+    const responseLength = Number(response.headers.get('content-length') || 0);
+    return {
+      response,
+      resumed,
+      received,
+      total: contentRange?.total ?? (responseLength > 0 ? received + responseLength : null),
+      sourceSignature: response.headers.get('etag') || response.headers.get('last-modified') || undefined,
+      mimeType: response.headers.get('content-type') || 'application/octet-stream',
+    };
+  };
+
+  let active = await openDownloadResponse(requestedOffset);
+  const resumed = active.resumed;
+  let response = active.response;
+  let received = active.received;
+  let total = active.total;
+  let sourceSignature = active.sourceSignature;
+  let mimeType = active.mimeType;
+  let reader = response.body?.getReader();
 
   if (!reader) {
     let blob: Blob;
@@ -591,22 +632,70 @@ export async function streamBookDownload(
     if (options.validateEpub !== false && format.toLowerCase() === 'epub' && !(await hasEpubCentralDirectory(blob))) {
       throw new Error('book.epub.invalid');
     }
-    return { mimeType: response.headers.get('content-type') || 'application/octet-stream', size: received, sourceSignature, resumed };
+    return { mimeType, size: received, sourceSignature, resumed };
   }
 
   let tail: Uint8Array = new Uint8Array(0);
+  let recoveryState = createOfflineTransferRecoveryState(received);
   while (true) {
-    let result: ReadableStreamReadResult<Uint8Array>;
+    let result: ReadableStreamReadResult<Uint8Array> | undefined;
+    let transferError: unknown;
     try {
       result = await reader.read();
     } catch (error) {
       if (isRequestCancelled(error)) throw error;
+      transferError = error;
       logBinaryTransferFailure(url, response, error, received);
-      throw new Error('book.download.transfer_failed');
     }
 
-    const { done, value } = result;
-    if (done) break;
+    if (result?.done && (total == null || received === total)) break;
+    if (result?.done) {
+      transferError = new Error('response body ended before the declared length');
+      logBinaryTransferFailure(url, response, transferError, received);
+    }
+
+    if (transferError) {
+      // A few self-hosted servers/proxies close large bodies early even though
+      // they advertise the full Content-Length. Keep the same .part writer and
+      // continue with a validated Range response instead of requiring one user
+      // retry per truncated chunk.
+      if (total != null && received === total) break;
+      const recovery = nextOfflineTransferRecovery(recoveryState, received);
+      if (!recovery) throw new Error('book.download.transfer_failed');
+      recoveryState = recovery.state;
+      await waitForTransferRetry(recovery.delayMs, options.signal);
+      debugLog('warn', 'download', `↻ GET ${url} 正文中断，自动续传`, {
+        attempt: recoveryState.attempts,
+        resumeFrom: received,
+        total,
+      }, 'network');
+
+      const previousReceived = received;
+      let next = await openDownloadResponse(received, sourceSignature);
+      const representationChanged = next.resumed && (
+        (total != null && next.total != null && total !== next.total)
+        || (sourceSignature != null && next.sourceSignature != null && sourceSignature !== next.sourceSignature)
+      );
+      if (representationChanged) {
+        await cancelResponseBodyQuietly(next.response);
+        await options.onRangeReset?.();
+        next = await openDownloadResponse(0);
+      }
+
+      active = next;
+      response = active.response;
+      received = active.received;
+      if (received < previousReceived) tail = new Uint8Array(0);
+      total = active.resumed ? active.total ?? total : active.total;
+      sourceSignature = active.resumed ? active.sourceSignature ?? sourceSignature : active.sourceSignature;
+      mimeType = active.mimeType;
+      const nextReader = response.body?.getReader();
+      if (!nextReader) throw new Error('book.download.transfer_failed');
+      reader = nextReader;
+      continue;
+    }
+
+    const value = result?.value;
     if (!value) continue;
 
     try {
@@ -630,10 +719,5 @@ export async function streamBookDownload(
   if (options.validateEpub !== false && format.toLowerCase() === 'epub' && !(await hasEpubCentralDirectory(new Blob([tail])))) {
     throw new Error('book.epub.invalid');
   }
-  return {
-    mimeType: response.headers.get('content-type') || 'application/octet-stream',
-    size: received,
-    sourceSignature,
-    resumed,
-  };
+  return { mimeType, size: received, sourceSignature, resumed };
 }

--- a/src/lib/offline-book-core.ts
+++ b/src/lib/offline-book-core.ts
@@ -89,6 +89,42 @@ export function parseContentRange(value: string | null): { start: number; end: n
 
 export type OfflineRangeResponseMode = 'full' | 'resume' | 'restart' | 'retry-full' | 'invalid';
 
+const MAX_AUTOMATIC_TRANSFER_RECOVERIES = 128;
+const MAX_NO_PROGRESS_TRANSFER_RECOVERIES = 3;
+
+export interface OfflineTransferRecoveryState {
+  attempts: number;
+  noProgressAttempts: number;
+  lastOffset: number;
+}
+
+export function createOfflineTransferRecoveryState(offset: number): OfflineTransferRecoveryState {
+  return { attempts: 0, noProgressAttempts: 0, lastOffset: Math.max(0, offset) };
+}
+
+/**
+ * Bound automatic Range recovery while allowing repeatedly truncated responses
+ * to finish as long as every request advances the on-disk partial file.
+ */
+export function nextOfflineTransferRecovery(
+  state: OfflineTransferRecoveryState,
+  offset: number,
+): { state: OfflineTransferRecoveryState; delayMs: number } | null {
+  const nextOffset = Math.max(0, offset);
+  const madeProgress = nextOffset > state.lastOffset;
+  const attempts = state.attempts + 1;
+  const noProgressAttempts = madeProgress ? 0 : state.noProgressAttempts + 1;
+  if (attempts > MAX_AUTOMATIC_TRANSFER_RECOVERIES
+    || noProgressAttempts > MAX_NO_PROGRESS_TRANSFER_RECOVERIES) return null;
+
+  return {
+    state: { attempts, noProgressAttempts, lastOffset: nextOffset },
+    // Progressing transfers can reconnect immediately. Repeated zero-byte
+    // failures back off so an unavailable server is not hammered.
+    delayMs: madeProgress ? 0 : Math.min(2_000, 250 * 2 ** (noProgressAttempts - 1)),
+  };
+}
+
 export function shouldResumeOfflineDownload(appPlatform?: string, status?: string): boolean {
   return appPlatform === 'tauri' && status !== 'completed';
 }

--- a/tests/offline-books.test.mjs
+++ b/tests/offline-books.test.mjs
@@ -11,10 +11,12 @@ import {
 import {
   beginOfflineDownload,
   classifyOfflineRangeResponse,
+  createOfflineTransferRecoveryState,
   endOfflineDownload,
   hasEpubCentralDirectory,
   makeOfflineBookKey,
   makeOfflineRelativePath,
+  nextOfflineTransferRecovery,
   parseContentRange,
   sanitizeOfflineFileName,
   shouldResumeOfflineDownload,
@@ -222,6 +224,40 @@ test('Range 响应只接受合法 Content-Range', () => {
   assert.equal(classifyOfflineRangeResponse(100, 206, null), 'retry-full');
   assert.equal(classifyOfflineRangeResponse(0, 206, null), 'invalid');
   assert.equal(classifyOfflineRangeResponse(0, 206, parseContentRange('bytes 0-299/300')), 'full');
+});
+
+test('正文中断自动续传允许持续进展，并限制无进展重试', () => {
+  let recovery = createOfflineTransferRecoveryState(100);
+  let next = nextOfflineTransferRecovery(recovery, 200);
+  assert.ok(next);
+  assert.equal(next.delayMs, 0);
+  recovery = next.state;
+
+  next = nextOfflineTransferRecovery(recovery, 200);
+  assert.equal(next?.delayMs, 250);
+  recovery = next.state;
+  next = nextOfflineTransferRecovery(recovery, 200);
+  assert.equal(next?.delayMs, 500);
+  recovery = next.state;
+  next = nextOfflineTransferRecovery(recovery, 200);
+  assert.equal(next?.delayMs, 1000);
+  recovery = next.state;
+  assert.equal(nextOfflineTransferRecovery(recovery, 200), null);
+
+  // Any newly persisted bytes reset the consecutive no-progress budget.
+  next = nextOfflineTransferRecovery(recovery, 201);
+  assert.ok(next);
+  assert.equal(next.state.noProgressAttempts, 0);
+});
+
+test('正文中断自动续传有总次数上限', () => {
+  let recovery = createOfflineTransferRecoveryState(0);
+  for (let attempt = 1; attempt <= 128; attempt += 1) {
+    const next = nextOfflineTransferRecovery(recovery, attempt);
+    assert.ok(next);
+    recovery = next.state;
+  }
+  assert.equal(nextOfflineTransferRecovery(recovery, 129), null);
 });
 
 test('瞬时下载失败保留断点，校验和存储失败清理断点', () => {


### PR DESCRIPTION
## 背景

现场日志显示 EPUB 接口先返回 `200`，但响应正文在约 108 KiB 后报 `error decoding response body`；手动重试得到合法的 `206 bytes 108557-...`，又在约 108 KiB 后中断。当前实现虽然保留 `.part` 文件，但每次正文中断都需要用户再次点击，7.7 MiB 文件可能需要数十次手动重试。

## 修改

- 正文读取异常或早于 `Content-Length` 结束时，自动从已落盘偏移发起 Range 续传。
- 续传携带 `If-Range`，并校验 `Content-Range`、总长度及 ETag/Last-Modified；资源变化或服务器忽略 Range 时安全截断后重下，避免拼接出损坏文件。
- 自动恢复最多 128 次；连续 3 次没有新增字节即停止，并对无进展请求指数退避，避免无限重试。
- 保留暂停/取消、写盘失败和最终 EPUB 校验的原有语义。
- 增加恢复次数、进展重置与无进展退避测试。

## 验证

- `pnpm test`：400/400 通过
- `pnpm typecheck`：通过
- `pnpm lint`：0 error（23 个仓库已有 warning）
- `pnpm build`：通过
- `git diff --check`：通过
