### PR TITLE
TB-200: 将详情页下载操作收为右侧图标按钮

### DIFF
--- a/src/app/detail/page.tsx
+++ b/src/app/detail/page.tsx
@@ -696,52 +696,69 @@ function DetailContent() {
 
             {isTauriApp ? (
               <>
-                <div
-                  data-testid="book-primary-action-group"
-                  className="mt-5 flex h-11 w-full flex-nowrap items-stretch gap-2 md:mt-6 md:w-[220px]"
-                >
+                {offlineMode ? (
                   <button
-                    data-testid="online-read-action"
-                    onClick={() => void handleOnlineRead()}
-                    disabled={openingReader || !onlineFormat}
-                    className="inline-flex h-full min-w-0 flex-1 items-center justify-center gap-2 whitespace-nowrap rounded-xl bg-primary text-sm font-semibold text-primary-foreground shadow-md transition-all duration-200 hover:bg-primary/90 hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-60"
+                    data-testid="offline-read-primary-action"
+                    onClick={() => void handleOfflineRead()}
+                    disabled={openingReader}
+                    aria-busy={openingReader}
+                    className="mt-5 inline-flex h-11 w-full items-center justify-center gap-2 whitespace-nowrap rounded-xl bg-primary text-sm font-semibold text-primary-foreground shadow-md transition-all duration-200 hover:bg-primary/90 hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-60 md:mt-6 md:w-[220px]"
                   >
-                    <BookOpen className="h-4 w-4 shrink-0" />
-                    {openingOnline ? '在线打开中' : onlineFormat ? `在线阅读${bookFiles.length > 1 ? `（${onlineFormat}）` : ''}` : '暂不支持在线阅读'}
-                  </button>
-                  <button
-                    data-testid="offline-download-action"
-                    onClick={() => void (downloaded ? handleOfflineRead() : handleDownload())}
-                    disabled={downloading || openingReader}
-                    aria-label={downloadActionLabel}
-                    aria-busy={downloading || (openingReader && !openingOnline)}
-                    title={downloadActionLabel}
-                    className={`relative inline-flex h-full w-11 shrink-0 items-center justify-center overflow-hidden rounded-xl border transition-all duration-200 hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-60 ${downloading ? 'border-primary/20 bg-primary/10 text-foreground' : 'border-amber-950/10 bg-white/60 text-foreground'}`}
-                  >
-                    {downloading && <span className="absolute inset-0 bg-primary/10" />}
-                    {downloading && (
-                      <span
-                        className="absolute inset-y-0 left-0 bg-primary/25 transition-[width] duration-150 ease-out"
-                        style={{ width: `${downloadProgress}%` }}
-                      />
+                    {openingReader ? (
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                    ) : (
+                      <HardDrive className="h-4 w-4" />
                     )}
-                    <span className="relative z-10 flex items-center justify-center" aria-hidden="true">
-                      {downloading || (openingReader && !openingOnline) ? (
-                        <Loader2 className="h-4 w-4 animate-spin" />
-                      ) : downloaded ? (
-                        <HardDrive className="h-4 w-4" />
-                      ) : (
-                        <Download className="h-4 w-4" />
-                      )}
-                    </span>
+                    {openingReader ? '打开中' : '离线阅读'}
                   </button>
-                </div>
-                {!onlineFormat && (
+                ) : (
+                  <div
+                    data-testid="book-primary-action-group"
+                    className="mt-5 flex h-11 w-full flex-nowrap items-stretch gap-2 md:mt-6 md:w-[220px]"
+                  >
+                    <button
+                      data-testid="online-read-action"
+                      onClick={() => void handleOnlineRead()}
+                      disabled={openingReader || !onlineFormat}
+                      className="inline-flex h-full min-w-0 flex-1 items-center justify-center gap-2 whitespace-nowrap rounded-xl bg-primary text-sm font-semibold text-primary-foreground shadow-md transition-all duration-200 hover:bg-primary/90 hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-60"
+                    >
+                      <BookOpen className="h-4 w-4 shrink-0" />
+                      {openingOnline ? '在线打开中' : onlineFormat ? '在线阅读' : '暂不支持在线阅读'}
+                    </button>
+                    <button
+                      data-testid="offline-download-action"
+                      onClick={() => void (downloaded ? handleOfflineRead() : handleDownload())}
+                      disabled={downloading || openingReader}
+                      aria-label={downloadActionLabel}
+                      aria-busy={downloading || (openingReader && !openingOnline)}
+                      title={downloadActionLabel}
+                      className={`relative inline-flex h-full w-11 shrink-0 items-center justify-center overflow-hidden rounded-xl border transition-all duration-200 hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-60 ${downloading ? 'border-primary/20 bg-primary/10 text-foreground' : 'border-amber-950/10 bg-white/60 text-foreground'}`}
+                    >
+                      {downloading && <span className="absolute inset-0 bg-primary/10" />}
+                      {downloading && (
+                        <span
+                          className="absolute inset-y-0 left-0 bg-primary/25 transition-[width] duration-150 ease-out"
+                          style={{ width: `${downloadProgress}%` }}
+                        />
+                      )}
+                      <span className="relative z-10 flex items-center justify-center" aria-hidden="true">
+                        {downloading || (openingReader && !openingOnline) ? (
+                          <Loader2 className="h-4 w-4 animate-spin" />
+                        ) : downloaded ? (
+                          <HardDrive className="h-4 w-4" />
+                        ) : (
+                          <Download className="h-4 w-4" />
+                        )}
+                      </span>
+                    </button>
+                  </div>
+                )}
+                {!offlineMode && !onlineFormat && (
                   <p className="mt-2 w-full px-1 text-xs leading-relaxed text-muted-foreground md:w-[220px]">
                     当前格式需先下载到本地再阅读。
                   </p>
                 )}
-                {bookFiles.length > 1 && !downloaded && (
+                {!offlineMode && bookFiles.length > 1 && !downloaded && (
                   <div className="mt-3 w-full md:w-[220px]">
                     <div className="flex flex-wrap gap-1.5">
                       {bookFiles.map((f) => {

--- a/src/app/detail/page.tsx
+++ b/src/app/detail/page.tsx
@@ -2,7 +2,7 @@
 
 import { Suspense, useState, useEffect, useRef, useCallback } from 'react';
 import { useSearchParams, useRouter } from 'next/navigation';
-import { ArrowLeft, ChevronRight, Star, FileText, HardDrive, Calendar, BookOpen, Building2, Barcode, Tags, Users, LibraryBig, FileBadge2, Bookmark, Trash2 } from 'lucide-react';
+import { ArrowLeft, ChevronRight, Star, FileText, HardDrive, Calendar, BookOpen, Building2, Barcode, Tags, Users, LibraryBig, FileBadge2, Bookmark, Download, Loader2, Trash2 } from 'lucide-react';
 import { requestAnimatedBack } from '@/lib/native-back';
 import { DesktopLayout } from '@/components/layout/DesktopLayout';
 import { getErrorMessage, MokeApiError, readApiJson, request } from '@/lib/api';
@@ -118,6 +118,13 @@ function DetailContent() {
   const primaryFile = bookFiles[0];
   const fileFormats = bookFiles.map((file) => file.format.toUpperCase());
   const onlineFormat = bookFiles.some((file) => file.format === 'epub') ? 'EPUB' : null;
+  const downloadActionLabel = downloading
+    ? `下载中 ${downloadProgress}%`
+    : openingReader && !openingOnline
+      ? '打开中'
+      : downloaded
+        ? '离线阅读'
+        : '下载后阅读';
   const ratingValue = typeof book?.rating === 'number' ? book.rating : book?.rating?.value;
   const handleAnnotationAuthRequired = useCallback(() => router.push('/login'), [router]);
 
@@ -689,31 +696,46 @@ function DetailContent() {
 
             {isTauriApp ? (
               <>
-                <button
-                  onClick={() => void handleOnlineRead()}
-                  disabled={openingReader || !onlineFormat}
-                  className="mt-5 inline-flex h-11 w-full items-center justify-center gap-2 rounded-xl bg-primary text-sm font-semibold text-primary-foreground shadow-md transition-all duration-200 hover:bg-primary/90 hover:shadow-lg active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-60 md:mt-6 md:w-[220px]"
+                <div
+                  data-testid="book-primary-action-group"
+                  className="mt-5 flex h-11 w-full flex-nowrap items-stretch gap-2 md:mt-6 md:w-[220px]"
                 >
-                  <BookOpen className="h-4 w-4" />
-                  {openingOnline ? '在线打开中' : onlineFormat ? `在线阅读${bookFiles.length > 1 ? `（${onlineFormat}）` : ''}` : '暂不支持在线阅读'}
-                </button>
-                <button
-                  onClick={() => void (downloaded ? handleOfflineRead() : handleDownload())}
-                  disabled={downloading || openingReader}
-                  className={`relative mt-3 inline-flex h-11 w-full items-center justify-center overflow-hidden rounded-xl border text-sm font-semibold transition-all duration-200 active:scale-[0.98] disabled:opacity-60 md:w-[220px] ${downloading ? 'border-primary/20 bg-primary/10 text-foreground' : 'border-amber-950/10 bg-white/60 text-foreground hover:bg-muted'}`}
-                >
-                  {downloading && <span className="absolute inset-0 bg-primary/10" />}
-                  {downloading && (
-                    <span
-                      className="absolute inset-y-0 left-0 bg-primary/25 transition-[width] duration-150 ease-out"
-                      style={{ width: `${downloadProgress}%` }}
-                    />
-                  )}
-                  <span className="relative z-10 flex items-center justify-center gap-2">
-                    {downloaded && <HardDrive className="h-4 w-4" />}
-                    {downloading ? `下载中 ${downloadProgress}%` : openingReader && !openingOnline ? '打开中' : downloaded ? '离线阅读' : '下载后阅读'}
-                  </span>
-                </button>
+                  <button
+                    data-testid="online-read-action"
+                    onClick={() => void handleOnlineRead()}
+                    disabled={openingReader || !onlineFormat}
+                    className="inline-flex h-full min-w-0 flex-1 items-center justify-center gap-2 whitespace-nowrap rounded-xl bg-primary text-sm font-semibold text-primary-foreground shadow-md transition-all duration-200 hover:bg-primary/90 hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-60"
+                  >
+                    <BookOpen className="h-4 w-4 shrink-0" />
+                    {openingOnline ? '在线打开中' : onlineFormat ? `在线阅读${bookFiles.length > 1 ? `（${onlineFormat}）` : ''}` : '暂不支持在线阅读'}
+                  </button>
+                  <button
+                    data-testid="offline-download-action"
+                    onClick={() => void (downloaded ? handleOfflineRead() : handleDownload())}
+                    disabled={downloading || openingReader}
+                    aria-label={downloadActionLabel}
+                    aria-busy={downloading || (openingReader && !openingOnline)}
+                    title={downloadActionLabel}
+                    className={`relative inline-flex h-full w-11 shrink-0 items-center justify-center overflow-hidden rounded-xl border transition-all duration-200 hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 active:scale-[0.98] disabled:cursor-not-allowed disabled:opacity-60 ${downloading ? 'border-primary/20 bg-primary/10 text-foreground' : 'border-amber-950/10 bg-white/60 text-foreground'}`}
+                  >
+                    {downloading && <span className="absolute inset-0 bg-primary/10" />}
+                    {downloading && (
+                      <span
+                        className="absolute inset-y-0 left-0 bg-primary/25 transition-[width] duration-150 ease-out"
+                        style={{ width: `${downloadProgress}%` }}
+                      />
+                    )}
+                    <span className="relative z-10 flex items-center justify-center" aria-hidden="true">
+                      {downloading || (openingReader && !openingOnline) ? (
+                        <Loader2 className="h-4 w-4 animate-spin" />
+                      ) : downloaded ? (
+                        <HardDrive className="h-4 w-4" />
+                      ) : (
+                        <Download className="h-4 w-4" />
+                      )}
+                    </span>
+                  </button>
+                </div>
                 {!onlineFormat && (
                   <p className="mt-2 w-full px-1 text-xs leading-relaxed text-muted-foreground md:w-[220px]">
                     当前格式需先下载到本地再阅读。

--- a/tests/detail-actions.spec.mjs
+++ b/tests/detail-actions.spec.mjs
@@ -1,0 +1,171 @@
+import { test, expect } from '@playwright/test';
+
+const SERVER_URL = 'https://books.test';
+const BOOK_ID = '42';
+
+async function installTauriHttpMock(page) {
+  await page.addInitScript(({ serverUrl, bookId }) => {
+    const requests = new Map();
+    const responseBodies = new Map();
+    let nextRid = 1;
+    let nextCallbackId = 1;
+
+    const payloadFor = (url) => {
+      const path = new URL(url).pathname;
+      if (path === `/api/book/${bookId}`) {
+        return {
+          err: 'ok',
+          book: {
+            id: bookId,
+            title: '在线阅读操作布局测试',
+            authors: ['Moke 测试'],
+            files: [
+              { format: 'epub', size: 440912 },
+              { format: 'pdf', size: 900000 },
+            ],
+            state: { wants: false, download: 0 },
+          },
+        };
+      }
+      if (path === '/api/welcome') return { err: 'not_invited' };
+      if (path === '/api/user/info') {
+        return { err: 'user.need_login', sys: { title: 'Moke 测试书库', version: '3.15.0' } };
+      }
+      return { err: 'page.not_found' };
+    };
+
+    const jsonResponse = (url) => ({
+      status: 200,
+      statusText: 'OK',
+      url,
+      headers: [['content-type', 'application/json']],
+      body: JSON.stringify(payloadFor(url)),
+    });
+
+    window.__TAURI_INTERNALS__ = {
+      invoke: async (command, args = {}) => {
+        if (command === 'plugin:http|fetch') {
+          const rid = nextRid++;
+          requests.set(rid, args.clientConfig);
+          return rid;
+        }
+        if (command === 'plugin:http|fetch_send') {
+          const request = requests.get(args.rid);
+          const response = jsonResponse(request?.url || `${serverUrl}/api/book/${bookId}`);
+          const responseRid = nextRid++;
+          responseBodies.set(responseRid, { body: response.body, sent: false });
+          return {
+            status: response.status,
+            statusText: response.statusText,
+            url: request?.url || response.url,
+            headers: response.headers,
+            rid: responseRid,
+          };
+        }
+        if (command === 'plugin:http|fetch_read_body') {
+          const responseBody = responseBodies.get(args.rid);
+          if (!responseBody || responseBody.sent) {
+            responseBodies.delete(args.rid);
+            return [1];
+          }
+          responseBody.sent = true;
+          return [...new TextEncoder().encode(responseBody.body), 0];
+        }
+        if (command.startsWith('plugin:http|fetch_cancel')) return null;
+        if (command === 'plugin:event|listen') return nextRid++;
+        if (command === 'plugin:event|unlisten') return null;
+        if (command === 'plugin:os|platform') return 'linux';
+        if (command === 'moke_list_downloaded_books') return [];
+        return null;
+      },
+      transformCallback: () => nextCallbackId++,
+      unregisterCallback: () => {},
+      convertFileSrc: (path) => path,
+    };
+    window.__TAURI_EVENT_PLUGIN_INTERNALS__ = { unregisterListener: () => {} };
+
+    localStorage.setItem('moke-privacy-consent', '2026-08-14');
+    localStorage.setItem('moke-server-storage', JSON.stringify({
+      state: {
+        serverUrl,
+        offlineMode: false,
+        protocol: 'https',
+        host: 'books.test',
+        port: '',
+        hasHydrated: true,
+        isConnected: true,
+        user: null,
+        capabilities: {
+          shelfApi: true,
+          annotationApiStatus: 'unsupported',
+          annotationApiCheckedAt: Date.now(),
+          readingStateApi: true,
+          readingProgressApi: true,
+          readingStatsApi: true,
+          networkSourcesApi: true,
+          checkedAt: Date.now(),
+          version: '3.15.0',
+        },
+      },
+      version: 0,
+    }));
+  }, { serverUrl: SERVER_URL, bookId: BOOK_ID });
+}
+
+for (const viewport of [
+  { name: 'mobile', width: 390, height: 844 },
+  { name: 'desktop', width: 1280, height: 900 },
+]) {
+  test(`online and download actions retain one-row layout on ${viewport.name}`, async ({ page }, testInfo) => {
+    await page.setViewportSize({ width: viewport.width, height: viewport.height });
+    await installTauriHttpMock(page);
+    await page.goto(`http://127.0.0.1:3000/detail?id=${BOOK_ID}`, { waitUntil: 'domcontentloaded' });
+
+    const group = page.getByTestId('book-primary-action-group');
+    const online = page.getByTestId('online-read-action');
+    const download = page.getByTestId('offline-download-action');
+    const cover = page.locator('.book-cover-shadow');
+    await expect(group).toBeVisible();
+    await expect(online).toHaveText('在线阅读（EPUB）');
+    await expect(download).toHaveAttribute('aria-label', '下载后阅读');
+    await expect(download).toHaveAttribute('title', '下载后阅读');
+    await expect(download).toBeEnabled();
+    await download.focus();
+    await expect(download).toBeFocused();
+
+    const layout = await page.evaluate(() => {
+      const rect = (testId) => document.querySelector(`[data-testid="${testId}"]`).getBoundingClientRect();
+      const groupRect = rect('book-primary-action-group');
+      const onlineRect = rect('online-read-action');
+      const downloadRect = rect('offline-download-action');
+      const coverRect = document.querySelector('.book-cover-shadow').getBoundingClientRect();
+      const onlineElement = document.querySelector('[data-testid="online-read-action"]');
+      const downloadElement = document.querySelector('[data-testid="offline-download-action"]');
+      return {
+        group: { x: groupRect.x, width: groupRect.width, height: groupRect.height },
+        online: { x: onlineRect.x, y: onlineRect.y, width: onlineRect.width, height: onlineRect.height },
+        download: { x: downloadRect.x, y: downloadRect.y, width: downloadRect.width, height: downloadRect.height },
+        coverWidth: coverRect.width,
+        onlineClientWidth: onlineElement.clientWidth,
+        onlineScrollWidth: onlineElement.scrollWidth,
+        downloadVisibleText: downloadElement.innerText.trim(),
+      };
+    });
+
+    expect(layout.group.width).toBeCloseTo(layout.coverWidth, 0);
+    expect(layout.group.height).toBe(44);
+    expect(layout.online.y).toBeCloseTo(layout.download.y, 0);
+    expect(layout.online.height).toBe(44);
+    expect(layout.download.height).toBe(44);
+    expect(layout.download.width).toBe(44);
+    expect(layout.download.width).toBeLessThan(layout.online.width);
+    expect(layout.download.x + layout.download.width).toBeCloseTo(layout.group.x + layout.group.width, 0);
+    expect(layout.onlineScrollWidth).toBeLessThanOrEqual(layout.onlineClientWidth);
+    expect(layout.downloadVisibleText).toBe('');
+
+    await page.screenshot({
+      path: testInfo.outputPath(`detail-actions-${viewport.name}.png`),
+      fullPage: true,
+    });
+  });
+}

--- a/tests/detail-actions.spec.mjs
+++ b/tests/detail-actions.spec.mjs
@@ -3,10 +3,24 @@ import { test, expect } from '@playwright/test';
 const SERVER_URL = 'https://books.test';
 const BOOK_ID = '42';
 
-async function installTauriHttpMock(page) {
-  await page.addInitScript(({ serverUrl, bookId }) => {
+async function installTauriHttpMock(page, { offlineMode = false } = {}) {
+  await page.addInitScript(({ serverUrl, bookId, offlineMode }) => {
     const requests = new Map();
     const responseBodies = new Map();
+    const httpRequests = [];
+    const nativeOfflineBooks = offlineMode ? [{
+      id: `${serverUrl}::${bookId}::epub`,
+      serverUrl,
+      bookId,
+      title: '离线阅读操作布局测试',
+      author: 'Moke 测试',
+      inShelf: true,
+      fileName: 'offline-layout.epub',
+      mimeType: 'application/epub+zip',
+      updatedAt: Date.now(),
+      filePath: '/tmp/offline-layout.epub',
+      fileSize: 440912,
+    }] : [];
     let nextRid = 1;
     let nextCallbackId = 1;
 
@@ -47,6 +61,7 @@ async function installTauriHttpMock(page) {
         if (command === 'plugin:http|fetch') {
           const rid = nextRid++;
           requests.set(rid, args.clientConfig);
+          httpRequests.push(args.clientConfig.url);
           return rid;
         }
         if (command === 'plugin:http|fetch_send') {
@@ -75,7 +90,7 @@ async function installTauriHttpMock(page) {
         if (command === 'plugin:event|listen') return nextRid++;
         if (command === 'plugin:event|unlisten') return null;
         if (command === 'plugin:os|platform') return 'linux';
-        if (command === 'moke_list_downloaded_books') return [];
+        if (command === 'moke_list_downloaded_books') return nativeOfflineBooks;
         return null;
       },
       transformCallback: () => nextCallbackId++,
@@ -83,17 +98,18 @@ async function installTauriHttpMock(page) {
       convertFileSrc: (path) => path,
     };
     window.__TAURI_EVENT_PLUGIN_INTERNALS__ = { unregisterListener: () => {} };
+    window.__MOKE_TEST_HTTP_REQUESTS__ = httpRequests;
 
     localStorage.setItem('moke-privacy-consent', '2026-08-14');
     localStorage.setItem('moke-server-storage', JSON.stringify({
       state: {
         serverUrl,
-        offlineMode: false,
+        offlineMode,
         protocol: 'https',
         host: 'books.test',
         port: '',
         hasHydrated: true,
-        isConnected: true,
+        isConnected: !offlineMode,
         user: null,
         capabilities: {
           shelfApi: true,
@@ -109,7 +125,7 @@ async function installTauriHttpMock(page) {
       },
       version: 0,
     }));
-  }, { serverUrl: SERVER_URL, bookId: BOOK_ID });
+  }, { serverUrl: SERVER_URL, bookId: BOOK_ID, offlineMode });
 }
 
 for (const viewport of [
@@ -126,7 +142,7 @@ for (const viewport of [
     const download = page.getByTestId('offline-download-action');
     const cover = page.locator('.book-cover-shadow');
     await expect(group).toBeVisible();
-    await expect(online).toHaveText('在线阅读（EPUB）');
+    await expect(online).toHaveText('在线阅读');
     await expect(download).toHaveAttribute('aria-label', '下载后阅读');
     await expect(download).toHaveAttribute('title', '下载后阅读');
     await expect(download).toBeEnabled();
@@ -165,6 +181,46 @@ for (const viewport of [
 
     await page.screenshot({
       path: testInfo.outputPath(`detail-actions-${viewport.name}.png`),
+      fullPage: true,
+    });
+  });
+
+  test(`offline mode exposes only its local reading action on ${viewport.name}`, async ({ page }, testInfo) => {
+    await page.setViewportSize({ width: viewport.width, height: viewport.height });
+    await installTauriHttpMock(page, { offlineMode: true });
+    await page.goto(`http://127.0.0.1:3000/detail?id=${BOOK_ID}`, { waitUntil: 'domcontentloaded' });
+
+    const offlineRead = page.getByTestId('offline-read-primary-action');
+    const cover = page.locator('.book-cover-shadow');
+    await expect(offlineRead).toBeVisible();
+    await expect(offlineRead).toHaveText('离线阅读');
+    await expect(offlineRead).toHaveAttribute('aria-busy', 'false');
+    await expect(page.getByTestId('book-primary-action-group')).toHaveCount(0);
+    await expect(page.getByTestId('online-read-action')).toHaveCount(0);
+    await expect(page.getByTestId('offline-download-action')).toHaveCount(0);
+    await offlineRead.focus();
+    await expect(offlineRead).toBeFocused();
+
+    const layout = await page.evaluate(() => {
+      const action = document.querySelector('[data-testid="offline-read-primary-action"]');
+      const coverElement = document.querySelector('.book-cover-shadow');
+      const actionRect = action.getBoundingClientRect();
+      const coverRect = coverElement.getBoundingClientRect();
+      return {
+        actionWidth: actionRect.width,
+        actionHeight: actionRect.height,
+        coverWidth: coverRect.width,
+        httpRequests: window.__MOKE_TEST_HTTP_REQUESTS__.length,
+      };
+    });
+
+    expect(layout.actionWidth).toBeCloseTo(layout.coverWidth, 0);
+    expect(layout.actionHeight).toBe(44);
+    expect(layout.httpRequests).toBe(0);
+    await expect(cover).toBeVisible();
+
+    await page.screenshot({
+      path: testInfo.outputPath(`detail-actions-offline-${viewport.name}.png`),
       fullPage: true,
     });
   });

--- a/tests/online-reading-ui.test.mjs
+++ b/tests/online-reading-ui.test.mjs
@@ -21,3 +21,22 @@ test('online opening does not enter the offline download manager', () => {
   assert.doesNotMatch(onlineHandler, /startOfflineDownload|downloadAndSaveOfflineBook|saveOfflineBook/);
   assert.match(onlineHandler, /onlineReadingErrorMessage/);
 });
+
+test('primary actions keep the original width while download is a fixed icon button', () => {
+  const groupStart = detail.indexOf('data-testid="book-primary-action-group"');
+  const groupEnd = detail.indexOf('{!onlineFormat &&', groupStart);
+  assert.ok(groupStart >= 0 && groupEnd > groupStart);
+  const group = detail.slice(groupStart, groupEnd);
+
+  assert.match(group, /className="mt-5 flex h-11 w-full flex-nowrap items-stretch gap-2 md:mt-6 md:w-\[220px\]"/);
+  assert.match(group, /data-testid="online-read-action"[\s\S]*?onClick=\{\(\) => void handleOnlineRead\(\)\}/);
+  assert.match(group, /data-testid="online-read-action"[\s\S]*?className="[^"]*h-full min-w-0 flex-1[^"]*whitespace-nowrap/);
+  assert.match(group, /data-testid="offline-download-action"[\s\S]*?onClick=\{\(\) => void \(downloaded \? handleOfflineRead\(\) : handleDownload\(\)\)\}/);
+  assert.match(group, /aria-label=\{downloadActionLabel\}/);
+  assert.match(group, /aria-busy=\{downloading \|\| \(openingReader && !openingOnline\)\}/);
+  assert.match(group, /title=\{downloadActionLabel\}/);
+  assert.match(group, /className=\{`[^`]*h-full w-11 shrink-0/);
+  assert.match(group, /<Download className="h-4 w-4" \/>/);
+  assert.match(group, /<Loader2 className="h-4 w-4 animate-spin" \/>/);
+  assert.match(group, /<HardDrive className="h-4 w-4" \/>/);
+});

--- a/tests/online-reading-ui.test.mjs
+++ b/tests/online-reading-ui.test.mjs
@@ -24,7 +24,7 @@ test('online opening does not enter the offline download manager', () => {
 
 test('primary actions keep the original width while download is a fixed icon button', () => {
   const groupStart = detail.indexOf('data-testid="book-primary-action-group"');
-  const groupEnd = detail.indexOf('{!onlineFormat &&', groupStart);
+  const groupEnd = detail.indexOf('{!offlineMode && !onlineFormat &&', groupStart);
   assert.ok(groupStart >= 0 && groupEnd > groupStart);
   const group = detail.slice(groupStart, groupEnd);
 
@@ -39,4 +39,25 @@ test('primary actions keep the original width while download is a fixed icon but
   assert.match(group, /<Download className="h-4 w-4" \/>/);
   assert.match(group, /<Loader2 className="h-4 w-4 animate-spin" \/>/);
   assert.match(group, /<HardDrive className="h-4 w-4" \/>/);
+  assert.match(group, /onlineFormat \? '在线阅读' : '暂不支持在线阅读'/);
+  assert.doesNotMatch(group, /在线阅读\$\{bookFiles/);
+});
+
+test('offline mode exposes only the local primary action', () => {
+  const actionsStart = detail.indexOf('{offlineMode ? (');
+  const actionsEnd = detail.indexOf('{!offlineMode && !onlineFormat &&', actionsStart);
+  assert.ok(actionsStart >= 0 && actionsEnd > actionsStart);
+  const actions = detail.slice(actionsStart, actionsEnd);
+
+  assert.match(actions, /data-testid="offline-read-primary-action"/);
+  assert.match(actions, /onClick=\{\(\) => void handleOfflineRead\(\)\}/);
+  assert.match(actions, /openingReader \? '打开中' : '离线阅读'/);
+  assert.ok(actions.indexOf('offline-read-primary-action') < actions.indexOf('book-primary-action-group'));
+
+  const handlerStart = detail.indexOf('const handleOfflineRead');
+  const remoteBranch = detail.indexOf('const useSystemReader', handlerStart);
+  const offlineHandler = detail.slice(handlerStart, remoteBranch);
+  assert.match(offlineHandler, /if \(offlineMode\) \{/);
+  assert.match(offlineHandler, /await openOfflineBook\(record, router\.push\)/);
+  assert.doesNotMatch(offlineHandler, /resolveTalebookOnlineSource|recordBookRead|request\(/);
 });


### PR DESCRIPTION
## 背景

TB-200 合入后，详情页将“在线阅读”和“下载后阅读”显示为两个等宽大按钮。本次按补充交互要求收紧主操作区：保留在线阅读为主按钮，把下载改为右侧小型图标按钮，并维持原主按钮占位宽度。

## 关键改动

- 使用固定外层操作组承载 `[在线阅读] + 间距 + [下载图标]`：移动端保持 `w-full`，桌面端保持原有 `220px`，不会撑宽父容器。
- 在线阅读按钮 `flex-1/min-w-0` 占剩余空间；下载按钮固定为 `44×44px`，两者同高、同一行、不换行。
- 在线主按钮统一只显示“在线阅读”，不再附加“（EPUB）”格式文字。
- 下载图标按钮继续调用原有下载流程；已下载后继续调用离线阅读，进行中/打开中使用同尺寸 spinner，状态切换不会改变按钮尺寸。
- 离线模式单独显示等宽“离线阅读”主按钮，不渲染在线阅读或下载图标按钮，也不发起 Talebook HTTP 请求；继续通过原有 `openOfflineBook` 打开本地文件。
- 增加动态 `aria-label`、`title`、`aria-busy`、键盘 focus ring 和 disabled 样式。
- 新增源码回归测试与真实 Chromium 桌面/移动布局测试；浏览器测试固定验证组宽、44px 图标按钮、同高同排、在线文案不裁切、无溢出、键盘焦点，以及离线模式零 HTTP 请求。

## 验证

- `pnpm test`：408 项通过。
- `pnpm typecheck`：通过。
- `pnpm lint`：通过，只有 23 个既有 warning。
- `pnpm build`：通过。
- `pnpm exec playwright test tests/detail-actions.spec.mjs --workers=1 --reporter=line`（以 Tauri 环境启动 Next，使用隔离的 Tauri HTTP/native index mock）：桌面 1280×900、移动 390×844 的在线/离线模式共 4 项通过。
- 初版及反馈后的在线/离线移动截图均随 TB-200 回复附上。

## 风险与兼容性

- 只调整详情页主操作布局及可访问性，不修改在线读取、下载管理、离线打开或服务端契约。
- Chromium 测试使用隔离 mock 数据验证布局和事件绑定；既有真实 Talebook 在线阅读 E2E 结果不受本次纯 UI 调整影响。

关联：TB-200